### PR TITLE
S28 2395: General Playback Report `GET /reports/playback`

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1123,8 +1123,11 @@ definitions:
           $ref: '#/definitions/RegionDTO'
         type: array
         uniqueItems: true
-      user:
-        description: PlaybackReportUser
+      user_email:
+        description: PlaybackReportUserEmail
+        type: string
+      user_full_name:
+        description: PlaybackReportUserFullName
         type: string
     type: object
   RecordingDTO:
@@ -1946,7 +1949,7 @@ paths:
     get:
       operationId: reportPlayback
       parameters:
-        - description: The source of the playback. Only accepts PORTAL or APPLICATION
+        - description: 'The source of the playback. Only accepts PORTAL, APPLICATION or null'
           enum:
             - APPLICATION
             - PORTAL
@@ -1954,7 +1957,7 @@ paths:
             - AUTO
           in: query
           name: source
-          required: true
+          required: false
           type: string
       produces:
         - application/octet-stream

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.preapi.controllers.params.SearchSharedReport;
 import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
@@ -105,13 +106,13 @@ public class ReportController {
         operationId = "reportPlayback",
         summary = "Get report on playback by playback source (PORTAL, APPLICATION)"
     )
+    @Parameter(
+        name = "source",
+        description = "The source of the playback. Only accepts PORTAL, APPLICATION or null",
+        schema = @Schema(implementation = AuditLogSource.class)
+    )
     public ResponseEntity<List<PlaybackReportDTO>> reportPlayback(
-        @Parameter(
-            name = "source",
-            description = "The source of the playback. Only accepts PORTAL or APPLICATION",
-            schema = @Schema(implementation = AuditLogSource.class),
-            required = true
-        ) AuditLogSource source
+        @RequestParam(required = false) AuditLogSource source
     ) {
         return ResponseEntity.ok(reportService.reportPlayback(source));
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/PlaybackReportDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/PlaybackReportDTO.java
@@ -4,11 +4,13 @@ package uk.gov.hmcts.reform.preapi.dto.reports;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.preapi.dto.RegionDTO;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
+import uk.gov.hmcts.reform.preapi.entities.User;
 
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -20,6 +22,7 @@ import javax.annotation.Nullable;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 @Schema(description = "PlaybackReportDTO")
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PlaybackReportDTO {
@@ -33,8 +36,11 @@ public class PlaybackReportDTO {
     @Schema(description = "PlaybackReportDuration", implementation = String.class)
     private Duration duration;
 
-    @Schema(description = "PlaybackReportUser")
-    private String user;
+    @Schema(description = "PlaybackReportUserFullName")
+    private String userFullName;
+
+    @Schema(description = "PlaybackReportUserEmail")
+    private String userEmail;
 
     @Schema(description = "PlaybackReportCaseReference")
     private String caseReference;
@@ -48,11 +54,14 @@ public class PlaybackReportDTO {
     @Schema(description = "PlaybackReportRecordingId")
     private UUID recordingId;
 
-    public PlaybackReportDTO(Audit audit, String email, @Nullable Recording recording) {
+    public PlaybackReportDTO(Audit audit, User user, @Nullable Recording recording) {
         playbackAt = audit.getCreatedAt();
         finishedAt = null;
         duration = null;
-        user = email;
+        if (user != null) {
+            userFullName = user.getFullName();
+            userEmail = user.getEmail();
+        }
         if (recording != null) {
             var caseEntity = recording.getCaptureSession().getBooking().getCaseId();
             var courtEntity = caseEntity.getCourt();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
 import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
@@ -11,4 +12,13 @@ import java.util.UUID;
 @Repository
 public interface AuditRepository extends JpaRepository<Audit, UUID> {
     List<Audit> findBySourceAndFunctionalAreaAndActivity(AuditLogSource source, String functionalArea, String activity);
+
+    @Query(
+        """
+        SELECT a FROM Audit a
+        WHERE a.activity != 'Recording Playback ended'
+        AND a.auditDetails ILIKE '%playback%'
+        """
+    )
+    List<Audit> findAllAccessAttempts();
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/ReportControllerTest.java
@@ -13,9 +13,11 @@ import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CompletedCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.ConcurrentCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTO;
+import uk.gov.hmcts.reform.preapi.dto.reports.PlaybackReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.ScheduleReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.SharedReportDTO;
+import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.services.ReportService;
 
@@ -323,5 +325,78 @@ public class ReportControllerTest {
             .andExpect(jsonPath("$[0].user_full_name").value(reportItem.getUserFullName()))
             .andExpect(jsonPath("$[0].user_email").value(reportItem.getUserEmail()))
             .andExpect(jsonPath("$[0].removal_reason").value(reportItem.getRemovalReason()));
+    }
+
+    @DisplayName("Should get a report containing a list of playback data for source 'PORTAL'")
+    @Test
+    void reportPlaybackPortalSuccess() throws Exception {
+        var reportItem = createPlaybackReport();
+
+        when(reportService.reportPlayback(AuditLogSource.PORTAL)).thenReturn(List.of(reportItem));
+
+        mockMvc.perform(get("/reports/playback")
+                            .param("source", "PORTAL"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].user_full_name").value(reportItem.getUserFullName()))
+            .andExpect(jsonPath("$[0].user_email").value(reportItem.getUserEmail()))
+            .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
+            .andExpect(jsonPath("$[0].court").value(reportItem.getCourt()))
+            .andExpect(jsonPath("$[0].recording_id").value(reportItem.getRecordingId().toString()));
+
+        verify(reportService, times(1)).reportPlayback(AuditLogSource.PORTAL);
+    }
+
+    @DisplayName("Should get a report containing a list of playback data for source 'APPLICATION'")
+    @Test
+    void reportPlaybackApplicationSuccess() throws Exception {
+        var reportItem = createPlaybackReport();
+
+        when(reportService.reportPlayback(AuditLogSource.APPLICATION)).thenReturn(List.of(reportItem));
+
+        mockMvc.perform(get("/reports/playback")
+                            .param("source", "APPLICATION"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].user_full_name").value(reportItem.getUserFullName()))
+            .andExpect(jsonPath("$[0].user_email").value(reportItem.getUserEmail()))
+            .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
+            .andExpect(jsonPath("$[0].court").value(reportItem.getCourt()))
+            .andExpect(jsonPath("$[0].recording_id").value(reportItem.getRecordingId().toString()));
+
+        verify(reportService, times(1)).reportPlayback(AuditLogSource.APPLICATION);
+    }
+
+    @DisplayName("Should get a report containing a list of playback data for no source")
+    @Test
+    void reportPlaybackAllSuccess() throws Exception {
+        var reportItem = createPlaybackReport();
+
+        when(reportService.reportPlayback(null)).thenReturn(List.of(reportItem));
+
+        mockMvc.perform(get("/reports/playback"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$[0].user_full_name").value(reportItem.getUserFullName()))
+            .andExpect(jsonPath("$[0].user_email").value(reportItem.getUserEmail()))
+            .andExpect(jsonPath("$[0].case_reference").value(reportItem.getCaseReference()))
+            .andExpect(jsonPath("$[0].court").value(reportItem.getCourt()))
+            .andExpect(jsonPath("$[0].recording_id").value(reportItem.getRecordingId().toString()));
+
+        verify(reportService, times(1)).reportPlayback(null);
+    }
+
+    private PlaybackReportDTO createPlaybackReport() {
+        return new PlaybackReportDTO(
+            Timestamp.from(Instant.now()),
+            Timestamp.from(Instant.now()),
+            Duration.ofMinutes(3),
+            "Example Person",
+            "example@example.com",
+            "CASE123456",
+            "Example Court",
+            Set.of(),
+            UUID.randomUUID()
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -358,6 +358,8 @@ public class ReportServiceTest {
         var user = new User();
         user.setId(UUID.randomUUID());
         user.setEmail("example@example.com");
+        user.setFirstName("Example");
+        user.setLastName("Person");
         auditEntity.setCreatedBy(user.getId());
         auditEntity.setSource(AuditLogSource.PORTAL);
 
@@ -377,7 +379,8 @@ public class ReportServiceTest {
         assertThat(report.getFirst().getPlaybackAt()).isEqualTo(auditEntity.getCreatedAt());
         assertThat(report.getFirst().getFinishedAt()).isNull();
         assertThat(report.getFirst().getDuration()).isNull();
-        assertThat(report.getFirst().getUser()).isEqualTo(user.getEmail());
+        assertThat(report.getFirst().getUserEmail()).isEqualTo(user.getEmail());
+        assertThat(report.getFirst().getUserFullName()).isEqualTo(user.getFullName());
         assertThat(report.getFirst().getCaseReference()).isEqualTo(caseEntity.getReference());
         assertThat(report.getFirst().getCourt()).isEqualTo(courtEntity.getName());
         assertThat(report.getFirst().getRecordingId()).isEqualTo(recordingEntity.getId());
@@ -397,6 +400,8 @@ public class ReportServiceTest {
         var user = new User();
         user.setId(UUID.randomUUID());
         user.setEmail("example@example.com");
+        user.setFirstName("Example");
+        user.setLastName("Person");
         auditEntity.setCreatedBy(user.getId());
         auditEntity.setSource(AuditLogSource.APPLICATION);
 
@@ -416,7 +421,8 @@ public class ReportServiceTest {
         assertThat(report.getFirst().getPlaybackAt()).isEqualTo(auditEntity.getCreatedAt());
         assertThat(report.getFirst().getFinishedAt()).isNull();
         assertThat(report.getFirst().getDuration()).isNull();
-        assertThat(report.getFirst().getUser()).isEqualTo(user.getEmail());
+        assertThat(report.getFirst().getUserEmail()).isEqualTo(user.getEmail());
+        assertThat(report.getFirst().getUserFullName()).isEqualTo(user.getFullName());
         assertThat(report.getFirst().getCaseReference()).isEqualTo(caseEntity.getReference());
         assertThat(report.getFirst().getCourt()).isEqualTo(courtEntity.getName());
         assertThat(report.getFirst().getRecordingId()).isEqualTo(recordingEntity.getId());
@@ -428,6 +434,45 @@ public class ReportServiceTest {
                        .getFirst()
                        .getName()
         ).isEqualTo(regionEntity.getName());
+    }
+
+    @DisplayName("Find audits relating to all playback attempts and return a report")
+    @Test
+    void reportPlaybackAllSuccess() {
+        var user = new User();
+        user.setId(UUID.randomUUID());
+        user.setEmail("example@example.com");
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        auditEntity.setCreatedBy(user.getId());
+        auditEntity.setSource(AuditLogSource.APPLICATION);
+
+        when(auditRepository.findAllAccessAttempts()).thenReturn(List.of(auditEntity));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(recordingRepository.findById(recordingEntity.getId())).thenReturn(Optional.of(recordingEntity));
+
+        var report = reportService.reportPlayback(null);
+
+        assertThat(report.size()).isEqualTo(1);
+        assertThat(report.getFirst().getPlaybackAt()).isEqualTo(auditEntity.getCreatedAt());
+        assertThat(report.getFirst().getFinishedAt()).isNull();
+        assertThat(report.getFirst().getDuration()).isNull();
+        assertThat(report.getFirst().getUserEmail()).isEqualTo(user.getEmail());
+        assertThat(report.getFirst().getUserFullName()).isEqualTo(user.getFullName());
+        assertThat(report.getFirst().getCaseReference()).isEqualTo(caseEntity.getReference());
+        assertThat(report.getFirst().getCourt()).isEqualTo(courtEntity.getName());
+        assertThat(report.getFirst().getRecordingId()).isEqualTo(recordingEntity.getId());
+        assertThat(report
+                       .getFirst()
+                       .getRegions()
+                       .stream()
+                       .toList()
+                       .getFirst()
+                       .getName()
+        ).isEqualTo(regionEntity.getName());
+
+        verify(auditRepository, times(1)).findAllAccessAttempts();
+        verify(auditRepository, never()).findBySourceAndFunctionalAreaAndActivity(any(), any(), any());
     }
 
     @DisplayName("Find audits relating to playbacks from the source 'admin' and throw not found error")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2395
https://tools.hmcts.net/jira/browse/S28-1637


### Change description ###
- Param `source` is no longer required
- Generic playback report `GET /reports/playback`
- PlaybackReportDTO field updates
    - Remove `user` (containing users email)
    - Add `userEmail`
    - Add `userFullName`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
