### PR TITLE
S28 2267: Delete/Undelete Updates AppAccess Active Value

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/base/CreatedModifiedAtEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/base/CreatedModifiedAtEntity.java
@@ -29,5 +29,6 @@ public class CreatedModifiedAtEntity extends BaseEntity {
     public void prePersist() {
         super.prePersist();
         setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        setModifiedAt(new Timestamp(System.currentTimeMillis()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AppAccessRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AppAccessRepository.java
@@ -16,5 +16,7 @@ public interface AppAccessRepository extends SoftDeleteRepository<AppAccess, UUI
 
     List<AppAccess> findAllByUser_EmailIgnoreCaseAndDeletedAtNullAndUser_DeletedAtNull(String email);
 
+    List<AppAccess> findAllByUser_IdAndDeletedAtIsNotNull(UUID id);
+
     Optional<AppAccess> findByIdAndDeletedAtNullAndUser_DeletedAtNull(UUID userId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/PortalAccessRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/PortalAccessRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
 import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,4 +39,6 @@ public interface PortalAccessRepository extends SoftDeleteRepository<PortalAcces
         @Param("organisation") String organisation,
         Pageable pageable
     );
+
+    List<PortalAccess> findAllByUser_IdAndDeletedAtIsNotNull(UUID id);
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.preapi.repositories.RoleRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -213,7 +214,11 @@ public class UserService {
 
         appAccessRepository
             .findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userId)
-            .ifPresent(appAccess -> appAccessRepository.deleteById(appAccess.getId()));
+            .ifPresent(appAccess -> {
+                appAccess.setActive(false);
+                appAccess.setDeletedAt(Timestamp.from(Instant.now()));
+                appAccessRepository.save(appAccess);
+            });
 
         userRepository.deleteById(userId);
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -231,5 +231,20 @@ public class UserService {
         }
         entity.setDeletedAt(null);
         userRepository.save(entity);
+
+        appAccessRepository
+            .findAllByUser_IdAndDeletedAtIsNotNull(id)
+            .forEach(a -> {
+                a.setDeletedAt(null);
+                a.setActive(true);
+                appAccessRepository.save(a);
+            });
+
+        portalAccessRepository
+            .findAllByUser_IdAndDeletedAtIsNotNull(id)
+            .forEach(p -> {
+                p.setDeletedAt(null);
+                portalAccessRepository.save(p);
+            });
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
@@ -484,7 +484,7 @@ public class UserServiceTest {
         verify(portalAccessRepository, times(1)).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
         verify(portalAccessRepository, times(1)).deleteById(portalAccessEntity.getId());
         verify(appAccessRepository, times(1)).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(appAccessRepository, times(1)).deleteById(appAccessEntity.getId());
+        verify(appAccessRepository, times(1)).save(appAccessEntity);
         verify(userRepository, times(1)).deleteById(userEntity.getId());
     }
 
@@ -501,9 +501,9 @@ public class UserServiceTest {
 
         verify(userRepository, times(1)).existsByIdAndDeletedAtIsNull(userEntity.getId());
         verify(portalAccessRepository, times(1)).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(portalAccessRepository, never()).deleteById(portalAccessEntity.getId());
+        verify(portalAccessRepository, never()).save(any());
         verify(appAccessRepository, times(1)).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(appAccessRepository, never()).deleteById(appAccessEntity.getId());
+        verify(appAccessRepository, never()).save(any());
         verify(userRepository, times(1)).deleteById(userEntity.getId());
     }
 
@@ -520,9 +520,9 @@ public class UserServiceTest {
 
         verify(userRepository, times(1)).existsByIdAndDeletedAtIsNull(userId);
         verify(portalAccessRepository, never()).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(portalAccessRepository, never()).deleteById(portalAccessEntity.getId());
+        verify(portalAccessRepository, never()).save(any());
         verify(appAccessRepository, never()).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(appAccessRepository, never()).deleteById(appAccessEntity.getId());
+        verify(appAccessRepository, never()).save(any());
         verify(userRepository, never()).deleteById(userEntity.getId());
     }
 
@@ -880,12 +880,30 @@ public class UserServiceTest {
         user.setId(UUID.randomUUID());
         user.setDeletedAt(Timestamp.from(Instant.now()));
 
+        var appAccess = new AppAccess();
+        appAccess.setId(UUID.randomUUID());
+        appAccess.setUser(user);
+        appAccess.setDeletedAt(Timestamp.from(Instant.now()));
+        appAccess.setActive(false);
+
+        var portalAccess = new PortalAccess();
+        portalAccess.setId(UUID.randomUUID());
+        portalAccess.setUser(user);
+        portalAccess.setDeletedAt(Timestamp.from(Instant.now()));
+
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(appAccessRepository.findAllByUser_IdAndDeletedAtIsNotNull(user.getId())).thenReturn(List.of(appAccess));
+        when(portalAccessRepository.findAllByUser_IdAndDeletedAtIsNotNull(user.getId()))
+            .thenReturn(List.of(portalAccess));
 
         userService.undelete(user.getId());
 
         verify(userRepository, times(1)).findById(user.getId());
         verify(userRepository, times(1)).save(user);
+        verify(appAccessRepository, times(1)).findAllByUser_IdAndDeletedAtIsNotNull(user.getId());
+        verify(appAccessRepository, times(1)).save(appAccess);
+        verify(portalAccessRepository, times(1)).findAllByUser_IdAndDeletedAtIsNotNull(user.getId());
+        verify(portalAccessRepository, times(1)).save(portalAccess);
     }
 
     @DisplayName("Should do nothing when user is not deleted")
@@ -899,7 +917,9 @@ public class UserServiceTest {
         userService.undelete(user.getId());
 
         verify(userRepository, times(1)).findById(user.getId());
-        verify(userRepository,never()).save(user);
+        verify(userRepository, never()).save(user);
+        verify(appAccessRepository, never()).save(any());
+        verify(portalAccessRepository, never()).save(any());
     }
 
     @DisplayName("Should throw not found exception when user cannot be found")
@@ -918,5 +938,7 @@ public class UserServiceTest {
 
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, never()).save(any());
+        verify(appAccessRepository, never()).save(any());
+        verify(portalAccessRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2267


### Change description ###
- On create any entity with `modifed_at` field will automatically set the value for `modifed_at` 
- On delete a user, attached app access entities will have `active` set to `false` (as well as `deleted_at` timestamp set)
- On undelete a user, attached app access entities will be undeleted (and `active` set to `true`)
- On undelete a user, attached portal access entities will be undeleted


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
