### PR TITLE
S28 2402: API GET `/capture-sessions/{id}`

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1606,6 +1606,31 @@ paths:
       summary: Share a Booking
       tags:
         - booking-controller
+  '/capture-sessions/{captureSessionId}':
+    get:
+      operationId: getCaptureSessionById
+      parameters:
+        - format: uuid
+          in: path
+          name: captureSessionId
+          required: true
+          type: string
+        - description: The User Id of the User making the request
+          format: uuid
+          in: header
+          name: X-User-Id
+          required: false
+          type: string
+          x-example: 123e4567-e89b-12d3-a456-426614174000
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/CaptureSessionDTO'
+      tags:
+        - capture-session-controller
   /cases:
     get:
       operationId: getCases

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.preapi.controllers;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.preapi.dto.CaptureSessionDTO;
+import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/capture-sessions")
+public class CaptureSessionController {
+
+    private final CaptureSessionService captureSessionService;
+
+    @Autowired
+    public CaptureSessionController(CaptureSessionService captureSessionService) {
+        this.captureSessionService = captureSessionService;
+    }
+
+    @GetMapping("/{captureSessionId}")
+    @Operation
+    public ResponseEntity<CaptureSessionDTO> getCaptureSessionById(@PathVariable UUID captureSessionId) {
+        return ResponseEntity.ok(captureSessionService.findById(captureSessionId));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -3,8 +3,12 @@ package uk.gov.hmcts.reform.preapi.services;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.preapi.dto.CaptureSessionDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
+import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
+
+import java.util.UUID;
 
 @Service
 public class CaptureSessionService {
@@ -17,6 +21,14 @@ public class CaptureSessionService {
                                  CaptureSessionRepository captureSessionRepository) {
         this.recordingService = recordingService;
         this.captureSessionRepository = captureSessionRepository;
+    }
+
+    @Transactional
+    public CaptureSessionDTO findById(UUID id) {
+        return captureSessionRepository
+            .findByIdAndDeletedAtIsNull(id)
+            .map(CaptureSessionDTO::new)
+            .orElseThrow(() -> new NotFoundException("CaptureSession: " + id));
     }
 
     @Transactional

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.preapi.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.preapi.controllers.CaptureSessionController;
+import uk.gov.hmcts.reform.preapi.dto.CaptureSessionDTO;
+import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CaptureSessionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class CaptureSessionControllerTest {
+    @Autowired
+    private transient MockMvc mockMvc;
+
+    @MockBean
+    private CaptureSessionService captureSessionService;
+    private static final String TEST_URL = "http://localhost";
+
+    @DisplayName("Should get capture session by id with 200 response code")
+    @Test
+    void getCaptureSessionByIdSuccess() throws Exception {
+        var id = UUID.randomUUID();
+        var model = new CaptureSessionDTO();
+        model.setId(id);
+        when(captureSessionService.findById(id)).thenReturn(model);
+
+        mockMvc.perform(get(TEST_URL + "/capture-sessions/" + id))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @DisplayName("Should return 404 when trying to get a non-existing capture session")
+    @Test
+    void getCaptureSessionByIdNotFound() throws Exception {
+        var id = UUID.randomUUID();
+        doThrow(new NotFoundException("CaptureSession: " + id)).when(captureSessionService).findById(id);
+
+        mockMvc.perform(get(TEST_URL + "/capture-sessions/" + id))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Not found: CaptureSession: " + id));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -8,11 +8,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
+import uk.gov.hmcts.reform.preapi.entities.User;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
+import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
+import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,15 +41,61 @@ public class CaptureSessionServiceTest {
 
     private static Booking booking;
 
+    private static User user;
+
     @BeforeAll
     static void setUp() {
+        user = new User();
+        user.setId(UUID.randomUUID());
         booking = new Booking();
         booking.setId(UUID.randomUUID());
         captureSession = new CaptureSession();
         captureSession.setId(UUID.randomUUID());
+        captureSession.setOrigin(RecordingOrigin.PRE);
         captureSession.setBooking(booking);
+        captureSession.setIngestAddress("example ingest address");
+        captureSession.setLiveOutputUrl("example url");
+        captureSession.setStartedAt(Timestamp.from(Instant.now()));
+        captureSession.setStartedByUser(user);
+        captureSession.setFinishedAt(Timestamp.from(Instant.now()));
+        captureSession.setFinishedByUser(user);
+        captureSession.setStatus(RecordingStatus.AVAILABLE);
     }
 
+    @DisplayName("Find a capture session and return a model")
+    @Test
+    void findByIdSuccess() {
+        when(captureSessionRepository.findByIdAndDeletedAtIsNull(captureSession.getId()))
+            .thenReturn(Optional.of(captureSession));
+
+        var model = captureSessionService.findById(captureSession.getId());
+
+        assertThat(model.getId()).isEqualTo(captureSession.getId());
+        assertThat(model.getBookingId()).isEqualTo(booking.getId());
+        assertThat(model.getOrigin()).isEqualTo(captureSession.getOrigin());
+        assertThat(model.getIngestAddress()).isEqualTo(captureSession.getIngestAddress());
+        assertThat(model.getLiveOutputUrl()).isEqualTo(captureSession.getLiveOutputUrl());
+        assertThat(model.getStartedAt()).isEqualTo(captureSession.getStartedAt());
+        assertThat(model.getStartedByUserId()).isEqualTo(user.getId());
+        assertThat(model.getFinishedAt()).isEqualTo(captureSession.getFinishedAt());
+        assertThat(model.getFinishedByUserId()).isEqualTo(user.getId());
+        assertThat(model.getStatus()).isEqualTo(captureSession.getStatus());
+        assertThat(model.getDeletedAt()).isEqualTo(captureSession.getDeletedAt());
+    }
+
+    @DisplayName("Find a capture session when capture session does not exist")
+    @Test
+    void findByIdNotFound() {
+        when(captureSessionRepository.findByIdAndDeletedAtIsNull(captureSession.getId()))
+            .thenReturn(Optional.empty());
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> captureSessionService.findById(captureSession.getId())
+        ).getMessage();
+
+        assertThat(message).isEqualTo("Not found: CaptureSession: " + captureSession.getId());
+    }
 
     @DisplayName("Should delete all attached recordings before marking capture session as deleted")
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2402


### Change description ###
- Add endpoint `GET /capture-sessions/{id}`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
