### PR TITLE
S28 2477: Undelete Endpoints

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/BookingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/BookingServiceIT.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
@@ -199,7 +199,7 @@ public class BookingController extends PreApiController {
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
     public ResponseEntity<Void> undeleteBooking(@PathVariable UUID bookingId) {
         bookingService.undelete(bookingId);
-        return noContent().build();
+        return ok().build();
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -191,6 +192,14 @@ public class BookingController extends PreApiController {
             throw new RequestedPageOutOfRangeException(pageable.getPageNumber(), resultPage.getTotalPages());
         }
         return ok(assembler.toModel(resultPage));
+    }
+
+    @PostMapping("/{bookingId}/undelete")
+    @Operation(operationId = "undeleteBooking", summary = "Revert deletion of a booking")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
+    public ResponseEntity<Void> undeleteBooking(@PathVariable UUID bookingId) {
+        bookingService.undelete(bookingId);
+        return noContent().build();
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -139,5 +140,13 @@ public class CaptureSessionController extends PreApiController {
             captureSessionService.upsert(createCaptureSessionDTO),
             createCaptureSessionDTO.getId()
         );
+    }
+
+    @PostMapping("/{captureSessionId}/undelete")
+    @Operation(operationId = "undeleteCaptureSession", summary = "Revert deletion of a capture session")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
+    public ResponseEntity<Void> undeleteCaptureSession(@PathVariable UUID captureSessionId) {
+        captureSessionService.undelete(captureSessionId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaseController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -115,6 +116,14 @@ public class CaseController extends PreApiController {
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_4')")
     public ResponseEntity<Void> deleteCase(@PathVariable UUID id) {
         caseService.deleteById(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/undelete")
+    @Operation(operationId = "undeleteCase", summary = "Revert deletion of a case")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
+    public ResponseEntity<Void> undeleteCase(@PathVariable UUID id) {
+        caseService.undelete(id);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -162,7 +162,7 @@ public class RecordingController extends PreApiController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/{recordingId}")
+    @PostMapping("/{recordingId}/undelete")
     @Operation(operationId = "undeleteRecording", summary = "Revert deletion of a recording")
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
     public ResponseEntity<Void> undeleteRecording(@PathVariable UUID recordingId) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -167,6 +167,6 @@ public class RecordingController extends PreApiController {
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
     public ResponseEntity<Void> undeleteRecording(@PathVariable UUID recordingId) {
         recordingService.undelete(recordingId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -159,5 +160,13 @@ public class RecordingController extends PreApiController {
     ) {
         recordingService.deleteById(recordingId);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{recordingId}")
+    @Operation(operationId = "undeleteRecording", summary = "Revert deletion of a recording")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
+    public ResponseEntity<Void> undeleteRecording(@PathVariable UUID recordingId) {
+        recordingService.undelete(recordingId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/UserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -139,7 +140,6 @@ public class UserController extends PreApiController {
             pageable
         );
 
-
         if (pageable.getPageNumber() > resultPage.getTotalPages()) {
             throw new RequestedPageOutOfRangeException(pageable.getPageNumber(), resultPage.getTotalPages());
         }
@@ -163,6 +163,14 @@ public class UserController extends PreApiController {
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_4')")
     public ResponseEntity<Void> deleteUserById(@PathVariable UUID userId) {
         userService.deleteById(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{userId}/undelete")
+    @Operation(operationId = "undeleteUser", summary = "Revert deletion of user")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1')")
+    public ResponseEntity<Void> undeleteUser(@PathVariable UUID userId) {
+        userService.undelete(userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
@@ -162,6 +162,17 @@ public class BookingService {
     }
 
     @Transactional
+    @PreAuthorize("@authorisationService.hasBookingAccess(authentication, #id)")
+    public void undelete(UUID id) {
+        var entity = bookingRepository.findById(id).orElseThrow(() -> new NotFoundException("Booking: " + id));
+        if (!entity.isDeleted()) {
+            return;
+        }
+        entity.setDeletedAt(null);
+        bookingRepository.save(entity);
+    }
+
+    @Transactional
     public void deleteCascade(Case caseEntity) {
         bookingRepository
             .findAllByCaseIdAndDeletedAtIsNull(caseEntity)

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -65,8 +65,7 @@ public class CaptureSessionService {
     ) {
         var until = scheduledFor.isEmpty()
             ? null
-            : scheduledFor.map(
-            t -> Timestamp.from(t.toInstant().plus(86399, ChronoUnit.SECONDS))).orElse(null);
+            : scheduledFor.map(t -> Timestamp.from(t.toInstant().plus(86399, ChronoUnit.SECONDS))).orElse(null);
 
         var auth = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication());
         var authorisedBookings = auth.isAdmin() || auth.isAppUser() ? null : auth.getSharedBookings();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
@@ -149,12 +149,22 @@ public class CaseService {
     @Transactional
     @PreAuthorize("@authorisationService.hasCaseAccess(authentication, #id)")
     public void deleteById(UUID id) {
-        var entity  = caseRepository.findByIdAndDeletedAtIsNull(id);
+        var entity = caseRepository.findByIdAndDeletedAtIsNull(id);
         if (entity.isEmpty()) {
             throw new NotFoundException("CaseDTO: " + id);
         }
         bookingService.deleteCascade(entity.get());
         caseRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void undelete(UUID id) {
+        var entity = caseRepository.findById(id).orElseThrow(() -> new NotFoundException("Case: " + id));
+        if (!entity.isDeleted()) {
+            return;
+        }
+        entity.setDeletedAt(null);
+        caseRepository.save(entity);
     }
 
     private boolean isCaseReferenceValid(boolean isUpdate, String caseReference, UUID caseId) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -138,4 +138,15 @@ public class RecordingService {
     public void deleteCascade(CaptureSession captureSession) {
         recordingRepository.deleteAllByCaptureSession(captureSession);
     }
+
+    @Transactional
+    @PreAuthorize("@authorisationService.hasRecordingAccess(authentication, #id)")
+    public void undelete(UUID id) {
+        var entity = recordingRepository.findById(id).orElseThrow(() -> new NotFoundException("Recording: " + id));
+        if (!entity.isDeleted()) {
+            return;
+        }
+        entity.setDeletedAt(null);
+        recordingRepository.save(entity);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -179,4 +179,14 @@ public class UserService {
 
         userRepository.deleteById(userId);
     }
+
+    @Transactional
+    public void undelete(UUID id) {
+        var entity = userRepository.findById(id).orElseThrow(() -> new NotFoundException("User: " + id));
+        if (!entity.isDeleted()) {
+            return;
+        }
+        entity.setDeletedAt(null);
+        userRepository.save(entity);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -762,7 +762,7 @@ class BookingControllerTest {
     void undeleteBookingNotFound() throws Exception {
         var bookingId = UUID.randomUUID();
         doThrow(
-            new NotFoundException("Not found: Booking: " + bookingId)
+            new NotFoundException("Booking: " + bookingId)
         ).when(bookingService).undelete(bookingId);
 
         mockMvc.perform(post("/bookings/" + bookingId + "/undelete")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -746,7 +746,7 @@ class BookingControllerTest {
 
     }
 
-    @DisplayName("Should undelete a booking by id and return a 204 response")
+    @DisplayName("Should undelete a booking by id and return a 200 response")
     @Test
     void undeleteBookingSuccess() throws Exception {
         var bookingId = UUID.randomUUID();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -754,7 +754,7 @@ class BookingControllerTest {
 
         mockMvc.perform(post("/bookings/" + bookingId + "/undelete")
                             .with(csrf()))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk());
     }
 
     @DisplayName("Should undelete a booking by id and return a 404 response")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -44,6 +44,7 @@ import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -52,6 +53,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -742,6 +744,32 @@ class BookingControllerTest {
             .andExpect(jsonPath("$.message")
                            .value("Not found: Booking: " + model.getBookingId()));
 
+    }
+
+    @DisplayName("Should undelete a booking by id and return a 204 response")
+    @Test
+    void undeleteBookingSuccess() throws Exception {
+        var bookingId = UUID.randomUUID();
+        doNothing().when(bookingService).undelete(bookingId);
+
+        mockMvc.perform(post("/bookings/" + bookingId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("Should undelete a booking by id and return a 404 response")
+    @Test
+    void undeleteBookingNotFound() throws Exception {
+        var bookingId = UUID.randomUUID();
+        doThrow(
+            new NotFoundException("Not found: Booking: " + bookingId)
+        ).when(bookingService).undelete(bookingId);
+
+        mockMvc.perform(post("/bookings/" + bookingId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                           .value("Not found: Booking: " + bookingId));
     }
 
     private String getPath(UUID bookingId) {

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -379,5 +381,31 @@ public class CaptureSessionControllerTest {
 
         assertThat(response.getResponse().getContentAsString())
             .isEqualTo("{\"message\":\"Path id does not match payload property createCaptureSessionDTO.id\"}");
+    }
+
+    @DisplayName("Should undelete a capture session by id and return a 200 response")
+    @Test
+    void undeleteCaptureSessionSuccess() throws Exception {
+        var captureSessionId = UUID.randomUUID();
+        doNothing().when(captureSessionService).undelete(captureSessionId);
+
+        mockMvc.perform(post("/capture-sessions/" + captureSessionId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("Should undelete a capture session by id and return a 404 response")
+    @Test
+    void undeleteCaptureSessionNotFound() throws Exception {
+        var captureSessionId = UUID.randomUUID();
+        doThrow(
+            new NotFoundException("Capture Session: " + captureSessionId)
+        ).when(captureSessionService).undelete(captureSessionId);
+
+        mockMvc.perform(post("/capture-sessions/" + captureSessionId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                           .value("Not found: Capture Session: " + captureSessionId));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -323,5 +324,31 @@ class CaseControllerTest {
             .andReturn();
 
         verify(caseService, times(1)).searchBy(isNull(), isNull(), eq(true), any());
+    }
+
+    @DisplayName("Should undelete a case by id and return a 200 response")
+    @Test
+    void undeleteCaseSuccess() throws Exception {
+        var caseId = UUID.randomUUID();
+        doNothing().when(caseService).undelete(caseId);
+
+        mockMvc.perform(post("/cases/" + caseId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("Should undelete a case by id and return a 404 response")
+    @Test
+    void undeleteCaseNotFound() throws Exception {
+        var caseId = UUID.randomUUID();
+        doThrow(
+            new NotFoundException("Case: " + caseId)
+        ).when(caseService).undelete(caseId);
+
+        mockMvc.perform(post("/cases/" + caseId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                           .value("Not found: Case: " + caseId));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -502,6 +503,33 @@ class RecordingControllerTest {
 
         verify(recordingService, times(1)).findAll(any(), eq(true), any());
     }
+
+    @DisplayName("Should undelete a recording by id and return a 200 response")
+    @Test
+    void undeleteRecordingSuccess() throws Exception {
+        var recordingId = UUID.randomUUID();
+        doNothing().when(recordingService).undelete(recordingId);
+
+        mockMvc.perform(post("/recordings/" + recordingId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("Should undelete a recording by id and return a 404 response")
+    @Test
+    void undeleteRecordingNotFound() throws Exception {
+        var recordingId = UUID.randomUUID();
+        doThrow(
+            new NotFoundException("Recording: " + recordingId)
+        ).when(recordingService).undelete(recordingId);
+
+        mockMvc.perform(post("/recordings/" + recordingId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                           .value("Not found: Recording: " + recordingId));
+    }
+
 
     private static String getPath(UUID recordingId) {
         return "/recordings/" + recordingId;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -431,5 +432,31 @@ public class UserControllerTest {
 
         verify(userService, times(1))
             .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(true), any());
+    }
+
+    @DisplayName("Should undelete a user by id and return a 200 response")
+    @Test
+    void undeleteRecordingSuccess() throws Exception {
+        var userId = UUID.randomUUID();
+        doNothing().when(userService).undelete(userId);
+
+        mockMvc.perform(post("/users/" + userId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isOk());
+    }
+
+    @DisplayName("Should undelete a user by id and return a 404 response")
+    @Test
+    void undeleteRecordingNotFound() throws Exception {
+        var userId = UUID.randomUUID();
+        doThrow(
+            new NotFoundException("User: " + userId)
+        ).when(userService).undelete(userId);
+
+        mockMvc.perform(post("/users/" + userId + "/undelete")
+                            .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                           .value("Not found: User: " + userId));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -37,7 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaseServiceTest.java
@@ -376,4 +376,51 @@ class CaseServiceTest {
         verify(bookingService, never()).deleteCascade(caseEntity);
         verify(caseRepository, never()).deleteById(caseId);
     }
+
+    @DisplayName("Should undelete a case successfully when case is marked as deleted")
+    @Test
+    void undeleteSuccess() {
+        var aCase = new Case();
+        aCase.setId(UUID.randomUUID());
+        aCase.setDeletedAt(Timestamp.from(Instant.now()));
+
+        when(caseRepository.findById(aCase.getId())).thenReturn(Optional.of(aCase));
+
+        caseService.undelete(aCase.getId());
+
+        verify(caseRepository, times(1)).findById(aCase.getId());
+        verify(caseRepository, times(1)).save(aCase);
+    }
+
+    @DisplayName("Should do nothing when case is not deleted")
+    @Test
+    void undeleteNotDeletedSuccess() {
+        var aCase = new Case();
+        aCase.setId(UUID.randomUUID());
+
+        when(caseRepository.findById(aCase.getId())).thenReturn(Optional.of(aCase));
+
+        caseService.undelete(aCase.getId());
+
+        verify(caseRepository, times(1)).findById(aCase.getId());
+        verify(caseRepository, never()).save(aCase);
+    }
+
+    @DisplayName("Should throw not found exception when case cannot be found")
+    @Test
+    void undeleteNotFound() {
+        var caseId = UUID.randomUUID();
+
+        when(caseRepository.findById(caseId)).thenReturn(Optional.empty());
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> caseService.undelete(caseId)
+        ).getMessage();
+
+        assertThat(message).isEqualTo("Not found: Case: " + caseId);
+
+        verify(caseRepository, times(1)).findById(caseId);
+        verify(caseRepository, never()).save(any());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -426,4 +426,51 @@ class RecordingServiceTest {
 
         assertThat(params.getScheduledForUntil()).isNull();
     }
+
+    @DisplayName("Should undelete a recording successfully when recording is marked as deleted")
+    @Test
+    void undeleteSuccess() {
+        var recording = new Recording();
+        recording.setId(UUID.randomUUID());
+        recording.setDeletedAt(Timestamp.from(Instant.now()));
+
+        when(recordingRepository.findById(recording.getId())).thenReturn(Optional.of(recording));
+
+        recordingService.undelete(recording.getId());
+
+        verify(recordingRepository, times(1)).findById(recording.getId());
+        verify(recordingRepository, times(1)).save(recording);
+    }
+
+    @DisplayName("Should do nothing when recording is not deleted")
+    @Test
+    void undeleteNotDeletedSuccess() {
+        var recording = new Recording();
+        recording.setId(UUID.randomUUID());
+
+        when(recordingRepository.findById(recording.getId())).thenReturn(Optional.of(recording));
+
+        recordingService.undelete(recording.getId());
+
+        verify(recordingRepository, times(1)).findById(recording.getId());
+        verify(recordingRepository,never()).save(recording);
+    }
+
+    @DisplayName("Should throw not found exception when recording cannot be found")
+    @Test
+    void undeleteNotFound() {
+        var recordingId = UUID.randomUUID();
+
+        when(recordingRepository.findById(recordingId)).thenReturn(Optional.empty());
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> recordingService.undelete(recordingId)
+        ).getMessage();
+
+        assertThat(message).isEqualTo("Not found: Recording: " + recordingId);
+
+        verify(recordingRepository, times(1)).findById(recordingId);
+        verify(recordingRepository, never()).save(any());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;
 import uk.gov.hmcts.reform.preapi.dto.base.BaseUserDTO;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
-import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.Court;
 import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
 import uk.gov.hmcts.reform.preapi.entities.Role;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2477


### Change description ###
- Add endpoint `POST /users/{id}/undelete`
- Add endpoint `POST /cases/{id}/undelete`
- Add endpoint `POST /bookings/{id}/undelete`
- Add endpoint `POST /capture-sessions/{id}/undelete`
- Add endpoint `POST /recordings/{id}/undelete`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
