### PR TITLE
S28 2367: API Report Edits

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -485,6 +485,34 @@ definitions:
         format: uuid
         type: string
     type: object
+  EditReportDTO:
+    description: EditReportDTO
+    properties:
+      case_reference:
+        description: EditReportCaseReference
+        type: string
+      court:
+        description: EditReportCourtName
+        type: string
+      created_at:
+        description: EditReportEditCreatedAt
+        format: date-time
+        type: string
+      recording_id:
+        description: EditReportRecordingId
+        format: uuid
+        type: string
+      regions:
+        description: EditReportRegions
+        items:
+          $ref: '#/definitions/RegionDTO'
+        type: array
+        uniqueItems: true
+      version:
+        description: EditReportRecordingVersion
+        format: int32
+        type: integer
+    type: object
   EntityModelBookingDTO:
     properties:
       _links:
@@ -1539,6 +1567,22 @@ paths:
             items:
               $ref: '#/definitions/CaptureSessionReportDTO'
             type: array
+      tags:
+        - report-controller
+  /reports/edits:
+    get:
+      operationId: reportEdits
+      parameters: []
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/EditReportDTO'
+            type: array
+      summary: Get a report on recordings edits
       tags:
         - report-controller
   /reports/recordings-per-case:

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
+import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTO;
 import uk.gov.hmcts.reform.preapi.services.ReportService;
 
@@ -34,5 +35,11 @@ public class ReportController {
     )
     public ResponseEntity<List<RecordingsPerCaseReportDTO>> reportRecordingsPerCase() {
         return ResponseEntity.ok(reportService.reportRecordingsPerCase());
+    }
+
+    @GetMapping("/edits")
+    @Operation(operationId = "reportEdits", summary = "Get a report on recordings edits")
+    public ResponseEntity<List<EditReportDTO>> reportEdits() {
+        return ResponseEntity.ok(reportService.reportEdits());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/EditReportDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/EditReportDTO.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.preapi.dto.reports;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.dto.RegionDTO;
+import uk.gov.hmcts.reform.preapi.entities.Recording;
+
+import java.sql.Timestamp;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+
+@Data
+@NoArgsConstructor
+@Schema(description = "EditReportDTO")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class EditReportDTO {
+
+    @Schema(description = "EditReportEditCreatedAt")
+    private Timestamp createdAt;
+
+    @Schema(description = "EditReportRecordingVersion")
+    private int version;
+
+    @Schema(description = "EditReportCaseReference")
+    private String caseReference;
+
+    @Schema(description = "EditReportCourtName")
+    private String court;
+
+    @Schema(description = "EditReportRegions")
+    private Set<RegionDTO> regions;
+
+    @Schema(description = "EditReportRecordingId")
+    private UUID recordingId;
+
+    public EditReportDTO(Recording recordingEntity) {
+        createdAt = recordingEntity.getCreatedAt();
+        version = recordingEntity.getVersion();
+        var caseEntity = recordingEntity
+            .getCaptureSession()
+            .getBooking()
+            .getCaseId();
+        caseReference = caseEntity.getReference();
+        court = caseEntity.getCourt().getName();
+        regions = caseEntity
+            .getCourt()
+            .getRegions()
+            .stream()
+            .map(RegionDTO::new)
+            .collect(Collectors.toSet());
+        recordingId = recordingEntity.getId();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -42,4 +43,6 @@ public interface RecordingRepository extends SoftDeleteRepository<Recording, UUI
     );
 
     boolean existsByIdAndDeletedAtIsNull(UUID id);
+
+    List<Recording> findAllByParentRecordingIsNotNull();
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -4,12 +4,14 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
+import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTO;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaseRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RecordingRepository;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,6 +54,16 @@ public class ReportService {
                 captureSessionRepository.countAllByBooking_CaseId_IdAndStatus(c.getId(), RecordingStatus.AVAILABLE)
             ))
             .sorted((case1, case2) -> Integer.compare(case2.getCount(), case1.getCount()))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<EditReportDTO> reportEdits() {
+        return recordingRepository
+            .findAllByParentRecordingIsNotNull()
+            .stream()
+            .map(EditReportDTO::new)
+            .sorted(Comparator.comparing(EditReportDTO::getCreatedAt))
             .collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.preapi.controllers.ReportController;
 import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
+import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTO;
 import uk.gov.hmcts.reform.preapi.services.ReportService;
 
@@ -69,5 +70,25 @@ public class ReportControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
             .andExpect(jsonPath("$[0].count").value(reportItem.getCount()));
+    }
+
+    @DisplayName("Should get a report containing a list of edited recordings")
+    @Test
+    void reportEditsSuccess() throws Exception  {
+        var reportItem = new EditReportDTO();
+        reportItem.setCreatedAt(Timestamp.from(Instant.now()));
+        reportItem.setVersion(2);
+        reportItem.setCaseReference("ABC123");
+        reportItem.setCourt("Example Court");
+        reportItem.setRegions(Set.of());
+        reportItem.setRecordingId(UUID.randomUUID());
+
+        when(reportService.reportEdits()).thenReturn(List.of(reportItem));
+        mockMvc.perform(get("/reports/edits"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
+            .andExpect(jsonPath("$[0].version").value(reportItem.getVersion()))
+            .andExpect(jsonPath("$[0].recording_id").value(reportItem.getRecordingId().toString()));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -93,6 +93,8 @@ public class ReportServiceTest {
         captureSessionEntity.setStartedAt(Timestamp.from(Instant.now()));
         captureSessionEntity.setFinishedAt(Timestamp.from(Instant.now()));
         recordingEntity.setDuration(null);
+        recordingEntity.setVersion(1);
+        recordingEntity.setParentRecording(null);
     }
 
     @DisplayName("Find all capture sessions and return a list of models as a report when capture session is incomplete")
@@ -199,5 +201,38 @@ public class ReportServiceTest {
                        .getFirst()
                        .getName()
         ).isEqualTo(regionEntity.getName());
+    }
+
+    @DisplayName("Find all edited recordings and return a report list")
+    @Test
+    void reportEditsSuccess() {
+        recordingEntity.setVersion(2);
+        var recording2 = new Recording();
+        recording2.setId(UUID.randomUUID());
+        recording2.setVersion(3);
+        recording2.setCreatedAt(Timestamp.from(Instant.MIN));
+        recording2.setCaptureSession(captureSessionEntity);
+
+        when(recordingRepository.findAllByParentRecordingIsNotNull()).thenReturn(List.of(recording2, recordingEntity));
+
+        var report = reportService.reportEdits();
+
+        assertThat(report.size()).isEqualTo(2);
+
+        assertThat(report.getFirst().getCreatedAt()).isEqualTo(recordingEntity.getCreatedAt());
+        assertThat(report.getFirst().getVersion()).isEqualTo(recordingEntity.getVersion());
+        assertThat(report.getFirst().getCaseReference()).isEqualTo(caseEntity.getReference());
+        assertThat(report.getFirst().getCourt()).isEqualTo(courtEntity.getName());
+        assertThat(report
+                       .getFirst()
+                       .getRegions()
+                       .stream()
+                       .toList()
+                       .getFirst()
+                       .getName()
+        ).isEqualTo(regionEntity.getName());
+        assertThat(report.getFirst().getRecordingId()).isEqualTo(recordingEntity.getId());
+
+        assertThat(report.getLast().getRecordingId()).isEqualTo(recording2.getId());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2367


### Change description ###
- Add endpoint `GET /reports/edits` to replace `v_recording_edits_report`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
