### PR TITLE
S28 2323: API Reports Recording Access Revoked

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1,5 +1,34 @@
 basePath: /pre-api
 definitions:
+  AccessRemovedReportDTO:
+    description: AccessRemovedReportDTO
+    properties:
+      case_reference:
+        description: AccessRemovedReportCaseReference
+        type: string
+      court:
+        description: AccessRemovedReportCourtName
+        type: string
+      regions:
+        description: AccessRemovedReportRegions
+        items:
+          $ref: '#/definitions/RegionDTO'
+        type: array
+        uniqueItems: true
+      removal_reason:
+        description: AccessRemovedReportRemovalReason
+        type: string
+      removed_at:
+        description: AccessRemovedReportRemovedAt
+        format: date-time
+        type: string
+      user_email:
+        description: AccessRemovedReportUserEmail
+        type: string
+      user_full_name:
+        description: AccessRemovedReportUserFullName
+        type: string
+    type: object
   Booking:
     properties:
       captureSessions:
@@ -1862,6 +1891,22 @@ paths:
               $ref: '#/definitions/ScheduleReportDTO'
             type: array
       summary: Get a list of completed capture sessions with booking details
+      tags:
+        - report-controller
+  /reports/share-bookings-removed:
+    get:
+      operationId: reportShareBookingRemoved
+      parameters: []
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/AccessRemovedReportDTO'
+            type: array
+      summary: Get report on booking share removal
       tags:
         - report-controller
   /reports/shared-bookings:

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.PlaybackReportDTO;
@@ -80,5 +81,14 @@ public class ReportController {
         ) AuditLogSource source
     ) {
         return ResponseEntity.ok(reportService.reportPlayback(source));
+    }
+
+    @GetMapping("/share-bookings-removed")
+    @Operation(
+        operationId = "reportShareBookingRemoved",
+        summary = "Get report on booking share removal"
+    )
+    public ResponseEntity<List<AccessRemovedReportDTO>> reportShareBookingRemoved() {
+        return ResponseEntity.ok(reportService.reportAccessRemoved());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
-import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CompletedCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.ConcurrentCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/AccessRemovedReportDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/AccessRemovedReportDTO.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.preapi.dto.reports;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.dto.RegionDTO;
+import uk.gov.hmcts.reform.preapi.entities.ShareBooking;
+
+import java.sql.Timestamp;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@Schema(description = "AccessRemovedReportDTO")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AccessRemovedReportDTO {
+
+    @Schema(description = "AccessRemovedReportRemovedAt")
+    private Timestamp removedAt;
+
+    @Schema(description = "AccessRemovedReportCaseReference")
+    private String caseReference;
+
+    @Schema(description = "AccessRemovedReportCourtName")
+    private String court;
+
+    @Schema(description = "AccessRemovedReportRegions")
+    private Set<RegionDTO> regions;
+
+    @Schema(description = "AccessRemovedReportUserFullName")
+    private String userFullName;
+
+    @Schema(description = "AccessRemovedReportUserEmail")
+    private String userEmail;
+
+    @Schema(description = "AccessRemovedReportRemovalReason")
+    private String removalReason;
+
+    public AccessRemovedReportDTO(ShareBooking shareBooking) {
+        var booking = shareBooking.getBooking();
+        var courtEntity = booking.getCaseId().getCourt();
+
+        removedAt = shareBooking.getDeletedAt();
+        caseReference = booking.getCaseId().getReference();
+        court = courtEntity.getName();
+        regions = courtEntity
+            .getRegions()
+            .stream()
+            .map(RegionDTO::new)
+            .collect(Collectors.toSet());
+
+        var user = shareBooking.getSharedWith();
+        userFullName = user.getFirstName() + " " + user.getLastName();
+        userEmail = user.getEmail();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/ShareBookingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/ShareBookingRepository.java
@@ -5,9 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.ShareBooking;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface ShareBookingRepository extends JpaRepository<ShareBooking, UUID> {
-
+    List<ShareBooking> findAllByDeletedAtIsNotNull();
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -4,7 +4,6 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
-import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CompletedCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.ConcurrentCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.preapi.services;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.PlaybackReportDTO;
@@ -136,5 +137,15 @@ public class ReportService {
         } else {
             throw new NotFoundException("Report for playback source: " + source);
         }
+    }
+
+    @Transactional
+    public List<AccessRemovedReportDTO> reportAccessRemoved() {
+        return shareBookingRepository
+            .findAllByDeletedAtIsNotNull()
+            .stream()
+            .map(AccessRemovedReportDTO::new)
+            .sorted(Comparator.comparing(AccessRemovedReportDTO::getRemovedAt))
+            .collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.preapi.controllers.ReportController;
+import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTO;
@@ -136,5 +137,29 @@ public class ReportControllerTest {
             .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
             .andExpect(jsonPath("$[0].court").value(reportItem.getCourt()))
             .andExpect(jsonPath("$[0].capture_session_user").value(reportItem.getCaptureSessionUser()));
+    }
+
+    @DisplayName("Should get a report containing a list of share booking removals with case and user details")
+    @Test
+    void reportAccessRemoved() throws Exception {
+        var reportItem = new AccessRemovedReportDTO();
+        reportItem.setRemovedAt(Timestamp.from(Instant.now()));
+        reportItem.setCaseReference("ABC123");
+        reportItem.setCourt("Example court");
+        reportItem.setRegions(Set.of());
+        reportItem.setUserFullName("Example Person");
+        reportItem.setUserEmail("example@example.com");
+        reportItem.setRemovalReason("Example reason");
+
+        when(reportService.reportAccessRemoved()).thenReturn(List.of(reportItem));
+
+        mockMvc.perform(get("/reports/share-bookings-removed"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
+            .andExpect(jsonPath("$[0].court").value(reportItem.getCourt()))
+            .andExpect(jsonPath("$[0].user_full_name").value(reportItem.getUserFullName()))
+            .andExpect(jsonPath("$[0].user_email").value(reportItem.getUserEmail()))
+            .andExpect(jsonPath("$[0].removal_reason").value(reportItem.getRemovalReason()));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.reform.preapi.controllers.ReportController;
 import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
-import uk.gov.hmcts.reform.preapi.dto.reports.CaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CompletedCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.ConcurrentCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -451,4 +451,38 @@ public class ReportServiceTest {
         verify(userRepository, never()).findById(any());
         verify(recordingRepository, never()).findById(any());
     }
+
+    @DisplayName("Find all share booking removals and return a report")
+    @Test
+    void reportAccessRemovedSuccess() {
+        var user = new User();
+        user.setId(UUID.randomUUID());
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        user.setEmail("example@example.com");
+        var shareBooking = new ShareBooking();
+        shareBooking.setId(UUID.randomUUID());
+        shareBooking.setSharedWith(user);
+        shareBooking.setBooking(bookingEntity);
+        shareBooking.setDeletedAt(Timestamp.from(Instant.now()));
+
+        when(shareBookingRepository.findAllByDeletedAtIsNotNull()).thenReturn(List.of(shareBooking));
+
+        var report = reportService.reportAccessRemoved();
+
+        assertThat(report.getFirst().getRemovedAt()).isEqualTo(shareBooking.getDeletedAt());
+        assertThat(report.getFirst().getCaseReference()).isEqualTo(caseEntity.getReference());
+        assertThat(report.getFirst().getCourt()).isEqualTo(courtEntity.getName());
+        assertThat(report
+                       .getFirst()
+                       .getRegions()
+                       .stream()
+                       .toList()
+                       .getFirst()
+                       .getName()
+        ).isEqualTo(regionEntity.getName());
+        assertThat(report.getFirst().getUserFullName()).isEqualTo(user.getFirstName() + " " + user.getLastName());
+        assertThat(report.getFirst().getUserEmail()).isEqualTo(user.getEmail());
+        assertThat(report.getFirst().getRemovalReason()).isNull();
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2323


### Change description ###
- Add endpoint `GET /reports/share-bookings-removed` to replace `v_recording_access_removed_report`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
