### PR TITLE
S28 2290: Flatten Recordings API Endpoints

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
@@ -3,14 +3,12 @@ package uk.gov.hmcts.reform.preapi.controllers;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.preapi.util.FunctionalTestBase;
 
-import java.text.MessageFormat;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BookingControllerFT extends FunctionalTestBase {
 
     private static final String BOOKINGS_ENDPOINT = "/bookings/";
-    private static final String RECORDINGS_ENDPOINT = "/bookings/{0}/recordings/";
+    private static final String RECORDINGS_ENDPOINT = "/recordings/";
 
     @Test
     void shouldDeleteRecordingsForBooking() {
@@ -25,8 +23,7 @@ class BookingControllerFT extends FunctionalTestBase {
         assertThat(bookingResponse.statusCode()).isEqualTo(200);
         assertThat(bookingResponse.body().jsonPath().getString("id")).isEqualTo(bookingId);
 
-        var recordingResponse = doGetRequest(
-            MessageFormat.format(RECORDINGS_ENDPOINT, bookingId) + recordingId);
+        var recordingResponse = doGetRequest(RECORDINGS_ENDPOINT + recordingId);
         assertThat(recordingResponse.statusCode()).isEqualTo(200);
         assertThat(recordingResponse.body().jsonPath().getString("id")).isEqualTo(recordingId);
         var recordingCreatedAt = recordingResponse.body().prettyPrint();
@@ -35,8 +32,7 @@ class BookingControllerFT extends FunctionalTestBase {
         var deleteResponse = doDeleteRequest(BOOKINGS_ENDPOINT + bookingId);
         assertThat(deleteResponse.statusCode()).isEqualTo(204);
 
-        var recordingResponse2 = doGetRequest(
-            MessageFormat.format(RECORDINGS_ENDPOINT, bookingId) + recordingId);
+        var recordingResponse2 = doGetRequest(RECORDINGS_ENDPOINT + recordingId);
         assertThat(recordingResponse2.statusCode()).isEqualTo(404);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.preapi.controllers;
 
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.preapi.controllers.base.PreApiController;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchRecordings;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
@@ -20,6 +22,7 @@ import uk.gov.hmcts.reform.preapi.exception.PathPayloadMismatchException;
 import uk.gov.hmcts.reform.preapi.services.RecordingService;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -49,12 +52,20 @@ public class RecordingController extends PreApiController {
 
     @GetMapping
     @Operation(operationId = "getRecordings", summary = "Search all Recordings")
-    public ResponseEntity<List<RecordingDTO>> searchRecordings(
-        @RequestParam(required = false) UUID captureSessionId,
-        @RequestParam(required = false) UUID parentRecordingId
-    ) {
+    @Parameter(
+        name = "captureSessionId",
+        description = "The capture session to search by",
+        example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    @Parameter(
+        name = "parentRecordingId",
+        description = "The parent recording to search by",
+        example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    public ResponseEntity<List<RecordingDTO>> searchRecordings(@RequestParam Map<String, String> params) {
         // TODO Recordings returned need to be shared with the user
-        return ResponseEntity.ok(recordingService.findAll(captureSessionId, parentRecordingId));
+        var searchParams = SearchRecordings.from(params);
+        return ResponseEntity.ok(recordingService.findAll(searchParams.captureSessionId(), searchParams.parentRecordingId()));
     }
 
     @PutMapping("/{recordingId}")

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -26,7 +26,6 @@ import uk.gov.hmcts.reform.preapi.exception.PathPayloadMismatchException;
 import uk.gov.hmcts.reform.preapi.exception.RequestedPageOutOfRangeException;
 import uk.gov.hmcts.reform.preapi.services.RecordingService;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/bookings/{bookingId}/recordings")
+@RequestMapping("/recordings")
 public class RecordingController extends PreApiController {
 
     private final RecordingService recordingService;
@@ -37,11 +37,10 @@ public class RecordingController extends PreApiController {
     @GetMapping("/{recordingId}")
     @Operation(operationId = "getRecordingById", summary = "Get a Recording by Id")
     public ResponseEntity<RecordingDTO> getRecordingById(
-        @PathVariable UUID bookingId,
         @PathVariable UUID recordingId
     ) {
         // TODO Recordings returned need to be shared with the current user
-        var recordingDTO = recordingService.findById(bookingId, recordingId);
+        var recordingDTO = recordingService.findById(recordingId);
         if (recordingDTO == null) {
             throw new NotFoundException("RecordingDTO: " + recordingId);
         }
@@ -49,20 +48,18 @@ public class RecordingController extends PreApiController {
     }
 
     @GetMapping
-    @Operation(operationId = "getRecordingsByBookingId", summary = "Get all Recordings by Booking Id")
-    public ResponseEntity<List<RecordingDTO>> getAllRecordingsByBookingId(
-        @PathVariable UUID bookingId,
+    @Operation(operationId = "getRecordings", summary = "Search all Recordings")
+    public ResponseEntity<List<RecordingDTO>> searchRecordings(
         @RequestParam(required = false) UUID captureSessionId,
         @RequestParam(required = false) UUID parentRecordingId
     ) {
         // TODO Recordings returned need to be shared with the user
-        return ResponseEntity.ok(recordingService.findAllByBookingId(bookingId, captureSessionId, parentRecordingId));
+        return ResponseEntity.ok(recordingService.findAll(captureSessionId, parentRecordingId));
     }
 
     @PutMapping("/{recordingId}")
     @Operation(operationId = "putRecordings", summary = "Create or Update a Recording")
     public ResponseEntity<Void> upsert(
-        @PathVariable UUID bookingId,
         @PathVariable UUID recordingId,
         @RequestBody CreateRecordingDTO createRecordingDTO
     ) {
@@ -71,17 +68,16 @@ public class RecordingController extends PreApiController {
             throw new PathPayloadMismatchException("recordingId", "createRecordingDTO.id");
         }
 
-        return getUpsertResponse(recordingService.upsert(bookingId, createRecordingDTO), createRecordingDTO.getId());
+        return getUpsertResponse(recordingService.upsert(createRecordingDTO), createRecordingDTO.getId());
     }
 
     @DeleteMapping("/{recordingId}")
     @Operation(operationId = "deleteRecording", summary = "Delete a Recording")
     public ResponseEntity<Void> deleteRecordingById(
-        @PathVariable UUID bookingId,
         @PathVariable UUID recordingId
     ) {
         // TODO Ensure user has access to the recording
-        recordingService.deleteById(bookingId, recordingId);
+        recordingService.deleteById(recordingId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
@@ -10,8 +10,12 @@ public record SearchRecordings(UUID captureSessionId, UUID parentRecordingId) {
 
     public static SearchRecordings from(Map<String, String> allParams) {
         return new SearchRecordings(
-            allParams.containsKey(PARAM_CAPTURE_SESSION_ID) ? UUID.fromString(allParams.get(PARAM_CAPTURE_SESSION_ID)) : null,
-            allParams.containsKey(PARAM_PARENT_RECORDING_ID) ? UUID.fromString(allParams.get(PARAM_PARENT_RECORDING_ID)) : null
+            allParams.containsKey(PARAM_CAPTURE_SESSION_ID)
+                ? UUID.fromString(allParams.get(PARAM_CAPTURE_SESSION_ID))
+                : null,
+            allParams.containsKey(PARAM_PARENT_RECORDING_ID)
+                ? UUID.fromString(allParams.get(PARAM_PARENT_RECORDING_ID))
+                : null
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.preapi.controllers.params;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record SearchRecordings(UUID captureSessionId, UUID parentRecordingId) {
+
+    private static final String PARAM_CAPTURE_SESSION_ID = "captureSessionId";
+    private static final String PARAM_PARENT_RECORDING_ID = "parentRecordingId";
+
+    public static SearchRecordings from(Map<String, String> allParams) {
+        return new SearchRecordings(
+            allParams.containsKey(PARAM_CAPTURE_SESSION_ID) ? UUID.fromString(allParams.get(PARAM_CAPTURE_SESSION_ID)) : null,
+            allParams.containsKey(PARAM_PARENT_RECORDING_ID) ? UUID.fromString(allParams.get(PARAM_PARENT_RECORDING_ID)) : null
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CaptureSessionRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CaptureSessionRepository.java
@@ -11,5 +11,5 @@ import java.util.UUID;
 @Repository
 @SuppressWarnings("PMD.MethodNamingConventions")
 public interface CaptureSessionRepository extends JpaRepository<CaptureSession, UUID> {
-    Optional<CaptureSession> findByIdAndBooking_IdAndDeletedAtIsNull(UUID captureSessionId, UUID bookingId);
+    Optional<CaptureSession> findByIdAndDeletedAtIsNull(UUID captureSessionId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.reform.preapi.repositories;
 
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,9 +33,10 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
         )
         """
     )
-    List<Recording> searchAllBy(
+    Page<Recording> searchAllBy(
         @Param("captureSessionId") UUID captureSessionId,
-        @Param("parentRecordingId") UUID parentRecordingId
+        @Param("parentRecordingId") UUID parentRecordingId,
+        Pageable pageable
     );
 
     boolean existsByIdAndDeletedAtIsNull(UUID id);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.preapi.repositories;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,9 +12,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@SuppressWarnings("PMD.MethodNamingConventions")
-public interface RecordingRepository extends JpaRepository<Recording, UUID> {
-    Optional<Recording> findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+@SuppressWarnings({"PMD.MethodNamingConventions", "LineLength"})
+public interface RecordingRepository extends SoftDeleteRepository<Recording, UUID> {
+    Optional<Recording> findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
         UUID recordingId
     );
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -14,16 +14,14 @@ import java.util.UUID;
 @Repository
 @SuppressWarnings("PMD.MethodNamingConventions")
 public interface RecordingRepository extends JpaRepository<Recording, UUID> {
-    Optional<Recording> findByIdAndCaptureSession_Booking_IdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
-        UUID recordingId,
-        UUID bookingId
+    Optional<Recording> findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+        UUID recordingId
     );
 
     @Query(
         """
         SELECT r FROM Recording r
         WHERE r.deletedAt IS NULL
-        AND r.captureSession.booking.id = :bookingId
         AND (
             CAST(:captureSessionId as uuid) IS NULL OR
             r.captureSession.id = :captureSessionId
@@ -35,7 +33,6 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
         """
     )
     List<Recording> searchAllBy(
-        @Param("bookingId") UUID bookingId,
         @Param("captureSessionId") UUID captureSessionId,
         @Param("parentRecordingId") UUID parentRecordingId
     );

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-@SuppressWarnings({"PMD.MethodNamingConventions", "LineLength"})
+@SuppressWarnings({"PMD.MethodNamingConventions", "checkstyle:LineLength"})
 public interface RecordingRepository extends SoftDeleteRepository<Recording, UUID> {
     Optional<Recording> findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
         UUID recordingId

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -15,9 +15,7 @@ import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RecordingRepository;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 public class RecordingService {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.preapi.services;
 
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
@@ -44,12 +46,10 @@ public class RecordingService {
     }
 
     @Transactional
-    public List<RecordingDTO> findAll(UUID captureSessionId, UUID parentRecordingId) {
+    public Page<RecordingDTO> findAll(UUID captureSessionId, UUID parentRecordingId, Pageable pageable) {
         return recordingRepository
-            .searchAllBy(captureSessionId, parentRecordingId)
-            .stream()
-            .map(RecordingDTO::new)
-            .collect(Collectors.toList());
+            .searchAllBy(captureSessionId, parentRecordingId, pageable)
+            .map(RecordingDTO::new);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -32,9 +32,8 @@ public class RecordingService {
 
     @Transactional
     public RecordingDTO findById(UUID recordingId) {
-
         return recordingRepository
-            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingId
             )
             .map(RecordingDTO::new)
@@ -92,7 +91,7 @@ public class RecordingService {
     @Transactional
     public void deleteById(UUID recordingId) {
         var recording = recordingRepository
-            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingId
             );
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -82,13 +84,16 @@ class RecordingControllerTest {
         var mockRecordingDTO = new RecordingDTO();
         mockRecordingDTO.setId(recordingId);
         var recordingDTOList = List.of(mockRecordingDTO);
-        when(recordingService.findAll(null, null)).thenReturn(recordingDTOList);
+        when(recordingService.findAll(any(), any(), any())).thenReturn(new PageImpl<>(recordingDTOList));
 
-        mockMvc.perform(get("/recordings"))
+        mockMvc.perform(get("/recordings")
+                            .with(csrf())
+                            .accept(MediaType.APPLICATION_JSON_VALUE)
+            )
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$").isNotEmpty())
-            .andExpect(jsonPath("$[0].id").value(recordingId.toString()));
+            .andExpect(jsonPath("$._embedded.recordingDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.recordingDTOList[0].id").value(recordingId.toString()));
     }
 
     @DisplayName("Should create a recording with 201 response code")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -54,12 +54,11 @@ class RecordingControllerTest {
     @Test
     void testGetRecordingByIdSuccess() throws Exception {
         UUID recordingId = UUID.randomUUID();
-        UUID bookingId = UUID.randomUUID();
         var mockRecordingDTO = new RecordingDTO();
         mockRecordingDTO.setId(recordingId);
-        when(recordingService.findById(bookingId, recordingId)).thenReturn(mockRecordingDTO);
+        when(recordingService.findById(recordingId)).thenReturn(mockRecordingDTO);
 
-        mockMvc.perform(get(getPath(bookingId, recordingId)))
+        mockMvc.perform(get(getPath(recordingId)))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.id").value(recordingId.toString()));
@@ -69,71 +68,39 @@ class RecordingControllerTest {
     @Test
     void testGetNonExistingRecordingById() throws Exception {
         UUID recordingId = UUID.randomUUID();
-        UUID bookingId = UUID.randomUUID();
-        when(recordingService.findById(bookingId, recordingId)).thenReturn(null);
+        when(recordingService.findById(recordingId)).thenReturn(null);
 
-        mockMvc.perform(get(getPath(bookingId, recordingId)))
+        mockMvc.perform(get(getPath(recordingId)))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message").value("Not found: RecordingDTO: " + recordingId));
     }
 
-    @DisplayName("Should return 404 when trying to get a non-existing booking")
+    @DisplayName("Should get a list of recordings with 200 response code")
     @Test
-    void testGetNonExistingBookingId() throws Exception {
-        UUID recordingId = UUID.randomUUID();
-        UUID bookingId = UUID.randomUUID();
-        when(recordingService.findById(bookingId, recordingId)).thenThrow(
-            new NotFoundException("BookingDTO: " + bookingId)
-        );
-
-        mockMvc.perform(get(getPath(bookingId, recordingId)))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message")
-                           .value("Not found: BookingDTO: " + bookingId));
-    }
-
-    // TODO 200 response
-    @DisplayName("Should get a list of recordings by booking id with 200 response code")
-    @Test
-    void testGetRecordingByBookingIdSuccess() throws Exception {
-        UUID bookingId = UUID.randomUUID();
+    void testGetRecordingIdSuccess() throws Exception {
         UUID recordingId = UUID.randomUUID();
         var mockRecordingDTO = new RecordingDTO();
         mockRecordingDTO.setId(recordingId);
         var recordingDTOList = List.of(mockRecordingDTO);
-        when(recordingService.findAllByBookingId(bookingId, null, null)).thenReturn(recordingDTOList);
+        when(recordingService.findAll(null, null)).thenReturn(recordingDTOList);
 
-        mockMvc.perform(get("/bookings/" + bookingId + "/recordings"))
+        mockMvc.perform(get("/recordings"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$").isNotEmpty())
             .andExpect(jsonPath("$[0].id").value(recordingId.toString()));
     }
 
-    @DisplayName("Should return 404 when trying to get recordings for a booking that doesn't exist")
-    @Test
-    void testGetRecordingsBookingNotFound() throws Exception {
-        UUID bookingId = UUID.randomUUID();
-        doThrow(new NotFoundException("BookingDTO: " + bookingId))
-            .when(recordingService)
-            .findAllByBookingId(any(), any(), any());
-
-        mockMvc.perform(get("/bookings/" + bookingId + "/recordings"))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value("Not found: BookingDTO: " + bookingId));
-    }
-
     @DisplayName("Should create a recording with 201 response code")
     @Test
     void createRecordingCreated() throws Exception {
-        var bookingId = UUID.randomUUID();
         var recordingId = UUID.randomUUID();
         var recording = new CreateRecordingDTO();
         recording.setId(recordingId);
 
-        when(recordingService.upsert(bookingId, recording)).thenReturn(UpsertResult.CREATED);
+        when(recordingService.upsert(recording)).thenReturn(UpsertResult.CREATED);
 
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, recordingId))
+        MvcResult response = mockMvc.perform(put(getPath(recordingId))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(recording))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -143,21 +110,20 @@ class RecordingControllerTest {
 
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
         assertThat(
-            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(bookingId, recordingId)
+            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(recordingId)
         );
     }
 
     @DisplayName("Should update a recording with 204 response code")
     @Test
     void updateRecordingUpdate() throws Exception {
-        var bookingId = UUID.randomUUID();
         var recordingId = UUID.randomUUID();
         var recording = new CreateRecordingDTO();
         recording.setId(recordingId);
 
-        when(recordingService.upsert(bookingId, recording)).thenReturn(UpsertResult.UPDATED);
+        when(recordingService.upsert(recording)).thenReturn(UpsertResult.UPDATED);
 
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, recordingId))
+        MvcResult response = mockMvc.perform(put(getPath(recordingId))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(recording))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -167,18 +133,17 @@ class RecordingControllerTest {
 
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
         assertThat(
-            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(bookingId, recordingId)
+            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(recordingId)
         );
     }
 
     @DisplayName("Should fail to create/update a recording with 400 response code recordingId mismatch")
     @Test
     void createRecordingIdMismatch() throws Exception {
-        var bookingId = UUID.randomUUID();
         var recording = new CreateRecordingDTO();
         recording.setId(UUID.randomUUID());
 
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, UUID.randomUUID()))
+        MvcResult response = mockMvc.perform(put(getPath(UUID.randomUUID()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(recording))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -190,40 +155,17 @@ class RecordingControllerTest {
             .isEqualTo("{\"message\":\"Path recordingId does not match payload property createRecordingDTO.id\"}");
     }
 
-    @DisplayName("Should fail to create/update a recording with 404 response code when booking does not exist")
-    @Test
-    void createRecordingBookingNotFound() throws Exception {
-        var bookingId = UUID.randomUUID();
-        var recordingId = UUID.randomUUID();
-        var recording = new CreateRecordingDTO();
-        recording.setId(recordingId);
-
-        doThrow(new NotFoundException("Booking: " + bookingId)).when(recordingService).upsert(any(), any());
-
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, recordingId))
-                                                 .with(csrf())
-                                                 .content(OBJECT_MAPPER.writeValueAsString(recording))
-                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isNotFound())
-            .andReturn();
-
-        assertThat(response.getResponse().getContentAsString())
-            .isEqualTo("{\"message\":\"Not found: Booking: " + bookingId + "\"}");
-    }
-
     @DisplayName("Should fail to update a recording with 400 response code when it has been marked as deleted")
     @Test
-    void updateRecordingBookingBadRequest() throws Exception {
-        var bookingId = UUID.randomUUID();
+    void updateRecordingBadRequest() throws Exception {
         var recordingId = UUID.randomUUID();
         var recording = new CreateRecordingDTO();
         recording.setId(recordingId);
 
         doThrow(new ResourceInDeletedStateException("RecordingDTO", recordingId.toString()))
-            .when(recordingService).upsert(any(), any());
+            .when(recordingService).upsert(any());
 
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, recordingId))
+        MvcResult response = mockMvc.perform(put(getPath(recordingId))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(recording))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -245,13 +187,12 @@ class RecordingControllerTest {
         var recording = new CreateRecordingDTO();
         recording.setId(recordingId);
         recording.setCaptureSessionId(captureSessionId);
-        var bookingId = UUID.randomUUID();
 
         doThrow(new NotFoundException("Capture Session: " + captureSessionId))
             .when(recordingService)
-            .upsert(any(), any());
+            .upsert(any());
 
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, recordingId))
+        MvcResult response = mockMvc.perform(put(getPath(recordingId))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(recording))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -271,13 +212,12 @@ class RecordingControllerTest {
         var recording = new CreateRecordingDTO();
         recording.setId(recordingId);
         recording.setParentRecordingId(parentRecordingId);
-        var bookingId = UUID.randomUUID();
 
         doThrow(new NotFoundException("Recording: " + parentRecordingId))
             .when(recordingService)
-            .upsert(any(), any());
+            .upsert(any());
 
-        MvcResult response = mockMvc.perform(put(getPath(bookingId, recordingId))
+        MvcResult response = mockMvc.perform(put(getPath(recordingId))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(recording))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -293,47 +233,29 @@ class RecordingControllerTest {
     @Test
     void testDeleteRecordingSuccess() throws Exception {
         UUID recordingId = UUID.randomUUID();
-        UUID bookingId = UUID.randomUUID();
-        doNothing().when(recordingService).deleteById(bookingId, recordingId);
+        doNothing().when(recordingService).deleteById(recordingId);
 
-        mockMvc.perform(delete(getPath(bookingId, recordingId))
+        mockMvc.perform(delete(getPath(recordingId))
                             .with(csrf()))
             .andExpect(status().isOk());
-    }
-
-    @DisplayName("Should return 404 when booking doesn't exist")
-    @Test
-    void testDeleteRecordingBookingNotFound() throws Exception {
-        UUID recordingId = UUID.randomUUID();
-        UUID bookingId = UUID.randomUUID();
-        doThrow(new NotFoundException("Booking: " + bookingId))
-            .when(recordingService)
-            .deleteById(bookingId, recordingId);
-
-        mockMvc.perform(delete(getPath(bookingId, recordingId))
-                            .with(csrf()))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message")
-                           .value("Not found: Booking: " + bookingId));
     }
 
     @DisplayName("Should return 404 when recording doesn't exist")
     @Test
     void testDeleteRecordingNotFound() throws Exception {
         UUID recordingId = UUID.randomUUID();
-        UUID bookingId = UUID.randomUUID();
         doThrow(new NotFoundException("Recording: " + recordingId))
             .when(recordingService)
-            .deleteById(bookingId, recordingId);
+            .deleteById(recordingId);
 
-        mockMvc.perform(delete(getPath(bookingId, recordingId))
+        mockMvc.perform(delete(getPath(recordingId))
                             .with(csrf()))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message")
                            .value("Not found: Recording: " + recordingId));
     }
 
-    private static String getPath(UUID bookingId, UUID recordingId) {
-        return "/bookings/" + bookingId + "/recordings/" + recordingId;
+    private static String getPath(UUID recordingId) {
+        return "/recordings/" + recordingId;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -141,7 +141,7 @@ class BookingServiceTest {
         var bookingModel = new BookingDTO(bookingEntity);
 
         when(bookingRepository.findByIdAndDeletedAtIsNull(bookingId)).thenReturn(java.util.Optional.of(bookingEntity));
-        when(recordingRepository.searchAllBy(bookingId, null, null))
+        when(recordingRepository.searchAllBy(null, null))
             .thenReturn(Collections.emptyList());
         assertThat(bookingService.findById(bookingId)).isEqualTo(bookingModel);
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -141,8 +141,8 @@ class BookingServiceTest {
         var bookingModel = new BookingDTO(bookingEntity);
 
         when(bookingRepository.findByIdAndDeletedAtIsNull(bookingId)).thenReturn(java.util.Optional.of(bookingEntity));
-        when(recordingRepository.searchAllBy(null, null))
-            .thenReturn(Collections.emptyList());
+        when(recordingRepository.searchAllBy(null, null, null))
+            .thenReturn(new PageImpl<>(Collections.emptyList()));
         assertThat(bookingService.findById(bookingId)).isEqualTo(bookingModel);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = RecordingService.class)
-@SuppressWarnings("PMD.LawOfDemeter")
+@SuppressWarnings({ "PMD.LawOfDemeter", "checkstyle:LineLength"})
 class RecordingServiceTest {
     private static Recording recordingEntity;
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -93,8 +93,6 @@ class RecordingServiceTest {
             )
         ).thenReturn(Optional.empty());
 
-        var model = recordingService.findById(recordingEntity.getId());
-        assertThat(model).isNull();
         assertThrows(
             NotFoundException.class,
             () -> recordingService.findById(recordingEntity.getId())

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -74,7 +74,7 @@ class RecordingServiceTest {
     @Test
     void findRecordingByIdSuccess() {
         when(
-            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             )
         ).thenReturn(Optional.of(recordingEntity));
@@ -88,7 +88,7 @@ class RecordingServiceTest {
     @Test
     void findRecordingByIdMissing() {
         when(
-            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             )
         ).thenReturn(Optional.empty());
@@ -99,7 +99,7 @@ class RecordingServiceTest {
         );
 
         verify(recordingRepository, times(1))
-            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             );
     }
@@ -246,7 +246,7 @@ class RecordingServiceTest {
     @Test
     void deleteRecordingSuccess() {
         when(
-            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             )
         ).thenReturn(Optional.of(recordingEntity));
@@ -254,7 +254,7 @@ class RecordingServiceTest {
         recordingService.deleteById(recordingEntity.getId());
 
         verify(recordingRepository, times(1))
-            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             );
         verify(recordingRepository, times(1)).deleteById(recordingEntity.getId());
@@ -265,7 +265,7 @@ class RecordingServiceTest {
     void deleteRecordingNotFound() {
         when(
             recordingRepository
-                .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+                .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                     recordingEntity.getId()
                 )
         ).thenReturn(Optional.empty());
@@ -276,7 +276,7 @@ class RecordingServiceTest {
         );
 
         verify(recordingRepository, times(1))
-            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             );
         verify(recordingRepository, never()).deleteById(recordingEntity.getId());
@@ -288,7 +288,7 @@ class RecordingServiceTest {
         Timestamp now = Timestamp.from(Instant.now());
         recordingEntity.setDeletedAt(now);
         when(
-            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            recordingRepository.findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             )
         ).thenReturn(Optional.of(recordingEntity));
@@ -299,7 +299,7 @@ class RecordingServiceTest {
         );
 
         verify(recordingRepository, times(1))
-            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNull(
+            .findByIdAndDeletedAtIsNullAndCaptureSessionDeletedAtIsNullAndCaptureSession_Booking_DeletedAtIsNull(
                 recordingEntity.getId()
             );
         verify(recordingRepository, never()).deleteById(recordingEntity.getId());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2290


### Change description ###
- Flattened recording endpoints from `/bookings/{bookingId/recordings` -> `/recordings`
- Added pagination to search recordings endpoint (`GET /recordings`)


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - Endpoints removed but not in prod yet
[ ] No
```
