### PR TITLE
S28 2563: Remove Hard-coded Court Filter (for API use in Admin Section)

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "41"
+  revision              = "42"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "43"
+  revision              = "44"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1972,6 +1972,12 @@ paths:
           name: scheduledFor
           type: string
           x-example: '2024-04-27'
+        - description: The court id of the capture session to search by
+          format: uuid
+          in: query
+          name: courtId
+          type: string
+          x-example: 123e4567-e89b-12d3-a456-426614174000
         - description: The page number of search result to return
           format: int32
           in: query

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
@@ -84,6 +84,12 @@ public class CaptureSessionController extends PreApiController {
         example = "2024-04-27"
     )
     @Parameter(
+        name = "courtId",
+        description = "The court id of the capture session to search by",
+        schema = @Schema(implementation = UUID.class),
+        example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    @Parameter(
         name = "page",
         description = "The page number of search result to return",
         schema = @Schema(implementation = Integer.class),
@@ -109,6 +115,7 @@ public class CaptureSessionController extends PreApiController {
             params.getScheduledFor() != null
                 ? Optional.of(Timestamp.from(params.getScheduledFor().toInstant()))
                 : Optional.empty(),
+            params.getCourtId(),
             pageable
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCaptureSessions.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCaptureSessions.java
@@ -16,4 +16,5 @@ public class SearchCaptureSessions {
     private RecordingStatus recordingStatus;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date scheduledFor;
+    private UUID courtId;
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CaptureSessionRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CaptureSessionRepository.java
@@ -51,7 +51,7 @@ public interface CaptureSessionRepository extends SoftDeleteRepository<CaptureSe
         AND (CAST(:bookingId as uuid) IS NULL OR c.booking.id = :bookingId)
         AND (CAST(:origin as text) IS NULL OR c.origin = :origin)
         AND (CAST(:recordingStatus as text) IS NULL OR c.status = :recordingStatus)
-
+        AND (CAST(:courtId as uuid) IS NULL OR c.booking.caseId.court.id = :courtId)
         AND (
             CAST(:scheduledForFrom as Timestamp) IS NULL OR
             CAST(:scheduledForUntil as Timestamp) IS NULL OR
@@ -64,6 +64,7 @@ public interface CaptureSessionRepository extends SoftDeleteRepository<CaptureSe
         @Param("bookingId") UUID bookingId,
         @Param("origin") RecordingOrigin origin,
         @Param("recordingStatus") RecordingStatus recordingStatus,
+        @Param("courtId") UUID courtId,
         @Param("scheduledForFrom") Timestamp scheduledForFrom,
         @Param("scheduledForUntil") Timestamp scheduledForUntil,
         @Param("authorisedBookings") List<UUID> authorisedBookings,

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
@@ -82,7 +82,7 @@ public class BookingService {
 
         var auth = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication());
         var authorisedBookings = auth.isAdmin() || auth.isAppUser() ? null : auth.getSharedBookings();
-        var authorisedCourt = auth.isPortalUser() ? null : auth.getCourtId();
+        var authorisedCourt = auth.isPortalUser() || auth.isAdmin() ? null : auth.getCourtId();
 
         return bookingRepository
             .searchBookingsBy(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -62,6 +62,7 @@ public class CaptureSessionService {
         RecordingOrigin origin,
         RecordingStatus recordingStatus,
         Optional<Timestamp> scheduledFor,
+        UUID courtId,
         Pageable pageable
     ) {
         var until = scheduledFor.isEmpty()
@@ -70,7 +71,7 @@ public class CaptureSessionService {
 
         var auth = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication());
         var authorisedBookings = auth.isAdmin() || auth.isAppUser() ? null : auth.getSharedBookings();
-        var authorisedCourt = auth.isPortalUser() ? null : auth.getCourtId();
+        var authorisedCourt = auth.isPortalUser() || auth.isAdmin() ? null : auth.getCourtId();
 
         return captureSessionRepository
             .searchCaptureSessionsBy(
@@ -78,6 +79,7 @@ public class CaptureSessionService {
                 bookingId,
                 origin,
                 recordingStatus,
+                courtId,
                 scheduledFor.orElse(null),
                 until,
                 authorisedBookings,

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
@@ -63,7 +63,7 @@ public class CaseService {
     @PreAuthorize("!#includeDeleted or @authorisationService.canViewDeleted(authentication)")
     public Page<CaseDTO> searchBy(String reference, UUID courtId, boolean includeDeleted, Pageable pageable) {
         var auth = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication());
-        var authorisedCourt = auth.isPortalUser() ? null : auth.getCourtId();
+        var authorisedCourt = auth.isPortalUser() || auth.isAdmin() ? null : auth.getCourtId();
 
         return caseRepository
             .searchCasesBy(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -75,7 +75,7 @@ public class RecordingService {
             auth.isAdmin() || auth.isAppUser() ? null : auth.getSharedBookings()
         );
         params.setAuthorisedCourt(
-            auth.isPortalUser() ? null : auth.getCourtId()
+            auth.isPortalUser() || auth.isAdmin() ? null : auth.getCourtId()
         );
 
         return recordingRepository

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -94,7 +94,7 @@ public class CaptureSessionControllerTest {
         var mock = new CaptureSessionDTO();
         mock.setId(UUID.randomUUID());
 
-        when(captureSessionService.searchBy(any(), any(), any(), any(), any(), any()))
+        when(captureSessionService.searchBy(any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(List.of(mock)));
 
         mockMvc.perform(get("/capture-sessions"))
@@ -103,7 +103,7 @@ public class CaptureSessionControllerTest {
             .andExpect(jsonPath("$._embedded.captureSessionDTOList[0].id").value(mock.getId().toString()));
 
         verify(captureSessionService, times(1))
-            .searchBy(isNull(), isNull(), isNull(), isNull(), eq(Optional.empty()), any());
+            .searchBy(isNull(), isNull(), isNull(), isNull(), eq(Optional.empty()), any(), any());
     }
 
     @DisplayName("Should get a list of capture sessions with 200 response code filtered by case reference")
@@ -113,7 +113,7 @@ public class CaptureSessionControllerTest {
         mock.setId(UUID.randomUUID());
         var searchParam = "TEST";
 
-        when(captureSessionService.searchBy(eq(searchParam), any(), any(), any(), any(), any()))
+        when(captureSessionService.searchBy(eq(searchParam), any(), any(), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(List.of(mock)));
 
         mockMvc.perform(get("/capture-sessions")
@@ -123,7 +123,7 @@ public class CaptureSessionControllerTest {
             .andExpect(jsonPath("$._embedded.captureSessionDTOList[0].id").value(mock.getId().toString()));
 
         verify(captureSessionService, times(1))
-            .searchBy(eq(searchParam), isNull(), isNull(), isNull(), eq(Optional.empty()), any());
+            .searchBy(eq(searchParam), isNull(), isNull(), isNull(), eq(Optional.empty()), any(), any());
     }
 
     @DisplayName("Should get a list of capture sessions with 200 response code filtered by booking id")
@@ -133,7 +133,7 @@ public class CaptureSessionControllerTest {
         mock.setId(UUID.randomUUID());
         var searchParam = UUID.randomUUID();
 
-        when(captureSessionService.searchBy(any(), eq(searchParam), any(), any(), any(), any()))
+        when(captureSessionService.searchBy(any(), eq(searchParam), any(), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(List.of(mock)));
 
         mockMvc.perform(get("/capture-sessions")
@@ -143,7 +143,7 @@ public class CaptureSessionControllerTest {
             .andExpect(jsonPath("$._embedded.captureSessionDTOList[0].id").value(mock.getId().toString()));
 
         verify(captureSessionService, times(1))
-            .searchBy(isNull(), eq(searchParam), isNull(), isNull(), eq(Optional.empty()), any());
+            .searchBy(isNull(), eq(searchParam), isNull(), isNull(), eq(Optional.empty()), any(), any());
     }
 
     @DisplayName("Should get a list of capture sessions with 200 response code filtered by origin")
@@ -153,7 +153,7 @@ public class CaptureSessionControllerTest {
         mock.setId(UUID.randomUUID());
         var searchParam = RecordingOrigin.PRE;
 
-        when(captureSessionService.searchBy(any(), any(), eq(searchParam), any(), any(), any()))
+        when(captureSessionService.searchBy(any(), any(), eq(searchParam), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(List.of(mock)));
 
         mockMvc.perform(get("/capture-sessions")
@@ -163,7 +163,7 @@ public class CaptureSessionControllerTest {
             .andExpect(jsonPath("$._embedded.captureSessionDTOList[0].id").value(mock.getId().toString()));
 
         verify(captureSessionService, times(1))
-            .searchBy(isNull(), isNull(), eq(searchParam), isNull(), eq(Optional.empty()), any());
+            .searchBy(isNull(), isNull(), eq(searchParam), isNull(), eq(Optional.empty()), any(), any());
     }
 
     @DisplayName("Should get a list of capture sessions with 200 response code filtered by recording status")
@@ -173,7 +173,7 @@ public class CaptureSessionControllerTest {
         mock.setId(UUID.randomUUID());
         var searchParam = RecordingStatus.RECORDING_AVAILABLE;
 
-        when(captureSessionService.searchBy(any(), any(), any(), eq(searchParam), any(), any()))
+        when(captureSessionService.searchBy(any(), any(), any(), eq(searchParam), any(), any(), any()))
             .thenReturn(new PageImpl<>(List.of(mock)));
 
         mockMvc.perform(get("/capture-sessions")
@@ -183,7 +183,7 @@ public class CaptureSessionControllerTest {
             .andExpect(jsonPath("$._embedded.captureSessionDTOList[0].id").value(mock.getId().toString()));
 
         verify(captureSessionService, times(1))
-            .searchBy(isNull(), isNull(), isNull(), eq(searchParam), eq(Optional.empty()), any());
+            .searchBy(isNull(), isNull(), isNull(), eq(searchParam), eq(Optional.empty()), any(), any());
     }
 
     @DisplayName("Should get a list of capture sessions with 200 response code filtered by scheduled for")
@@ -193,7 +193,7 @@ public class CaptureSessionControllerTest {
         mock.setId(UUID.randomUUID());
         var searchParam = "2023-01-01";
 
-        when(captureSessionService.searchBy(any(), any(), any(), any(), any(), any()))
+        when(captureSessionService.searchBy(any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(List.of(mock)));
 
         mockMvc.perform(get("/capture-sessions")
@@ -209,6 +209,7 @@ public class CaptureSessionControllerTest {
                 isNull(),
                 isNull(),
                 eq(Optional.of(Timestamp.valueOf("2023-01-01 00:00:00"))),
+                isNull(),
                 any()
             );
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -324,6 +324,7 @@ class BookingServiceTest {
         caseEntity.setId(caseId);
         bookingModel.setId(UUID.randomUUID());
         bookingModel.setCaseId(caseId);
+        bookingModel.setCaseId(caseId);
         bookingModel.setParticipants(Set.of());
         var participantModel = new CreateParticipantDTO();
         participantModel.setId(UUID.randomUUID());

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -150,7 +150,8 @@ public class CaptureSessionServiceTest {
 
         SecurityContextHolder.getContext().setAuthentication(mockAuth);
 
-        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.empty(), null,null).getContent();
+        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.empty(), null,null)
+            .getContent();
         assertThat(modelList.size()).isEqualTo(1);
         assertThat(modelList.getFirst().getId()).isEqualTo(captureSession.getId());
     }
@@ -180,7 +181,8 @@ public class CaptureSessionServiceTest {
                      isNull())
         ).thenReturn(new PageImpl<>(List.of(captureSession)));
 
-        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.of(from), null, null).getContent();
+        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.of(from), null, null)
+            .getContent();
         assertThat(modelList.size()).isEqualTo(1);
         assertThat(modelList.getFirst().getId()).isEqualTo(captureSession.getId());
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -156,6 +156,41 @@ public class CaptureSessionServiceTest {
         assertThat(modelList.getFirst().getId()).isEqualTo(captureSession.getId());
     }
 
+    @DisplayName("Find a list of capture sessions and return a list of models when user is non admin")
+    @Test
+    void searchCaptureSessionsSuccessNonAdmin() {
+        var courtId = UUID.randomUUID();
+        when(captureSessionRepository.searchCaptureSessionsBy(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        ).thenReturn(new PageImpl<>(List.of(captureSession)));
+        var mockAuth = mock(UserAuthentication.class);
+        when(mockAuth.isAdmin()).thenReturn(false);
+        when(mockAuth.isAppUser()).thenReturn(true);
+        when(mockAuth.isPortalUser()).thenReturn(false);
+        when(mockAuth.getCourtId()).thenReturn(courtId);
+
+        SecurityContextHolder.getContext().setAuthentication(mockAuth);
+
+        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.empty(), null,null)
+            .getContent();
+        assertThat(modelList.size()).isEqualTo(1);
+        assertThat(modelList.getFirst().getId()).isEqualTo(captureSession.getId());
+
+        verify(captureSessionRepository, times(1))
+            .searchCaptureSessionsBy(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                courtId,
+                null
+            );
+    }
+
     @DisplayName("Find a list of capture sessions filtered by scheduledFor and return a list of models")
     @Test
     void searchCaptureSessionsScheduledForSuccess() {

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -142,7 +142,7 @@ public class CaptureSessionServiceTest {
     @Test
     void searchCaptureSessionsSuccess() {
         when(captureSessionRepository.searchCaptureSessionsBy(
-            any(), any(), any(), any(), any(), any(), any(), any(), any())
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         ).thenReturn(new PageImpl<>(List.of(captureSession)));
         var mockAuth = mock(UserAuthentication.class);
         when(mockAuth.isAdmin()).thenReturn(true);
@@ -150,7 +150,7 @@ public class CaptureSessionServiceTest {
 
         SecurityContextHolder.getContext().setAuthentication(mockAuth);
 
-        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.empty(), null).getContent();
+        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.empty(), null,null).getContent();
         assertThat(modelList.size()).isEqualTo(1);
         assertThat(modelList.getFirst().getId()).isEqualTo(captureSession.getId());
     }
@@ -172,6 +172,7 @@ public class CaptureSessionServiceTest {
                      isNull(),
                      isNull(),
                      isNull(),
+                     isNull(),
                      eq(from),
                      eq(until),
                      isNull(),
@@ -179,7 +180,7 @@ public class CaptureSessionServiceTest {
                      isNull())
         ).thenReturn(new PageImpl<>(List.of(captureSession)));
 
-        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.of(from), null).getContent();
+        var modelList = captureSessionService.searchBy(null, null, null, null, Optional.of(from), null, null).getContent();
         assertThat(modelList.size()).isEqualTo(1);
         assertThat(modelList.getFirst().getId()).isEqualTo(captureSession.getId());
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaseServiceTest.java
@@ -131,6 +131,27 @@ class CaseServiceTest {
         assertThat(models.get().toList().getFirst().getCourt().getId()).isEqualTo(caseEntity.getCourt().getId());
     }
 
+    @DisplayName("Find all cases and return a list of models as non admin")
+    @Test
+    void findAllSuccessNonAdmin() {
+        var courtId = UUID.randomUUID();
+        when(caseRepository.searchCasesBy(null, null, false, courtId,null)).thenReturn(new PageImpl<>(allCaseEntities));
+
+        var mockAuth = mock(UserAuthentication.class);
+        when(mockAuth.isPortalUser()).thenReturn(false);
+        when(mockAuth.isAdmin()).thenReturn(false);
+        when(mockAuth.getCourtId()).thenReturn(courtId);
+        SecurityContextHolder.getContext().setAuthentication(mockAuth);
+
+
+        var models = caseService.searchBy(null, null, false, null);
+        assertThat(models.getTotalElements()).isEqualTo(1);
+        assertThat(models.get().toList().getFirst().getId()).isEqualTo(caseEntity.getId());
+        assertThat(models.get().toList().getFirst().getCourt().getId()).isEqualTo(caseEntity.getCourt().getId());
+
+        verify(caseRepository, times(1)).searchCasesBy(null, null, false, courtId, null);
+    }
+
     @DisplayName("Find all cases and return list of models where reference is in list")
     @Test
     void findAllReferenceParamSuccess() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2563


### Change description ###
- Add search param `courtId` to `GET /capture-sessions` 
- Remove hard-coded court filter by court for admins on search endpoints of
    - Cases
    - Bookings
    - Capture sessions 
    - Recordings


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
