### PR TITLE
S28 2324: Fix 500 error when capture session started by is null (`/schedules`)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/ScheduleReportDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/ScheduleReportDTO.java
@@ -43,7 +43,9 @@ public class ScheduleReportDTO {
         scheduledFor = bookingEntity.getScheduledFor();
         bookingCreatedAt = bookingEntity.getCreatedAt();
         caseReference = caseEntity.getReference();
-        captureSessionUser = captureSession.getStartedByUser().getEmail();
+        if (captureSession.getStartedByUser() != null) {
+            captureSessionUser = captureSession.getStartedByUser().getEmail();
+        }
         court = caseEntity.getCourt().getName();
         regions = Stream.ofNullable(caseEntity.getCourt().getRegions())
             .flatMap(regions -> regions.stream().map(RegionDTO::new))


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2324


### Change description ###
- Fix 500 error capture session started by user is null when calling `/schedules`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
