### PR TITLE
Fix: 500 Error on PUT `cases/{id}` Request Body id is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaseController.java
@@ -50,7 +50,7 @@ public class CaseController extends PreApiController {
     @PutMapping("/{id}")
     @Operation(operationId = "putCase", summary = "Create or Update a Case")
     public ResponseEntity<Void> upsertCase(@PathVariable UUID id, @RequestBody CreateCaseDTO createCaseDTO) {
-        if (!id.toString().equals(createCaseDTO.getId().toString())) {
+        if (createCaseDTO.getId() == null || !id.toString().equals(createCaseDTO.getId().toString())) {
             throw new PathPayloadMismatchException("id", "createCaseDTO.id");
         }
         return getUpsertResponse(caseService.upsert(createCaseDTO), createCaseDTO.getId());


### PR DESCRIPTION
### Change description ###
- Error handling for when PUT `cases/{id}` request body id is null


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
