### PR TITLE
Prevent renovate merging major updates automatically

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>hmcts/.github:renovate-config",
-    "local>hmcts/.github//renovate/automerge-all"
+    "local>hmcts/.github//renovate/automerge-minor"
   ],
   "vulnerabilityAlerts": {
     "labels": ["security"]


### PR DESCRIPTION
The flyway v10 plugin keeps getting updated and breaking the build. For now at least, we should disable auto-merging major changes to deps"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
