### PR TITLE
Fix: CreateCourtDTO Ensure Valid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath("org.flywaydb:flyway-database-postgresql:10.5.0")
+    classpath("org.flywaydb:flyway-database-postgresql:10.6.0")
   }
 }
 
@@ -15,7 +15,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.50.0'
   id 'org.sonarqube' version '4.4.1.3373'
   id "io.freefair.lombok" version "8.4"
-  id 'org.flywaydb.flyway' version '10.5.0'
+  id 'org.flywaydb.flyway' version '10.6.0'
   id "info.solidsoft.pitest" version '1.15.0'
 }
 
@@ -270,8 +270,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
 
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.5.0'
-  implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.5.0'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.6.0'
+  implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.6.0'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.1'
   implementation group: 'io.hypersistence', name: 'hypersistence-utils-hibernate-63', version: '3.7.0'
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CourtController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CourtController.java
@@ -4,6 +4,7 @@ package uk.gov.hmcts.reform.preapi.controllers;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -108,7 +109,7 @@ public class CourtController extends PreApiController {
 
     @PutMapping("/{courtId}")
     @Operation(operationId = "putCourt", summary = "Create or Update a Court")
-    public ResponseEntity<Void> upsert(@PathVariable UUID courtId, @RequestBody CreateCourtDTO createCourtDTO) {
+    public ResponseEntity<Void> upsert(@PathVariable UUID courtId,  @Valid @RequestBody CreateCourtDTO createCourtDTO) {
         if (!courtId.equals(createCourtDTO.getId())) {
             throw new PathPayloadMismatchException("courtId", "createCourtDTO.id");
         }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCourtDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCourtDTO.java
@@ -4,6 +4,8 @@ package uk.gov.hmcts.reform.preapi.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
@@ -17,20 +19,28 @@ import java.util.UUID;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateCourtDTO {
     @Schema(description = "CreateCourtId")
+    @NotNull(message = "id is required")
     private UUID id;
 
     @Schema(description = "CreateCourtName")
+    @NotNull(message = "name is required")
     private String name;
 
     @Schema(description = "CreateCourtType")
+    @NotNull(message = "court_type is required")
     private CourtType courtType;
 
     @Schema(description = "CreateCourtLocationCode")
+    @NotNull(message = "location_code is required")
     private String locationCode;
 
     @Schema(description = "CreateCourtRegionIds")
+    @Size(min = 1, message = "must contain at least 1")
+    @NotNull(message = "regions is required and must contain at least 1")
     private List<UUID> regions = List.of();
 
     @Schema(description = "CreateCourtRoomIds")
+    @Size(min = 1, message = "must contain at least 1")
+    @NotNull(message = "rooms is required and must contain at least 1")
     private List<UUID> rooms = List.of();
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/exception/GlobalControllerExceptionHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -112,6 +113,20 @@ public class GlobalControllerExceptionHandler {
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
         error.put(MESSAGE, e.getCause().getMessage());
+
+        return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error),
+                                    responseHeaders,
+                                    HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ResponseEntity<String> onHttpMessageNotReadableException(final HttpMessageNotReadableException e)
+        throws JsonProcessingException {
+
+        var error = new HashMap<String, String>();
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set(CONTENT_TYPE, APPLICATION_JSON);
+        error.put(MESSAGE, e.getMessage());
 
         return new ResponseEntity<>(new ObjectMapper().writeValueAsString(error),
                                     responseHeaders,

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CourtControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.preapi.controllers.CourtController;
 import uk.gov.hmcts.reform.preapi.dto.CourtDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCourtDTO;
+import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.services.CourtService;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -93,13 +95,11 @@ public class CourtControllerTest {
     @DisplayName("Should create a court with 201 response code")
     @Test
     void createCourtCreated() throws Exception {
-        var courtId = UUID.randomUUID();
-        var mockCourt = new CreateCourtDTO();
-        mockCourt.setId(courtId);
+        var mockCourt = createMockCreateCourt();
 
         when(courtService.upsert(mockCourt)).thenReturn(UpsertResult.CREATED);
 
-        MvcResult response = mockMvc.perform(put(getPath(courtId))
+        MvcResult response = mockMvc.perform(put(getPath(mockCourt.getId()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -109,20 +109,18 @@ public class CourtControllerTest {
 
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
         assertThat(
-            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(courtId)
+            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(mockCourt.getId())
         );
     }
 
     @DisplayName("Should update a court with 204 response code")
     @Test
     void updateCourtNoContent() throws Exception {
-        var courtId = UUID.randomUUID();
-        var mockCourt = new CreateCourtDTO();
-        mockCourt.setId(courtId);
+        var mockCourt = createMockCreateCourt();
 
         when(courtService.upsert(mockCourt)).thenReturn(UpsertResult.UPDATED);
 
-        MvcResult response = mockMvc.perform(put(getPath(courtId))
+        MvcResult response = mockMvc.perform(put(getPath(mockCourt.getId()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -132,18 +130,16 @@ public class CourtControllerTest {
 
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
         assertThat(
-            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(courtId)
+            response.getResponse().getHeaderValue("Location")).isEqualTo(TEST_URL + getPath(mockCourt.getId())
         );
     }
 
     @DisplayName("Should fail to create/update a court with 400 response code id mismatch")
     @Test
     void createCourtIdMismatch() throws Exception {
-        var courtId = UUID.randomUUID();
-        var mockCourt = new CreateCourtDTO();
-        mockCourt.setId(UUID.randomUUID());
+        var mockCourt = createMockCreateCourt();
 
-        MvcResult response = mockMvc.perform(put(getPath(courtId))
+        MvcResult response = mockMvc.perform(put(getPath(UUID.randomUUID()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -158,15 +154,11 @@ public class CourtControllerTest {
     @DisplayName("Should fail to create/update a court with 404 response code when region does not exist")
     @Test
     void updateCourtRegionNotFound() throws Exception {
-        var courtId = UUID.randomUUID();
-        var regionId = UUID.randomUUID();
-        var mockCourt = new CreateCourtDTO();
-        mockCourt.setId(courtId);
-        mockCourt.setRegions(List.of(regionId));
+        var mockCourt = createMockCreateCourt();
 
-        doThrow(new NotFoundException("Region: " + regionId)).when(courtService).upsert(any());
+        doThrow(new NotFoundException("Region: " + mockCourt.getRegions().getFirst())).when(courtService).upsert(any());
 
-        MvcResult response = mockMvc.perform(put(getPath(courtId))
+        MvcResult response = mockMvc.perform(put(getPath(mockCourt.getId()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -175,21 +167,17 @@ public class CourtControllerTest {
             .andReturn();
 
         assertThat(response.getResponse().getContentAsString())
-            .isEqualTo("{\"message\":\"Not found: Region: " + regionId + "\"}");
+            .isEqualTo("{\"message\":\"Not found: Region: " + mockCourt.getRegions().getFirst() + "\"}");
     }
 
     @DisplayName("Should fail to create/update a court with 404 response code when room does not exist")
     @Test
     void updateCourtRoomNotFound() throws Exception {
-        var courtId = UUID.randomUUID();
-        var roomId = UUID.randomUUID();
-        var mockCourt = new CreateCourtDTO();
-        mockCourt.setId(courtId);
-        mockCourt.setRooms(List.of(roomId));
+        var mockCourt = createMockCreateCourt();
 
-        doThrow(new NotFoundException("Room: " + roomId)).when(courtService).upsert(any());
+        doThrow(new NotFoundException("Room: " + mockCourt.getRooms().getFirst())).when(courtService).upsert(any());
 
-        MvcResult response = mockMvc.perform(put(getPath(courtId))
+        MvcResult response = mockMvc.perform(put(getPath(mockCourt.getId()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -198,10 +186,141 @@ public class CourtControllerTest {
             .andReturn();
 
         assertThat(response.getResponse().getContentAsString())
-            .isEqualTo("{\"message\":\"Not found: Room: " + roomId + "\"}");
+            .isEqualTo("{\"message\":\"Not found: Room: " + mockCourt.getRooms().getFirst() + "\"}");
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when id is null")
+    @Test
+    void createCourtIdNullBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setId(null);
+
+        mockMvc.perform(put(getPath(UUID.randomUUID()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.id").value("id is required"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when name is null")
+    @Test
+    void createCourtNameNullBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setName(null);
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.name").value("name is required"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when court type is null")
+    @Test
+    void createCourtCourtTypeNullBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setCourtType(null);
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.courtType").value("court_type is required"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when location code is null")
+    @Test
+    void createCourtLocationCodeNullBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setLocationCode(null);
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.locationCode").value("location_code is required"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when regions is null")
+    @Test
+    void createCourtRegionsNullBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setRegions(null);
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.regions").value("regions is required and must contain at least 1"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when regions is empty")
+    @Test
+    void createCourtRegionsEmptyBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setRegions(List.of());
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.regions").value("must contain at least 1"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when rooms is null")
+    @Test
+    void createCourtRoomsNullBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setRooms(null);
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.rooms").value("rooms is required and must contain at least 1"));
+    }
+
+    @DisplayName("Should fail to create/update a court with 404 response code when rooms is empty")
+    @Test
+    void createCourtRoomsEmptyBadRequest() throws Exception {
+        var mockCourt = createMockCreateCourt();
+        mockCourt.setRooms(List.of());
+
+        mockMvc.perform(put(getPath(mockCourt.getId()))
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(mockCourt))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.rooms").value("must contain at least 1"));
     }
 
     private String getPath(UUID id) {
         return "/courts/" + id;
+    }
+
+    private CreateCourtDTO createMockCreateCourt() {
+        var mockCourt = new CreateCourtDTO();
+        mockCourt.setId(UUID.randomUUID());
+        mockCourt.setCourtType(CourtType.CROWN);
+        mockCourt.setName("Example court");
+        mockCourt.setLocationCode("1234567890");
+        mockCourt.setRooms(List.of(UUID.randomUUID()));
+        mockCourt.setRegions(List.of(UUID.randomUUID()));
+        return mockCourt;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CourtControllerTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2254


### Change description ###
- Add check: id, name, court_type, location_code, regions and rooms values are not null
- Add check: regions and rooms lists are not empty
- Add error message for `HttpMessageNotReadableException` which is caused when values don't map correctly (error message returned when invalid enum value are sent). 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
