### PR TITLE
S28 2266: PUT `/users/{id}` Add Portal Access Field

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "40"
+  revision              = "41"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -621,6 +621,38 @@ definitions:
           - DEFENDANT
         type: string
     type: object
+  CreatePortalAccessDTO:
+    description: CreatePortalAccessDTO
+    properties:
+      id:
+        description: PortalAccessId
+        format: uuid
+        type: string
+      invited_at:
+        description: PortalAccessInvitedAt
+        format: date-time
+        type: string
+      last_access:
+        description: PortalAccessLastAccess
+        format: date-time
+        type: string
+      registered_at:
+        description: PortalAccessRegisteredAt
+        format: date-time
+        type: string
+      status:
+        description: PortalAccessStatus
+        enum:
+          - INVITATION_SENT
+          - REGISTERED
+          - ACTIVE
+          - INACTIVE
+        type: string
+    required:
+      - id
+      - invited_at
+      - status
+    type: object
   CreateRecordingDTO:
     description: CreateRecordingDTO
     properties:
@@ -703,12 +735,19 @@ definitions:
       phone_number:
         description: UserPhoneNumber
         type: string
+      portal_access:
+        description: UserPortalAccess
+        items:
+          $ref: '#/definitions/CreatePortalAccessDTO'
+        type: array
+        uniqueItems: true
     required:
       - app_access
       - email
       - first_name
       - id
       - last_name
