### PR TITLE
S28 2470: Shorten Timestamps Saved to Match Old DB

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/AppAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/AppAccess.java
@@ -8,6 +8,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
 
 import java.sql.Date;
@@ -37,6 +38,7 @@ public class AppAccess extends CreatedModifiedAtEntity {
     @Column(name = "active")
     private boolean active = true;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Audit.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Audit.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -55,6 +56,7 @@ public class Audit extends BaseEntity {
     private UUID createdBy;
 
     @CreationTimestamp
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "created_at", nullable = false)
     private Timestamp createdAt;
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Booking.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Booking.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
 
 import java.sql.Timestamp;
@@ -27,9 +28,11 @@ public class Booking extends CreatedModifiedAtEntity {
     @JoinColumn(name = "case_id", referencedColumnName = "id")
     private Case caseId;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "scheduled_for", nullable = false)
     private Timestamp scheduledFor;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/CaptureSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/CaptureSession.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.reform.preapi.entities.base.BaseEntity;
@@ -41,6 +42,7 @@ public class CaptureSession extends BaseEntity {
     @Column(name = "live_output_url", length = 100)
     private String liveOutputUrl;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "started_at")
     private Timestamp startedAt;
 
@@ -48,6 +50,7 @@ public class CaptureSession extends BaseEntity {
     @JoinColumn(name = "started_by_user_id", referencedColumnName = "id")
     private User startedByUser;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "finished_at")
     private Timestamp finishedAt;
 
@@ -60,6 +63,7 @@ public class CaptureSession extends BaseEntity {
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     private RecordingStatus status;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Case.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Case.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
 
 import java.sql.Timestamp;
@@ -34,6 +35,7 @@ public class Case extends CreatedModifiedAtEntity {
     @Column(name = "test")
     private boolean test;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Participant.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Participant.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
@@ -40,6 +41,7 @@ public class Participant extends CreatedModifiedAtEntity {
     @Column(name = "last_name", length = 100, nullable = false)
     private String lastName;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
@@ -32,6 +33,7 @@ public class PortalAccess extends CreatedModifiedAtEntity {
     private String password;
 
     @Column(name = "last_access")
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     private Timestamp lastAccess;
 
     @Enumerated(EnumType.STRING)
@@ -39,12 +41,15 @@ public class PortalAccess extends CreatedModifiedAtEntity {
     @Column(name = "status", nullable = false)
     private AccessStatus status = AccessStatus.INVITATION_SENT;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "invited_at")
     private Timestamp invitedAt;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "registered_at")
     private Timestamp registeredAt;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Recording.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Recording.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Type;
@@ -44,6 +45,7 @@ public class Recording extends BaseEntity {
     private String filename;
 
     @CreationTimestamp
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "created_at", nullable = false)
     private Timestamp createdAt;
 
@@ -58,6 +60,7 @@ public class Recording extends BaseEntity {
     @JdbcTypeCode(SqlTypes.JSON)
     private String editInstruction;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/ShareBooking.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/ShareBooking.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.CreationTimestamp;
 import uk.gov.hmcts.reform.preapi.entities.base.BaseEntity;
 
@@ -35,9 +36,11 @@ public class ShareBooking extends BaseEntity {
     private User sharedBy;
 
     @CreationTimestamp
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "created_at")
     private Timestamp createdAt;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/User.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
 
 import java.sql.Timestamp;
@@ -35,6 +36,7 @@ public class User extends CreatedModifiedAtEntity {
     @Column(name = "phone", length = 50)
     private String phone;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/base/CreatedModifiedAtEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/base/CreatedModifiedAtEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PreUpdate;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
@@ -14,9 +15,10 @@ import java.sql.Timestamp;
 @Setter
 public class CreatedModifiedAtEntity extends BaseEntity {
     @CreationTimestamp
-    @Column(name = "created_at", nullable = false)
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     private Timestamp createdAt;
 
+    @ColumnTransformer(write = "CAST(? AS TIMESTAMP(3))")
     @Column(name = "modified_at")
     private Timestamp modifiedAt;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2470


### Change description ###
- Truncate timestamps as they are saved `yyyy-MM-dd HH:mm:ss.SSSSSS` -> `yyyy-MM-dd HH:mm:ss.SSS`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
