### PR TITLE
Provide swagger with longer API description

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1511,7 +1511,7 @@ externalDocs:
   url: 'https://github.com/hmcts/pre-api'
 host: 'sds-api-mgmt.staging.platform.hmcts.net'
 info:
-  description: PRE API
+  description: 'PRE API - Used for managing courts, bookings, recordings and permissions.'
   license:
     name: MIT
     url: 'https://opensource.org/licenses/MIT'

--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/OpenAPIConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/OpenAPIConfiguration.java
@@ -22,7 +22,7 @@ public class OpenAPIConfiguration {
     public OpenAPI openAPI() {
         return new OpenAPI()
             .info(new Info().title("PRE API")
-                      .description("PRE API")
+                      .description("PRE API - Used for managing courts, bookings, recordings and permissions.")
                       .version("v0.0.1")
                       .license(new License().name("MIT").url("https://opensource.org/licenses/MIT")))
             .externalDocs(new ExternalDocumentation()


### PR DESCRIPTION
Power Platform custom connectors suddenly need at least 30n characters in their API description so this will save time when updating it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
