### PR TITLE
Use the PlatOps naming standards for db secrets

### DIFF
--- a/charts/pre-api/values.yaml
+++ b/charts/pre-api/values.yaml
@@ -7,11 +7,15 @@ java:
   keyVaults:
     pre:
       secrets:
-        - name: postgresdb-host
+        - name: API_POSTGRES_HOST
           alias: POSTGRES_HOST
-        - name: postgresdb-password
+        - name: API_POSTGRES_PORT
+          alias: POSTGRES_PORT
+        - name: API_POSTGRES_DATABASE
+          alias: POSTGRES_DATABASE
+        - name: API_POSTGRES_PASS
           alias: POSTGRES_PASSWORD
-        - name: postgresdb-username
+        - name: API_POSTGRES_USER
           alias: POSTGRES_USER
         - name: AppInsightsInstrumentationKey
           alias: APPINSIGHTS_INSTRUMENTATIONKEY


### PR DESCRIPTION
To be merged after  https://github.com/hmcts/pre-shared-infrastructure/pull/658

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
