### PR TITLE
S28 2405: API DELETE `/capture-session/{id}`

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1607,6 +1607,27 @@ paths:
       tags:
         - booking-controller
   '/capture-sessions/{captureSessionId}':
+    delete:
+      operationId: deleteCaptureSessionById
+      parameters:
+        - format: uuid
+          in: path
+          name: captureSessionId
+          required: true
+          type: string
+        - description: The User Id of the User making the request
+          format: uuid
+          in: header
+          name: X-User-Id
+          required: false
+          type: string
+          x-example: 123e4567-e89b-12d3-a456-426614174000
+      responses:
+        '200':
+          description: OK
+      summary: Delete Capture Session by Id
+      tags:
+        - capture-session-controller
     get:
       operationId: getCaptureSessionById
       parameters:

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.preapi.controllers;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +28,12 @@ public class CaptureSessionController {
     @Operation
     public ResponseEntity<CaptureSessionDTO> getCaptureSessionById(@PathVariable UUID captureSessionId) {
         return ResponseEntity.ok(captureSessionService.findById(captureSessionId));
+    }
+
+    @DeleteMapping("/{captureSessionId}")
+    @Operation(operationId = "deleteCaptureSessionById", summary = "Delete Capture Session by Id")
+    public ResponseEntity<Void> deleteCaptureSessionById(@PathVariable UUID captureSessionId) {
+        captureSessionService.deleteById(captureSessionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
@@ -34,6 +34,6 @@ public class CaptureSessionController {
     @Operation(operationId = "deleteCaptureSessionById", summary = "Delete Capture Session by Id")
     public ResponseEntity<Void> deleteCaptureSessionById(@PathVariable UUID captureSessionId) {
         captureSessionService.deleteById(captureSessionId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -32,6 +32,16 @@ public class CaptureSessionService {
     }
 
     @Transactional
+    public void deleteById(UUID id) {
+        var entity = captureSessionRepository.findByIdAndDeletedAtIsNull(id);
+        if (entity.isEmpty()) {
+            throw new NotFoundException("CaptureSession: " + id);
+        }
+        recordingService.deleteCascade(entity.get());
+        captureSessionRepository.deleteById(id);
+    }
+
+    @Transactional
     public void deleteCascade(Booking booking) {
         captureSessionRepository
             .findAllByBookingAndDeletedAtIsNull(booking)

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -31,6 +33,8 @@ public class CaptureSessionControllerTest {
     @MockBean
     private CaptureSessionService captureSessionService;
     private static final String TEST_URL = "http://localhost";
+
+    private static final String CAPTURE_SESSION_ID_PATH = "/capture-sessions/{id}";
 
     @DisplayName("Should get capture session by id with 200 response code")
     @Test
@@ -55,5 +59,26 @@ public class CaptureSessionControllerTest {
         mockMvc.perform(get(TEST_URL + "/capture-sessions/" + id))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message").value("Not found: CaptureSession: " + id));
+    }
+
+    @DisplayName("Should delete capture session with 200 response code")
+    @Test
+    void deleteCaptureSessionByIdSuccess() throws Exception {
+        var id = UUID.randomUUID();
+
+        mockMvc.perform(delete(CAPTURE_SESSION_ID_PATH, id)
+                            .with(csrf()))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("Should delete capture session with 404 response code when not found")
+    @Test
+    void deleteCaptureSessionByIdNotFound() throws Exception {
+        var id = UUID.randomUUID();
+        doThrow(new NotFoundException("CaptureSession: " + id)).when(captureSessionService).deleteById(id);
+
+        mockMvc.perform(delete(CAPTURE_SESSION_ID_PATH, id)
+                            .with(csrf()))
+            .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -22,6 +22,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -107,5 +109,36 @@ public class CaptureSessionServiceTest {
         verify(captureSessionRepository, times(1)).findAllByBookingAndDeletedAtIsNull(booking);
         verify(recordingService, times(1)).deleteCascade(captureSession);
         verify(captureSessionRepository, times(1)).deleteAllByBooking(booking);
+    }
+
+    @DisplayName("Should delete a capture session by id")
+    @Test
+    void deleteByIdSuccess() {
+        when(captureSessionRepository.findByIdAndDeletedAtIsNull(captureSession.getId()))
+            .thenReturn(Optional.of(captureSession));
+
+        captureSessionService.deleteById(captureSession.getId());
+
+        verify(captureSessionRepository, times(1)).findByIdAndDeletedAtIsNull(captureSession.getId());
+        verify(recordingService, times(1)).deleteCascade(captureSession);
+        verify(captureSessionRepository, times(1)).deleteById(captureSession.getId());
+    }
+
+    @DisplayName("Should delete a capture session by id when capture session not found")
+    @Test
+    void deleteByIdNotFound() {
+        when(captureSessionRepository.findByIdAndDeletedAtIsNull(captureSession.getId()))
+            .thenReturn(Optional.empty());
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> captureSessionService.deleteById(captureSession.getId())
+        ).getMessage();
+
+        assertThat(message).isEqualTo("Not found: CaptureSession: " + captureSession.getId());
+
+        verify(captureSessionRepository, times(1)).findByIdAndDeletedAtIsNull(captureSession.getId());
+        verify(recordingService, never()).deleteCascade(any());
+        verify(captureSessionRepository, never()).deleteById(any());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2405


### Change description ###
- Add endpoint `DELETE /capture-session/{id}`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
