### PR TITLE
Downgrade gradle flyway plugin to 9.x due to bug with migrations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '9.0.1'
   id 'com.github.ben-manes.versions' version '0.50.0'
   id 'org.sonarqube' version '4.4.1.3373'
-  id 'org.flywaydb.flyway' version '10.1.0' // issues with 10.0.x https://github.com/spring-projects/spring-boot/issues/38164
+  id 'org.flywaydb.flyway' version '9.22.3' // issues with 10.0.x https://github.com/spring-projects/spring-boot/issues/38164
 }
 
 group = 'uk.gov.hmcts.reform'


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
