### PR TITLE
Fix: 401 Errors Instead of 500 Errors + `/reports/playback` Error 401 Fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
         "/prometheus",
         "/users/by-email/**",
         "/reports/**",
-        "/audit/**"
+        "/audit/**",
+        "/error"
     };
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
@@ -17,9 +17,9 @@ public interface AuditRepository extends JpaRepository<Audit, UUID> {
         value = """
         SELECT a FROM Audit a
         WHERE a.activity != 'Recording Playback ended'
-        AND jsonb_extract_path_text(a.auditDetails, 'description') ILIKE '%playback%'
+        AND CAST(FUNCTION('jsonb_extract_path_text', a.auditDetails, 'description') as text) ILIKE '%playback%'
         """,
-        nativeQuery = true
+        nativeQuery = false
     )
     List<Audit> findAllAccessAttempts();
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
@@ -14,12 +14,11 @@ public interface AuditRepository extends JpaRepository<Audit, UUID> {
     List<Audit> findBySourceAndFunctionalAreaAndActivity(AuditLogSource source, String functionalArea, String activity);
 
     @Query(
-        value = """
+        """
         SELECT a FROM Audit a
         WHERE a.activity != 'Recording Playback ended'
         AND CAST(FUNCTION('jsonb_extract_path_text', a.auditDetails, 'description') as text) ILIKE '%playback%'
-        """,
-        nativeQuery = false
+        """
     )
     List<Audit> findAllAccessAttempts();
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -166,14 +166,19 @@ public class ReportService {
     }
 
     private PlaybackReportDTO toPlaybackReport(Audit audit) {
+        System.out.println("HERE: " + audit.getId());
         return new PlaybackReportDTO(
             audit,
-            userRepository
+            audit.getCreatedBy() != null
+                ? userRepository
                 .findById(audit.getCreatedBy())
-                .orElse(null),
-            recordingRepository
+                .orElse(null)
+                : null,
+            audit.getTableRecordId() != null
+                ? recordingRepository
                 .findById(audit.getTableRecordId())
                 .orElse(null)
+                : null
         );
     }
 }


### PR DESCRIPTION
### Change description ###
- Add `/errors` to the list of endpoints to avoid authentication checks on to prevent 401 errors when 500 errors should be returned. 
- Fix 500 error when `/reports/playback` encounters a record with no `createdBy` or `tableRecordId` set
- Fix 500 error with JPA query


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
