### PR TITLE
Fix: `GET /courts` Pagination Data Issues

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaseController.java
@@ -90,7 +90,7 @@ public class CaseController extends PreApiController {
     @PutMapping("/{id}")
     @Operation(operationId = "putCase", summary = "Create or Update a Case")
     public ResponseEntity<Void> upsertCase(@PathVariable UUID id, @Valid @RequestBody CreateCaseDTO createCaseDTO) {
-        if (createCaseDTO.getId() == null || !id.toString().equals(createCaseDTO.getId().toString())) {
+        if (!id.equals(createCaseDTO.getId())) {
             throw new PathPayloadMismatchException("id", "createCaseDTO.id");
         }
         return getUpsertResponse(caseService.upsert(createCaseDTO), createCaseDTO.getId());

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CourtController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CourtController.java
@@ -109,7 +109,7 @@ public class CourtController extends PreApiController {
     @PutMapping("/{courtId}")
     @Operation(operationId = "putCourt", summary = "Create or Update a Court")
     public ResponseEntity<Void> upsert(@PathVariable UUID courtId, @RequestBody CreateCourtDTO createCourtDTO) {
-        if (!createCourtDTO.getId().equals(courtId)) {
+        if (!courtId.equals(createCourtDTO.getId())) {
             throw new PathPayloadMismatchException("courtId", "createCourtDTO.id");
         }
         return getUpsertResponse(courtService.upsert(createCourtDTO), createCourtDTO.getId());

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CourtRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CourtRepository.java
@@ -20,7 +20,7 @@ public interface CourtRepository extends JpaRepository<Court, UUID> {
         SELECT c FROM Court c
         WHERE (CAST(:courtType as text) IS NULL OR c.courtType = :courtType)
         AND (:name IS NULL OR c.name ILIKE %:name%)
-        AND (:locationCode IS NULL OR c.locationCode = :locationCode)
+        AND (:locationCode IS NULL OR c.locationCode ILIKE :locationCode)
         AND (
             :regionName IS NULL OR EXISTS (
                 SELECT 1 FROM c.regions r

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CourtRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CourtRepository.java
@@ -21,12 +21,20 @@ public interface CourtRepository extends JpaRepository<Court, UUID> {
         WHERE (CAST(:courtType as text) IS NULL OR c.courtType = :courtType)
         AND (:name IS NULL OR c.name ILIKE %:name%)
         AND (:locationCode IS NULL OR c.locationCode = :locationCode)
+        AND (
+            :regionName IS NULL OR EXISTS (
+                SELECT 1 FROM c.regions r
+                WHERE r.name ILIKE %:regionName%
+            )
+        )
+
         """
     )
     Page<Court> searchBy(
         @Param("courtType") CourtType courtType,
         @Param("name") String name,
         @Param("locationCode") String locationCode,
+        @Param("regionName") String regionName,
         Pageable pageable
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CourtRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CourtRepository.java
@@ -20,7 +20,7 @@ public interface CourtRepository extends JpaRepository<Court, UUID> {
         SELECT c FROM Court c
         WHERE (CAST(:courtType as text) IS NULL OR c.courtType = :courtType)
         AND (:name IS NULL OR c.name ILIKE %:name%)
-        AND (:locationCode IS NULL OR c.locationCode ILIKE :locationCode)
+        AND (:locationCode IS NULL OR c.locationCode ILIKE %:locationCode%)
         AND (
             :regionName IS NULL OR EXISTS (
                 SELECT 1 FROM c.regions r

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CourtService.java
@@ -4,13 +4,11 @@ package uk.gov.hmcts.reform.preapi.services;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.preapi.dto.CourtDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCourtDTO;
 import uk.gov.hmcts.reform.preapi.entities.Court;
-import uk.gov.hmcts.reform.preapi.entities.Region;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
@@ -18,7 +16,6 @@ import uk.gov.hmcts.reform.preapi.repositories.CourtRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RegionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RoomRepository;
 
-import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -55,19 +52,9 @@ public class CourtService {
         String regionName,
         Pageable pageable
     ) {
-        var result =  courtRepository
-            .searchBy(courtType, name, locationCode, pageable)
-            .stream()
-            .filter(
-                court -> regionName == null
-                    || court.getRegions()
-                    .stream()
-                    .map(Region::getName)
-                    .anyMatch(n -> n.toLowerCase(Locale.ROOT).contains(regionName.toLowerCase(Locale.ROOT)))
-            )
-            .map(CourtDTO::new)
-            .toList();
-        return new PageImpl<>(result, pageable, result.size());
+        return courtRepository
+            .searchBy(courtType, name, locationCode, regionName, pageable)
+            .map(CourtDTO::new);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CourtServiceTest.java
@@ -94,7 +94,7 @@ public class CourtServiceTest {
     @Test
     void findAllCourtsSuccess() {
         when(
-            courtRepository.searchBy(null, null, null, pageable)
+            courtRepository.searchBy(null, null, null, null, pageable)
         ).thenReturn(new PageImpl<>(List.of(courtEntity)));
 
         var models = courtService.findAllBy(null, null, null, null, pageable);
@@ -105,39 +105,6 @@ public class CourtServiceTest {
         assertThat(first.getName()).isEqualTo(courtEntity.getName());
         assertThat(first.getLocationCode()).isEqualTo(courtEntity.getLocationCode());
         assertThat(first.getCourtType()).isEqualTo(courtEntity.getCourtType());
-    }
-
-    @DisplayName("Find all courts when region name is filtered and return a list of model")
-    @Test
-    void findAllCourtsRegionSearchSuccess() {
-        when(
-            courtRepository.searchBy(null, null, null, pageable)
-        ).thenReturn(new PageImpl<>(List.of(courtEntity)));
-
-        var models = courtService.findAllBy(null, null, null, "example", pageable);
-        assertThat(models.getTotalElements()).isEqualTo(1);
-
-        var first = models.get().toList().getFirst();
-        assertThat(first.getId()).isEqualTo(courtEntity.getId());
-        assertThat(first.getName()).isEqualTo(courtEntity.getName());
-        assertThat(first.getLocationCode()).isEqualTo(courtEntity.getLocationCode());
-        assertThat(first.getCourtType()).isEqualTo(courtEntity.getCourtType());
-
-        assertThat(first.getRegions().size()).isEqualTo(1);
-        var region = first.getRegions().stream().findFirst().get();
-        assertThat(region).isNotNull();
-        assertThat(region.getName()).isEqualTo("Example Region");
-    }
-
-    @DisplayName("Find all courts when region name is filtered and return a list of model")
-    @Test
-    void findAllCourtsRegionSearchEmptySuccess() {
-        when(
-            courtRepository.searchBy(null, null, null, pageable)
-        ).thenReturn(new PageImpl<>(List.of(courtEntity)));
-
-        var models = courtService.findAllBy(null, null, null, "invalid region", pageable);
-        assertThat(models.getNumberOfElements()).isEqualTo(0);
     }
 
     @DisplayName("Create a court")


### PR DESCRIPTION
### Change description ###
- Fix issue where page data field was not getting the correct data due to custom page implementation for `GET /courts`
- Moved filtering of courts by region name to court repository


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