+      - portal_access
     type: object
   EditReportDTO:
     description: EditReportDTO

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/entities/PortalAccessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/entities/PortalAccessTest.java
@@ -27,7 +27,6 @@ class PortalAccessTest {
 
         PortalAccess testPortalAccess = new PortalAccess();
         testPortalAccess.setUser(user);
-        testPortalAccess.setPassword("TestPassword");
         testPortalAccess.setLastAccess(new Timestamp(System.currentTimeMillis()));
         testPortalAccess.setStatus(AccessStatus.REGISTERED);
         testPortalAccess.setInvitedAt(new Timestamp(System.currentTimeMillis()));
@@ -41,7 +40,6 @@ class PortalAccessTest {
 
         assertEquals(testPortalAccess.getId(), retrievedPortalAccess.getId(), "Id should match");
         assertEquals(testPortalAccess.getUser(), retrievedPortalAccess.getUser(), "User should match");
-        assertEquals(testPortalAccess.getPassword(), retrievedPortalAccess.getPassword(), "Password should match");
         assertEquals(testPortalAccess.getStatus(), retrievedPortalAccess.getStatus(), "Status should match");
         assertEquals(
             testPortalAccess.getLastAccess(),

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserServiceIT.java
@@ -107,13 +107,11 @@ public class UserServiceIT {
         portalAccessEntity = new PortalAccess();
         portalAccessEntity.setId(UUID.randomUUID());
         portalAccessEntity.setUser(userEntity);
-        portalAccessEntity.setPassword("mahpassword");
         entityManager.persist(portalAccessEntity);
 
         portalAccessEntity2 = new PortalAccess();
         portalAccessEntity2.setId(UUID.randomUUID());
         portalAccessEntity2.setUser(portalUserEntity);
-        portalAccessEntity2.setPassword("mahpassword");
         entityManager.persist(portalAccessEntity2);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreatePortalAccessDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreatePortalAccessDTO.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.preapi.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@Schema(description = "CreatePortalAccessDTO")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CreatePortalAccessDTO {
+    @Schema(description = "PortalAccessId")
+    @NotNull
+    private UUID id;
+
+    @Schema(description = "PortalAccessLastAccess")
+    private Timestamp lastAccess;
+
+    @Schema(description = "PortalAccessStatus")
+    @NotNull
+    private AccessStatus status;
+
+    @Schema(description = "PortalAccessInvitedAt")
+    @NotNull
+    private Timestamp invitedAt;
+
+    @Schema(description = "PortalAccessRegisteredAt")
+    private Timestamp registeredAt;
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateUserDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateUserDTO.java
@@ -23,5 +23,10 @@ public class CreateUserDTO extends BaseUserDTO {
     @NotNull
     @Valid
     private Set<CreateAppAccessDTO> appAccess;
+
+    @Schema(description = "UserPortalAccess")
+    @NotNull
+    @Valid
+    private Set<CreatePortalAccessDTO> portalAccess;
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
@@ -28,9 +28,6 @@ public class PortalAccess extends CreatedModifiedAtEntity {
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
-    @Column(name = "password", nullable = false, length = 45)
-    private String password;
-
     @Column(name = "last_access")
     private Timestamp lastAccess;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/PortalAccessRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/PortalAccessRepository.java
@@ -22,6 +22,8 @@ public interface PortalAccessRepository extends SoftDeleteRepository<PortalAcces
 
     Optional<PortalAccess> findByUser_EmailAndCodeAndDeletedAtNullAndUser_DeletedAtNull(String email, String code);
 
+    Optional<PortalAccess> findByIdAndDeletedAtIsNull(UUID id);
+
     @Query(
         """
         SELECT pa FROM PortalAccess pa

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/PortalAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/PortalAccessService.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.preapi.services;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
+import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
+import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.repositories.PortalAccessRepository;
+
+@Service
+public class PortalAccessService {
+
+    private final PortalAccessRepository portalAccessRepository;
+
+    @Autowired
+    public PortalAccessService(PortalAccessRepository portalAccessRepository) {
+        this.portalAccessRepository = portalAccessRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
+    public UpsertResult update(CreatePortalAccessDTO createDto) {
+        var entity = portalAccessRepository
+            .findByIdAndDeletedAtIsNull(createDto.getId())
+            .orElseThrow(() -> new NotFoundException("PortalAccess: " + createDto.getId()));
+
+        entity.setLastAccess(createDto.getLastAccess());
+        entity.setStatus(createDto.getStatus());
+        entity.setInvitedAt(createDto.getInvitedAt());
+        entity.setRegisteredAt(createDto.getRegisteredAt());
+        portalAccessRepository.save(entity);
+
+        return UpsertResult.UPDATED;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.AppAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateAppAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateInviteDTO;
+import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;
 import uk.gov.hmcts.reform.preapi.dto.UserDTO;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
@@ -39,8 +40,8 @@ public class UserService {
     private final RoleRepository roleRepository;
     private final UserRepository userRepository;
     private final PortalAccessRepository portalAccessRepository;
-
     private final AppAccessService appAccessService;
+    private final PortalAccessService portalAccessService;
 
     @Autowired
     public UserService(AppAccessRepository appAccessRepository,
@@ -48,16 +49,18 @@ public class UserService {
                        RoleRepository roleRepository,
                        UserRepository userRepository,
                        PortalAccessRepository portalAccessRepository,
-                       AppAccessService appAccessService) {
+                       AppAccessService appAccessService,
+                       PortalAccessService portalAccessService) {
         this.appAccessRepository = appAccessRepository;
         this.courtRepository = courtRepository;
         this.roleRepository = roleRepository;
         this.userRepository = userRepository;
         this.portalAccessRepository = portalAccessRepository;
         this.appAccessService = appAccessService;
+        this.portalAccessService = portalAccessService;
     }
 
-    @Transactional
+    @Transactional()
     public UserDTO findById(UUID userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
             .map(UserDTO::new)
@@ -117,9 +120,17 @@ public class UserService {
     @SuppressWarnings("PMD.CyclomaticComplexity")
     public UpsertResult upsert(CreateUserDTO createUserDTO) {
         var user = userRepository.findById(createUserDTO.getId());
-        if (user.isPresent() && user.get().isDeleted()) {
+
+        var isUpdate = user.isPresent();
+        if (isUpdate && user.get().isDeleted()) {
             throw new ResourceInDeletedStateException("UserDTO", createUserDTO.getId().toString());
         }
+
+        createUserDTO.getPortalAccess().stream().map(CreatePortalAccessDTO::getId).forEach(id -> {
+            if (!portalAccessRepository.existsById(id)) {
+                throw new NotFoundException("Portal Access: " + id);
+            }
+        });
 
         var entity = user.orElse(new User());
         entity.setId(createUserDTO.getId());
@@ -130,7 +141,6 @@ public class UserService {
         entity.setOrganisation(createUserDTO.getOrganisation());
         userRepository.saveAndFlush(entity);
 
-        var isUpdate = user.isPresent();
         if (isUpdate) {
             entity
                 .getAppAccess()
@@ -139,6 +149,16 @@ public class UserService {
                 .filter(id -> createUserDTO.getAppAccess().stream().map(CreateAppAccessDTO::getId)
                     .noneMatch(newAccessId -> newAccessId == id))
                 .forEach(appAccessRepository::deleteById);
+
+            entity
+                .getPortalAccess()
+                .stream()
+                .map(PortalAccess::getId)
+                .filter(id -> createUserDTO.getPortalAccess().stream().map(CreatePortalAccessDTO::getId)
+                    .noneMatch(newAccessId -> newAccessId == id))
+                .forEach(portalAccessRepository::deleteById);
+
+            createUserDTO.getPortalAccess().forEach(portalAccessService::update);
         }
 
         createUserDTO.getAppAccess().forEach(appAccessService::upsert);

--- a/src/main/resources/db/migration/V017__RemovePortalAccessPasswordField.sql
+++ b/src/main/resources/db/migration/V017__RemovePortalAccessPasswordField.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.portal_access DROP COLUMN password CASCADE;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
@@ -15,14 +15,18 @@ import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.preapi.controllers.UserController;
 import uk.gov.hmcts.reform.preapi.dto.AppAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateAppAccessDTO;
+import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;
 import uk.gov.hmcts.reform.preapi.dto.UserDTO;
+import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
 import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.UserService;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -193,6 +197,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         when(userService.upsert(user)).thenReturn(UpsertResult.CREATED);
 
@@ -220,6 +225,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         when(userService.upsert(user)).thenReturn(UpsertResult.UPDATED);
 
@@ -247,6 +253,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + UUID.randomUUID())
                                                  .with(csrf())
@@ -270,6 +277,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         doThrow(new ResourceInDeletedStateException("UserDTO", user.getId().toString()))
             .when(userService).upsert((CreateUserDTO) any());
@@ -297,6 +305,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -321,6 +330,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -346,6 +356,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -370,6 +381,7 @@ public class UserControllerTest {
         user.setFirstName("Example");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -395,6 +407,7 @@ public class UserControllerTest {
         user.setLastName("");
         user.setEmail("example@example.com");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -419,6 +432,7 @@ public class UserControllerTest {
         user.setFirstName("Example");
         user.setLastName("Person");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -444,6 +458,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -468,6 +483,7 @@ public class UserControllerTest {
         user.setFirstName("Example");
         user.setLastName("Person");
         user.setEmail("example@example.com");
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -497,6 +513,7 @@ public class UserControllerTest {
         appAccess.setCourtId(UUID.randomUUID());
         appAccess.setRoleId(UUID.randomUUID());
         user.setAppAccess(Set.of(appAccess));
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -526,6 +543,7 @@ public class UserControllerTest {
         appAccess.setCourtId(UUID.randomUUID());
         appAccess.setRoleId(UUID.randomUUID());
         user.setAppAccess(Set.of(appAccess));
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -555,6 +573,7 @@ public class UserControllerTest {
         appAccess.setUserId(UUID.randomUUID());
         appAccess.setRoleId(UUID.randomUUID());
         user.setAppAccess(Set.of(appAccess));
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -584,6 +603,7 @@ public class UserControllerTest {
         appAccess.setUserId(UUID.randomUUID());
         appAccess.setCourtId(UUID.randomUUID());
         user.setAppAccess(Set.of(appAccess));
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -609,6 +629,7 @@ public class UserControllerTest {
         user.setLastName("Person");
         user.setEmail("example not email");
         user.setAppAccess(Set.of());
+        user.setPortalAccess(Set.of());
 
         MvcResult response = mockMvc.perform(put("/users/" + userId)
                                                  .with(csrf())
@@ -621,6 +642,118 @@ public class UserControllerTest {
         assertThat(response.getResponse().getContentAsString())
             .isEqualTo(
                 "{\"email\":\"must be a well-formed email address\"}"
+            );
+    }
+
+    @DisplayName("Should fail to create/update a user with 400 when user portal access is null")
+    @Test
+    void upsertUserPortalAccessNull() throws Exception {
+        var userId = UUID.randomUUID();
+        var user = new CreateUserDTO();
+        user.setId(userId);
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        user.setEmail("example@example.com");
+        user.setAppAccess(Set.of());
+
+        MvcResult response = mockMvc.perform(put("/users/" + userId)
+                                                 .with(csrf())
+                                                 .content(OBJECT_MAPPER.writeValueAsString(user))
+                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo(
+                "{\"portalAccess\":\"must not be null\"}"
+            );
+    }
+
+    @DisplayName("Should fail to create/update a user with 400 when user portal access id is null")
+    @Test
+    void upsertUserPortalAccessIdNull() throws Exception {
+        var userId = UUID.randomUUID();
+        var user = new CreateUserDTO();
+        user.setId(userId);
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        user.setEmail("example@example.com");
+        user.setAppAccess(Set.of());
+        var access = new CreatePortalAccessDTO();
+        access.setStatus(AccessStatus.INACTIVE);
+        access.setInvitedAt(Timestamp.from(Instant.now()));
+        user.setPortalAccess(Set.of(access));
+
+        MvcResult response = mockMvc.perform(put("/users/" + userId)
+                                                 .with(csrf())
+                                                 .content(OBJECT_MAPPER.writeValueAsString(user))
+                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo(
+                "{\"portalAccess[].id\":\"must not be null\"}"
+            );
+    }
+
+    @DisplayName("Should fail to create/update a user with 400 when user portal access status is null")
+    @Test
+    void upsertUserPortalAccessStatusNull() throws Exception {
+        var userId = UUID.randomUUID();
+        var user = new CreateUserDTO();
+        user.setId(userId);
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        user.setEmail("example@example.com");
+        user.setAppAccess(Set.of());
+        var access = new CreatePortalAccessDTO();
+        access.setId(UUID.randomUUID());
+        access.setInvitedAt(Timestamp.from(Instant.now()));
+        user.setPortalAccess(Set.of(access));
+
+        MvcResult response = mockMvc.perform(put("/users/" + userId)
+                                                 .with(csrf())
+                                                 .content(OBJECT_MAPPER.writeValueAsString(user))
+                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo(
+                "{\"portalAccess[].status\":\"must not be null\"}"
+            );
+    }
+
+    @DisplayName("Should fail to create/update a user with 400 when user portal access invited at is null")
+    @Test
+    void upsertUserPortalAccessInvitedAtNull() throws Exception {
+        var userId = UUID.randomUUID();
+        var user = new CreateUserDTO();
+        user.setId(userId);
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        user.setEmail("example@example.com");
+        user.setAppAccess(Set.of());
+        var access = new CreatePortalAccessDTO();
+        access.setId(UUID.randomUUID());
+        access.setStatus(AccessStatus.INACTIVE);
+        user.setPortalAccess(Set.of(access));
+
+        MvcResult response = mockMvc.perform(put("/users/" + userId)
+                                                 .with(csrf())
+                                                 .content(OBJECT_MAPPER.writeValueAsString(user))
+                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo(
+                "{\"portalAccess[].invitedAt\":\"must not be null\"}"
             );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import javax.swing.text.html.Option;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.reform.preapi.services;
+
+import javax.swing.text.html.Option;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
+import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
+import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
+import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
+import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
+import uk.gov.hmcts.reform.preapi.repositories.PortalAccessRepository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = PortalAccessService.class)
+public class PortalAccessServiceTest {
+    @MockBean
+    private PortalAccessRepository portalAccessRepository;
+
+    @Autowired
+    private PortalAccessService portalAccessService;
+
+    @DisplayName("Update a portal access entity")
+    @Test
+    public void updateSuccess() {
+        var model = new CreatePortalAccessDTO();
+        model.setId(UUID.randomUUID());
+        model.setStatus(AccessStatus.ACTIVE);
+        model.setLastAccess(Timestamp.from(Instant.now()));
+        model.setInvitedAt(Timestamp.from(Instant.now()));
+
+        var entity = new PortalAccess();
+        entity.setId(model.getId());
+
+        when(portalAccessRepository.findByIdAndDeletedAtIsNull(model.getId()))
+            .thenReturn(Optional.of(entity));
+
+        assertThat(portalAccessService.update(model)).isEqualTo(UpsertResult.UPDATED);
+
+        verify(portalAccessRepository, times(1)).findByIdAndDeletedAtIsNull(model.getId());
+        verify(portalAccessRepository, times(1)).save(any());
+    }
+
+    @DisplayName("Update a portal access entity when portal access does not exist")
+    @Test
+    public void updateNotFound() {
+        var model = new CreatePortalAccessDTO();
+        model.setId(UUID.randomUUID());
+        model.setStatus(AccessStatus.ACTIVE);
+        model.setLastAccess(Timestamp.from(Instant.now()));
+        model.setInvitedAt(Timestamp.from(Instant.now()));
+
+        when(portalAccessRepository.findByIdAndDeletedAtIsNull(model.getId()))
+            .thenReturn(Optional.empty());
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> portalAccessService.update(model)
+        ).getMessage();
+        assertThat(message).isEqualTo("Not found: PortalAccess: " + model.getId());
+
+        verify(portalAccessRepository, times(1)).findByIdAndDeletedAtIsNull(model.getId());
+        verify(portalAccessRepository, never()).save(any());
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2266


### Change description ###
- Add `portalAccess` field to CreateUserDTO
- Only allow updating existing portal access entities (must invite to create a new portal access


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
