### PR TITLE
Fix: `/recordings` Duration Object in Swagger

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -472,46 +472,8 @@ definitions:
         type: string
       duration:
         description: RecordingDuration
-        properties:
-          nano:
-            format: int32
-            type: integer
-          negative:
-            type: boolean
-          positive:
-            type: boolean
-          seconds:
-            format: int64
-            type: integer
-          units:
-            items:
-              properties:
-                dateBased:
-                  type: boolean
-                duration:
-                  properties:
-                    nano:
-                      format: int32
-                      type: integer
-                    negative:
-                      type: boolean
-                    positive:
-                      type: boolean
-                    seconds:
-                      format: int64
-                      type: integer
-                    zero:
-                      type: boolean
-                  type: object
-                durationEstimated:
-                  type: boolean
-                timeBased:
-                  type: boolean
-              type: object
-            type: array
-          zero:
-            type: boolean
-        type: object
+        example: PT3M
+        type: string
       edit_instructions:
         description: RecordingEditInstructions
         type: string
@@ -720,46 +682,8 @@ definitions:
         type: string
       duration:
         description: RecordingDuration
-        properties:
-          nano:
-            format: int32
-            type: integer
-          negative:
-            type: boolean
-          positive:
-            type: boolean
-          seconds:
-            format: int64
-            type: integer
-          units:
-            items:
-              properties:
-                dateBased:
-                  type: boolean
-                duration:
-                  properties:
-                    nano:
-                      format: int32
-                      type: integer
-                    negative:
-                      type: boolean
-                    positive:
-                      type: boolean
-                    seconds:
-                      format: int64
-                      type: integer
-                    zero:
-                      type: boolean
-                  type: object
-                durationEstimated:
-                  type: boolean
-                timeBased:
-                  type: boolean
-              type: object
-            type: array
-          zero:
-            type: boolean
-        type: object
+        example: PT3M
+        type: string
       edit_instructions:
         description: RecordingEditInstructions
         type: string
@@ -1095,46 +1019,8 @@ definitions:
         type: string
       duration:
         description: RecordingDuration
-        properties:
-          nano:
-            format: int32
-            type: integer
-          negative:
-            type: boolean
-          positive:
-            type: boolean
-          seconds:
-            format: int64
-            type: integer
-          units:
-            items:
-              properties:
-                dateBased:
-                  type: boolean
-                duration:
-                  properties:
-                    nano:
-                      format: int32
-                      type: integer
-                    negative:
-                      type: boolean
-                    positive:
-                      type: boolean
-                    seconds:
-                      format: int64
-                      type: integer
-                    zero:
-                      type: boolean
-                  type: object
-                durationEstimated:
-                  type: boolean
-                timeBased:
-                  type: boolean
-              type: object
-            type: array
-          zero:
-            type: boolean
-        type: object
+        example: PT3M
+        type: string
       edit_instructions:
         description: RecordingEditInstructions
         type: string

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/base/BaseRecordingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/base/BaseRecordingDTO.java
@@ -26,7 +26,11 @@ public abstract class BaseRecordingDTO {
     @Schema(description = "RecordingFilename")
     protected String filename;
 
-    @Schema(description = "RecordingDuration")
+    @Schema(
+        description = "RecordingDuration",
+        implementation = String.class,
+        example = "PT3M"
+    )
     protected Duration duration;
 
     @Schema(description = "RecordingEditInstructions")


### PR DESCRIPTION
### Change description ###
- Changed duration implementation to string instead of the duration object


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
