### PR TITLE
Fix: Sharing a Booking Uses UUID instead of UserDTO + Callable without `sharedBy` set

### DIFF
--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -622,9 +622,11 @@ definitions:
         format: uuid
         type: string
       shared_by_user:
-        $ref: '#/definitions/BaseUserDTO'
+        format: uuid
+        type: string
       shared_with_user:
-        $ref: '#/definitions/BaseUserDTO'
+        format: uuid
+        type: string
     type: object
   CreateUserDTO:
     description: CreateUserDTO

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
@@ -13,6 +13,7 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -29,6 +30,7 @@ import uk.gov.hmcts.reform.preapi.dto.CreateShareBookingDTO;
 import uk.gov.hmcts.reform.preapi.dto.ShareBookingDTO;
 import uk.gov.hmcts.reform.preapi.exception.PathPayloadMismatchException;
 import uk.gov.hmcts.reform.preapi.exception.RequestedPageOutOfRangeException;
+import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 import uk.gov.hmcts.reform.preapi.services.BookingService;
 import uk.gov.hmcts.reform.preapi.services.ShareBookingService;
 
@@ -153,9 +155,13 @@ public class BookingController extends PreApiController {
         @PathVariable UUID bookingId,
         @RequestBody CreateShareBookingDTO createShareBookingDTO
     ) {
-        // TODO Ensure user has access to share the recording
         if (!bookingId.equals(createShareBookingDTO.getBookingId())) {
             throw new PathPayloadMismatchException("bookingId", "shareBookingDTO.bookingId");
+        }
+
+        if (createShareBookingDTO.getSharedByUser() == null) {
+            createShareBookingDTO.setSharedByUser(((UserAuthentication) SecurityContextHolder
+                .getContext().getAuthentication()).getUserId());
         }
 
         return getUpsertResponse(shareBookingService

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateShareBookingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateShareBookingDTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.hmcts.reform.preapi.dto.base.BaseUserDTO;
 
 import java.util.UUID;
 
@@ -14,6 +13,6 @@ import java.util.UUID;
 public class CreateShareBookingDTO {
     private UUID id;
     private UUID bookingId;
-    private BaseUserDTO sharedWithUser;
-    private BaseUserDTO sharedByUser;
+    private UUID sharedWithUser;
+    private UUID sharedByUser;
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
@@ -119,7 +119,7 @@ public class AuthorisationService {
     }
 
     public boolean hasUpsertAccess(UserAuthentication authentication, CreateShareBookingDTO dto) {
-        return authentication.getUserId().equals(dto.getSharedByUser().getId())
+        return authentication.getUserId().equals(dto.getSharedByUser())
             && (authentication.isAdmin() || hasBookingAccess(authentication, dto.getBookingId()));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
@@ -45,9 +45,9 @@ public class ShareBookingService {
 
         final var booking = bookingRepository.findById(createShareBookingDTO.getBookingId())
             .orElseThrow(() -> new NotFoundException("Booking: " + createShareBookingDTO.getBookingId()));
-        final var sharedByUser = userRepository.findById(createShareBookingDTO.getSharedByUser().getId())
+        final var sharedByUser = userRepository.findById(createShareBookingDTO.getSharedByUser())
             .orElseThrow(() -> new NotFoundException("Shared by User: " + createShareBookingDTO.getSharedByUser()));
-        final var sharedWithUser = userRepository.findById(createShareBookingDTO.getSharedWithUser().getId())
+        final var sharedWithUser = userRepository.findById(createShareBookingDTO.getSharedWithUser())
             .orElseThrow(() -> new NotFoundException("Shared with User: " + createShareBookingDTO.getSharedWithUser()));
 
         var shareBookingEntity = new ShareBooking();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/security/AuthorisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/security/AuthorisationServiceTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.preapi.dto.CreateCaseDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateParticipantDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateShareBookingDTO;
-import uk.gov.hmcts.reform.preapi.dto.UserDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.Case;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/security/AuthorisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/security/AuthorisationServiceTest.java
@@ -625,10 +625,8 @@ public class AuthorisationServiceTest {
     void hasUpsertAccessUserIsSharingAndHasBookingAccess() {
         var dto = new CreateShareBookingDTO();
         var userId = UUID.randomUUID();
-        var sharedBy = new UserDTO();
-        sharedBy.setId(userId);
 
-        dto.setSharedByUser(sharedBy);
+        dto.setSharedByUser(userId);
         dto.setBookingId(UUID.randomUUID());
 
         when(authenticationUser.getUserId()).thenReturn(userId);
@@ -642,10 +640,8 @@ public class AuthorisationServiceTest {
     @Test
     void hasUpsertAccessUserIsNotSharing() {
         var dto = new CreateShareBookingDTO();
-        var sharedBy = new UserDTO();
-        sharedBy.setId(UUID.randomUUID());
 
-        dto.setSharedByUser(sharedBy);
+        dto.setSharedByUser(UUID.randomUUID());
         dto.setBookingId(UUID.randomUUID());
 
         when(authenticationUser.getUserId()).thenReturn(UUID.randomUUID());
@@ -658,10 +654,8 @@ public class AuthorisationServiceTest {
     void hasUpsertAccessUserIsAdmin() {
         var dto = new CreateShareBookingDTO();
         var userId = UUID.randomUUID();
-        var sharedBy = new UserDTO();
-        sharedBy.setId(userId);
 
-        dto.setSharedByUser(sharedBy);
+        dto.setSharedByUser(userId);
         dto.setBookingId(UUID.randomUUID());
 
         when(authenticationUser.getUserId()).thenReturn(userId);
@@ -675,10 +669,8 @@ public class AuthorisationServiceTest {
     void hasUpsertAccessUserIsNotAdminAndNoBookingAccess() {
         var dto = new CreateShareBookingDTO();
         var userId = UUID.randomUUID();
-        var sharedBy = new UserDTO();
-        sharedBy.setId(userId);
 
-        dto.setSharedByUser(sharedBy);
+        dto.setSharedByUser(userId);
         dto.setBookingId(UUID.randomUUID());
 
         var booking = new Booking();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.BookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.ShareBookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
-import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 
 import java.sql.Timestamp;
 import java.time.Instant;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.ShareBooking;
 import uk.gov.hmcts.reform.preapi.entities.User;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
+import uk.gov.hmcts.reform.preapi.exception.ConflictException;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.BookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.ShareBookingRepository;
@@ -52,8 +53,8 @@ public class ShareBookingServiceTest {
         var shareBookingDTO = new CreateShareBookingDTO();
         shareBookingDTO.setId(UUID.randomUUID());
         shareBookingDTO.setBookingId(UUID.randomUUID());
-        shareBookingDTO.setSharedByUser(HelperFactory.easyCreateBaseUserDTO());
-        shareBookingDTO.setSharedWithUser(HelperFactory.easyCreateBaseUserDTO());
+        shareBookingDTO.setSharedByUser(UUID.randomUUID());
+        shareBookingDTO.setSharedWithUser(UUID.randomUUID());
 
         var bookingEntity = new Booking();
         var sharedByUser = new User();
@@ -63,10 +64,10 @@ public class ShareBookingServiceTest {
             bookingRepository.findById(shareBookingDTO.getBookingId())
         ).thenReturn(Optional.of(bookingEntity));
         when(
-            userRepository.findById(shareBookingDTO.getSharedByUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedByUser())
         ).thenReturn(Optional.of(sharedByUser));
         when(
-            userRepository.findById(shareBookingDTO.getSharedWithUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedWithUser())
         ).thenReturn(Optional.of(sharedWithUser));
 
         assertThat(shareBookingService.shareBookingById(shareBookingDTO)).isEqualTo(UpsertResult.CREATED);
@@ -78,14 +79,14 @@ public class ShareBookingServiceTest {
         var shareBookingDTO = new CreateShareBookingDTO();
         shareBookingDTO.setId(UUID.randomUUID());
         shareBookingDTO.setBookingId(UUID.randomUUID());
-        shareBookingDTO.setSharedByUser(HelperFactory.easyCreateBaseUserDTO());
-        shareBookingDTO.setSharedWithUser(HelperFactory.easyCreateBaseUserDTO());
+        shareBookingDTO.setSharedByUser(UUID.randomUUID());
+        shareBookingDTO.setSharedWithUser(UUID.randomUUID());
 
         when(
             bookingRepository.findById(shareBookingDTO.getBookingId())
         ).thenReturn(Optional.empty());
 
-        assertThatExceptionOfType(uk.gov.hmcts.reform.preapi.exception.NotFoundException.class)
+        assertThatExceptionOfType(NotFoundException.class)
             .isThrownBy(() -> {
                 shareBookingService.shareBookingById(shareBookingDTO);
             })
@@ -98,8 +99,8 @@ public class ShareBookingServiceTest {
         var shareBookingDTO = new CreateShareBookingDTO();
         shareBookingDTO.setId(UUID.randomUUID());
         shareBookingDTO.setBookingId(UUID.randomUUID());
-        shareBookingDTO.setSharedByUser(HelperFactory.easyCreateBaseUserDTO());
-        shareBookingDTO.setSharedWithUser(HelperFactory.easyCreateBaseUserDTO());
+        shareBookingDTO.setSharedByUser(UUID.randomUUID());
+        shareBookingDTO.setSharedWithUser(UUID.randomUUID());
 
         var bookingEntity = new Booking();
 
@@ -107,7 +108,7 @@ public class ShareBookingServiceTest {
             bookingRepository.findById(shareBookingDTO.getBookingId())
         ).thenReturn(Optional.of(bookingEntity));
         when(
-            userRepository.findById(shareBookingDTO.getSharedByUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedByUser())
         ).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(uk.gov.hmcts.reform.preapi.exception.NotFoundException.class)
@@ -123,8 +124,8 @@ public class ShareBookingServiceTest {
         var shareBookingDTO = new CreateShareBookingDTO();
         shareBookingDTO.setId(UUID.randomUUID());
         shareBookingDTO.setBookingId(UUID.randomUUID());
-        shareBookingDTO.setSharedByUser(HelperFactory.easyCreateBaseUserDTO());
-        shareBookingDTO.setSharedWithUser(HelperFactory.easyCreateBaseUserDTO());
+        shareBookingDTO.setSharedByUser(UUID.randomUUID());
+        shareBookingDTO.setSharedWithUser(UUID.randomUUID());
 
         var bookingEntity = new Booking();
         var sharedByUser = new User();
@@ -133,10 +134,10 @@ public class ShareBookingServiceTest {
             bookingRepository.findById(shareBookingDTO.getBookingId())
         ).thenReturn(Optional.of(bookingEntity));
         when(
-            userRepository.findById(shareBookingDTO.getSharedByUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedByUser())
         ).thenReturn(Optional.of(sharedByUser));
         when(
-            userRepository.findById(shareBookingDTO.getSharedWithUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedWithUser())
         ).thenReturn(Optional.empty());
 
         assertThatExceptionOfType(uk.gov.hmcts.reform.preapi.exception.NotFoundException.class)
@@ -152,8 +153,8 @@ public class ShareBookingServiceTest {
         var shareBookingDTO = new CreateShareBookingDTO();
         shareBookingDTO.setId(UUID.randomUUID());
         shareBookingDTO.setBookingId(UUID.randomUUID());
-        shareBookingDTO.setSharedByUser(HelperFactory.easyCreateBaseUserDTO());
-        shareBookingDTO.setSharedWithUser(HelperFactory.easyCreateBaseUserDTO());
+        shareBookingDTO.setSharedByUser(UUID.randomUUID());
+        shareBookingDTO.setSharedWithUser(UUID.randomUUID());
 
         var bookingEntity = new Booking();
         var sharedByUser = new User();
@@ -163,16 +164,16 @@ public class ShareBookingServiceTest {
             bookingRepository.findById(shareBookingDTO.getBookingId())
         ).thenReturn(Optional.of(bookingEntity));
         when(
-            userRepository.findById(shareBookingDTO.getSharedByUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedByUser())
         ).thenReturn(Optional.of(sharedByUser));
         when(
-            userRepository.findById(shareBookingDTO.getSharedWithUser().getId())
+            userRepository.findById(shareBookingDTO.getSharedWithUser())
         ).thenReturn(Optional.of(sharedWithUser));
         when(
             shareBookingRepository.existsById(shareBookingDTO.getId())
         ).thenReturn(true);
 
-        assertThatExceptionOfType(uk.gov.hmcts.reform.preapi.exception.ConflictException.class)
+        assertThatExceptionOfType(ConflictException.class)
             .isThrownBy(() -> {
                 shareBookingService.shareBookingById(shareBookingDTO);
             })


### PR DESCRIPTION
### Change description ###
- Update CreateShareBookingDTO to use UUID instead of BaseUserDTO for `sharedWithUser` and `sharedByUser`
- `sharedByUser` can be inferred from the authenticated user if the value is not set in the request


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
