### PR TITLE
Fix: Cascade Delete Error When Associated Recording Not Deleted

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
@@ -27,7 +27,7 @@ class BookingControllerFT extends FunctionalTestBase {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
-    void shouldDeleteRecordingsForBooking() {
+    void shouldNotDeleteRecordingsForBooking() {
 
         var testIds = doPostRequest("/testing-support/should-delete-recordings-for-booking", false).body().jsonPath();
 
@@ -44,10 +44,12 @@ class BookingControllerFT extends FunctionalTestBase {
         assertThat(recordingResponse.body().jsonPath().getString("created_at")).isNotBlank();
 
         var deleteResponse = doDeleteRequest(BOOKINGS_ENDPOINT + bookingId, true);
-        assertThat(deleteResponse.statusCode()).isEqualTo(204);
+        assertThat(deleteResponse.statusCode()).isEqualTo(400);
+        assertThat(deleteResponse.getBody().jsonPath().getString("message"))
+            .isEqualTo("Cannot delete because and associated recording has not been deleted.");
 
         var recordingResponse2 = doGetRequest(RECORDINGS_ENDPOINT + recordingId, true);
-        assertThat(recordingResponse2.statusCode()).isEqualTo(404);
+        assertThat(recordingResponse2.statusCode()).isEqualTo(200);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
@@ -16,6 +16,8 @@ import uk.gov.hmcts.reform.preapi.dto.ParticipantDTO;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
+import uk.gov.hmcts.reform.preapi.exception.RecordingNotDeletedException;
+import uk.gov.hmcts.reform.preapi.repositories.RecordingRepository;
 import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 
@@ -35,6 +37,8 @@ public class CaseServiceIT {
 
     @Autowired
     private CaseService caseService;
+    @Autowired
+    private RecordingRepository recordingRepository;
 
     public static void mockAdminUser() {
         var mockAuth = mock(UserAuthentication.class);
@@ -204,6 +208,27 @@ public class CaseServiceIT {
 
         var recording = HelperFactory.createRecording(captureSession, null, 1, "url", "filename",null);
         entityManager.persist(recording);
+
+        var message = Assertions.assertThrows(
+            RecordingNotDeletedException.class,
+            () ->  caseService.deleteById(caseEntity.getId())
+        ).getMessage();
+
+        Assertions.assertEquals(message, "Cannot delete because and associated recording has not been deleted.");
+
+        entityManager.refresh(caseEntity);
+        entityManager.refresh(booking);
+        entityManager.refresh(captureSession);
+        entityManager.refresh(recording);
+
+        Assertions.assertNull(caseEntity.getDeletedAt());
+        Assertions.assertNull(booking.getDeletedAt());
+        Assertions.assertNull(captureSession.getDeletedAt());
+        Assertions.assertNull(recording.getDeletedAt());
+
+        recording.setDeletedAt(Timestamp.from(Instant.now()));
+        recordingRepository.saveAndFlush(recording);
+        entityManager.refresh(recording);
 
         caseService.deleteById(caseEntity.getId());
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/exception/GlobalControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/exception/GlobalControllerExceptionHandler.java
@@ -104,6 +104,13 @@ public class GlobalControllerExceptionHandler {
         return getResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(RecordingNotDeletedException.class)
+    ResponseEntity<String> onRecordingNotDeletedException(final RecordingNotDeletedException e)
+        throws JsonProcessingException {
+
+        return getResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
     private static ResponseEntity<String> getResponseEntity(String message, HttpStatus status)
         throws JsonProcessingException {
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/exception/RecordingNotDeletedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/exception/RecordingNotDeletedException.java
@@ -6,9 +6,4 @@ public class RecordingNotDeletedException extends RuntimeException {
     public RecordingNotDeletedException() {
         super("Cannot delete because and associated recording has not been deleted.");
     }
-
-    public RecordingNotDeletedException(Exception exception) {
-        super(exception);
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/exception/RecordingNotDeletedException.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/exception/RecordingNotDeletedException.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.preapi.exception;
+
+public class RecordingNotDeletedException extends RuntimeException {
+    private static final long serialVersionUID = 6579841826356533851L;
+
+    public RecordingNotDeletedException() {
+        super("Cannot delete because and associated recording has not been deleted.");
+    }
+
+    public RecordingNotDeletedException(Exception exception) {
+        super(exception);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -90,6 +90,8 @@ public interface RecordingRepository extends SoftDeleteRepository<Recording, UUI
 
     List<Recording> findAllByParentRecordingIsNull();
 
+    boolean existsByCaptureSessionAndDeletedAtIsNull(CaptureSession captureSession);
+
     @Query("""
         update #{#entityName} e
         set e.deletedAt=CURRENT_TIMESTAMP

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.BookingDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateBookingDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
@@ -162,7 +163,7 @@ public class BookingService {
         bookingRepository.deleteById(id);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     public void deleteCascade(Case caseEntity) {
         bookingRepository
             .findAllByCaseIdAndDeletedAtIsNull(caseEntity)

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -1,12 +1,13 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CaptureSessionDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaptureSessionDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
@@ -98,7 +99,7 @@ public class CaptureSessionService {
         captureSessionRepository.deleteById(id);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     public void deleteCascade(Booking booking) {
         captureSessionRepository
             .findAllByBookingAndDeletedAtIsNull(booking)

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CaseDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaseDTO;
 import uk.gov.hmcts.reform.preapi.entities.Case;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CourtService.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.preapi.services;
 
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CourtDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCourtDTO;
 import uk.gov.hmcts.reform.preapi.entities.Court;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/InviteService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/InviteService.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CreateInviteDTO;
 import uk.gov.hmcts.reform.preapi.dto.InviteDTO;
 import uk.gov.hmcts.reform.preapi.enums.AccessStatus;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.exception.RecordingNotDeletedException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RecordingRepository;
@@ -137,6 +138,8 @@ public class RecordingService {
 
     @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     public void deleteCascade(CaptureSession captureSession) {
-        recordingRepository.deleteAllByCaptureSession(captureSession);
+        if (recordingRepository.existsByCaptureSessionAndDeletedAtIsNull(captureSession)) {
+            throw new RecordingNotDeletedException();
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.reform.preapi.services;
 
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.controllers.params.SearchRecordings;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
@@ -134,7 +135,7 @@ public class RecordingService {
         recordingRepository.deleteById(recordingId);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     public void deleteCascade(CaptureSession captureSession) {
         recordingRepository.deleteAllByCaptureSession(captureSession);
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.CompletedCaptureSessionReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.ConcurrentCaptureSessionReportDTO;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RoleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RoleService.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.RoleDTO;
 import uk.gov.hmcts.reform.preapi.repositories.RoleRepository;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CreateShareBookingDTO;
 import uk.gov.hmcts.reform.preapi.dto.ShareBookingDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
@@ -82,7 +83,7 @@ public class ShareBookingService {
         shareBookingRepository.deleteById(shareId);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     public void deleteCascade(Booking booking) {
         shareBookingRepository.deleteAllByBooking(booking);
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.reform.preapi.services;
 
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.AppAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateInviteDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.preapi.dto.ShareBookingDTO;
 import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.exception.RecordingNotDeletedException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
 import uk.gov.hmcts.reform.preapi.exception.UnknownServerException;
 import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
@@ -459,6 +460,20 @@ class BookingControllerTest {
                             .with(csrf())
                             .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNoContent());
+
+    }
+
+    @DisplayName("Should return 400 when booking has associated recordings that have not been deleted")
+    @Test
+    void deleteBookingRecordingNotDeleted() throws Exception {
+        var bookingId = UUID.randomUUID();
+        doThrow(new RecordingNotDeletedException()).when(bookingService).markAsDeleted(bookingId);
+
+        mockMvc.perform(delete("/bookings/" + bookingId)
+                            .with(csrf()))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message")
+                           .value("Cannot delete because and associated recording has not been deleted."));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.exception.RecordingNotDeletedException;
 import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
 
@@ -229,6 +230,20 @@ public class CaptureSessionControllerTest {
         mockMvc.perform(delete(CAPTURE_SESSION_ID_PATH, id)
                             .with(csrf()))
             .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("Should return 400 when booking has associated recordings that have not been deleted")
+    @Test
+    void deleteCaptureSessionRecordingNotDeleted() throws Exception {
+        var captureSessionId = UUID.randomUUID();
+        doThrow(new RecordingNotDeletedException()).when(captureSessionService).deleteById(captureSessionId);
+
+        mockMvc.perform(delete("/capture-sessions/" + captureSessionId)
+                            .with(csrf()))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message")
+                           .value("Cannot delete because and associated recording has not been deleted."));
+
     }
 
     @DisplayName("Should create capture session with 201 response code")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.preapi.dto.CaseDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaseDTO;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.exception.RecordingNotDeletedException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
 import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.CaseService;
@@ -279,6 +280,19 @@ class CaseControllerTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message")
                            .value("Invalid UUID string: 12345678"));
+    }
+
+    @DisplayName("Should return 400 when case has associated recordings that have not been deleted")
+    @Test
+    void deleteCaseRecordingNotDeleted() throws Exception {
+        var caseId = UUID.randomUUID();
+        doThrow(new RecordingNotDeletedException()).when(caseService).deleteById(caseId);
+        mockMvc.perform(delete("/cases/" + caseId)
+                            .with(csrf()))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message")
+                           .value("Cannot delete because and associated recording has not been deleted."));
+
     }
 
     @DisplayName("Should set include deleted param to false if not set")


### PR DESCRIPTION
### Change description ###
- When deleting case/booking/capture session an error will occur if there is an associated recording that has not been marked as deleted preventing deleting of any associated entities. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
