### PR TITLE
Revert class name changes which happened during DTO refactor

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,6 +24,11 @@
   </suppress>
 
   <suppress>
+    <notes>Will be fixable when we can upgrade to Spring Boot 3.2.1</notes>
+    <cve>CVE-2023-6378</cve>
+  </suppress>
+
+  <suppress>
     <notes>Dependency brought in through gov-notify, so we can't control this.</notes>
     <cve>CVE-2022-45688</cve>
   </suppress>

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(BookingController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @SuppressWarnings({"PMD.LinguisticNaming"})
-class BookingDTOControllerTest {
+class BookingControllerTest {
 
     @Autowired
     private transient MockMvc mockMvc;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -39,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(CaseController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class CaseDTOControllerTest {
+class CaseControllerTest {
 
     @Autowired
     private transient MockMvc mockMvc;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(RecordingController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class RecordingDTOControllerTest {
+class RecordingControllerTest {
     @Autowired
     private transient MockMvc mockMvc;
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = BookingService.class)
-class BookingDTOServiceTest {
+class BookingServiceTest {
 
     @MockBean
     private BookingRepository bookingRepository;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaseServiceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = CaseService.class)
 @SuppressWarnings({"PMD.LawOfDemeter", "PMD.TooManyMethods"})
-class CaseDTOServiceTest {
+class CaseServiceTest {
 
     private static Case caseEntity;
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = RecordingService.class)
 @SuppressWarnings("PMD.LawOfDemeter")
-class RecordingDTOServiceTest {
+class RecordingServiceTest {
     private static Recording recordingEntity;
 
     private static Booking bookingEntity;


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
