### PR TITLE
Fix: Allow invited_at to be nullable

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "42"
+  revision              = "43"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -650,7 +650,6 @@ definitions:
         type: string
     required:
       - id
-      - invited_at
       - status
     type: object
   CreateRecordingDTO:

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreatePortalAccessDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreatePortalAccessDTO.java
@@ -28,7 +28,6 @@ public class CreatePortalAccessDTO {
     private AccessStatus status;
 
     @Schema(description = "PortalAccessInvitedAt")
-    @NotNull
     private Timestamp invitedAt;
 
     @Schema(description = "PortalAccessRegisteredAt")

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
@@ -36,7 +36,7 @@ public class PortalAccess extends CreatedModifiedAtEntity {
     @Column(name = "status", nullable = false)
     private AccessStatus status = AccessStatus.INVITATION_SENT;
 
-    @Column(name = "invite_code", nullable = false, length = 45)
+    @Column(name = "invite_code", length = 45)
     private String code;
 
     @Column(name = "invited_at")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
@@ -726,35 +726,6 @@ public class UserControllerTest {
             );
     }
 
-    @DisplayName("Should fail to create/update a user with 400 when user portal access invited at is null")
-    @Test
-    void upsertUserPortalAccessInvitedAtNull() throws Exception {
-        var userId = UUID.randomUUID();
-        var user = new CreateUserDTO();
-        user.setId(userId);
-        user.setFirstName("Example");
-        user.setLastName("Person");
-        user.setEmail("example@example.com");
-        user.setAppAccess(Set.of());
-        var access = new CreatePortalAccessDTO();
-        access.setId(UUID.randomUUID());
-        access.setStatus(AccessStatus.INACTIVE);
-        user.setPortalAccess(Set.of(access));
-
-        MvcResult response = mockMvc.perform(put("/users/" + userId)
-                                                 .with(csrf())
-                                                 .content(OBJECT_MAPPER.writeValueAsString(user))
-                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isBadRequest())
-            .andReturn();
-
-        assertThat(response.getResponse().getContentAsString())
-            .isEqualTo(
-                "{\"portalAccess[].invitedAt\":\"must not be null\"}"
-            );
-    }
-
     @DisplayName("Should return 400 when user id is not a uuid")
     @Test
     void testFindByIdBadRequest() throws Exception {
@@ -889,6 +860,7 @@ public class UserControllerTest {
 
         mockMvc.perform(post("/users/" + userId + "/undelete")
                             .with(csrf()))
+            .andExpect(status().isNotFound())
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message")
                            .value("Not found: User: " + userId));


### PR DESCRIPTION
### Change description ###
- Allow portal_access.invited_at to be nullable (matching db)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
