### PR TITLE
S28 2550: Fix Empty String Search Params Affecting Responses

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchBookings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchBookings.java
@@ -15,4 +15,8 @@ public class SearchBookings {
     private Date scheduledFor;
     private UUID participantId;
     private Boolean hasRecordings;
+
+    public String getCaseReference() {
+        return caseReference != null && !caseReference.isEmpty() ? caseReference : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCaptureSessions.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCaptureSessions.java
@@ -17,4 +17,8 @@ public class SearchCaptureSessions {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date scheduledFor;
     private UUID courtId;
+
+    public String getCaseReference() {
+        return caseReference != null && !caseReference.isEmpty() ? caseReference : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCases.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCases.java
@@ -10,4 +10,8 @@ public class SearchCases {
     private String reference;
     private UUID courtId;
     private Boolean includeDeleted;
+
+    public String getReference() {
+        return reference != null && !reference.isEmpty() ? reference : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCourts.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCourts.java
@@ -9,4 +9,16 @@ public class SearchCourts {
     private String name;
     private String locationCode;
     private String regionName;
+
+    public String getName() {
+        return name != null && !name.isEmpty() ? name : null;
+    }
+
+    public String getLocationCode() {
+        return locationCode != null && !locationCode.isEmpty() ? locationCode : null;
+    }
+
+    public String getRegionName() {
+        return regionName != null && !regionName.isEmpty() ? regionName : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchInvites.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchInvites.java
@@ -8,4 +8,20 @@ public class SearchInvites {
     private String lastName;
     private String email;
     private String organisation;
+
+    public String getFirstName() {
+        return firstName != null && !firstName.isEmpty() ? firstName : null;
+    }
+
+    public String getLastName() {
+        return lastName != null && !lastName.isEmpty() ? lastName : null;
+    }
+
+    public String getEmail() {
+        return email != null && !email.isEmpty() ? email : null;
+    }
+
+    public String getOrganisation() {
+        return organisation != null && !organisation.isEmpty() ? organisation : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
@@ -30,4 +30,16 @@ public class SearchRecordings {
     private Timestamp scheduledForUntil;
     private List<UUID> authorisedBookings;
     private UUID authorisedCourt;
+
+    public String getCaseReference() {
+        return caseReference != null && !caseReference.isEmpty() ? caseReference : null;
+    }
+
+    public String getWitnessName() {
+        return witnessName != null && !witnessName.isEmpty() ? witnessName : null;
+    }
+
+    public String getDefendantName() {
+        return defendantName != null && !defendantName.isEmpty() ? defendantName : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchSharedReport.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchSharedReport.java
@@ -10,4 +10,9 @@ public class SearchSharedReport {
     private UUID bookingId;
     private UUID sharedWithId;
     private String sharedWithEmail;
+
+    public String getSharedWithEmail() {
+        return sharedWithEmail != null && !sharedWithEmail.isEmpty() ? sharedWithEmail : null;
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchUsers.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchUsers.java
@@ -14,4 +14,16 @@ public class SearchUsers {
     private UUID roleId;
     private AccessType accessType;
     private Boolean includeDeleted;
+
+    public String getName() {
+        return name != null && !name.isEmpty() ? name : null;
+    }
+
+    public String getEmail() {
+        return email != null && !email.isEmpty() ? email : null;
+    }
+
+    public String getOrganisation() {
+        return organisation != null && !organisation.isEmpty() ? organisation : null;
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchBookingsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchBookingsTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchBookings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchBookingsTest {
+    @Test
+    public void testGetCaseReference() {
+        var searchBookings = new SearchBookings();
+        searchBookings.setCaseReference("ABC123");
+        assertEquals("ABC123", searchBookings.getCaseReference());
+
+        searchBookings.setCaseReference("");
+        assertNull(searchBookings.getCaseReference());
+
+        searchBookings.setCaseReference(null);
+        assertNull(searchBookings.getCaseReference());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchCaptureSessionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchCaptureSessionsTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchCaptureSessions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchCaptureSessionsTest {
+    @Test
+    public void testGetCaseReference() {
+        var searchCaptureSessions = new SearchCaptureSessions();
+        searchCaptureSessions.setCaseReference("ABC123");
+        assertEquals("ABC123", searchCaptureSessions.getCaseReference());
+
+        searchCaptureSessions.setCaseReference("");
+        assertNull(searchCaptureSessions.getCaseReference());
+
+        searchCaptureSessions.setCaseReference(null);
+        assertNull(searchCaptureSessions.getCaseReference());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchCasesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchCasesTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchCases;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchCasesTest {
+    @Test
+    public void testGetReference() {
+        var searchRecordings = new SearchCases();
+        searchRecordings.setReference("ABC123");
+        assertEquals("ABC123", searchRecordings.getReference());
+
+        searchRecordings.setReference("");
+        assertNull(searchRecordings.getReference());
+
+        searchRecordings.setReference(null);
+        assertNull(searchRecordings.getReference());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchCourtsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchCourtsTest.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchCourts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchCourtsTest {
+    @Test
+    public void testGetName() {
+        var searchCourts = new SearchCourts();
+        searchCourts.setName("John Doe");
+        assertEquals("John Doe", searchCourts.getName());
+
+        searchCourts.setName("");
+        assertNull(searchCourts.getName());
+
+        searchCourts.setName(null);
+        assertNull(searchCourts.getName());
+    }
+
+    @Test
+    public void testGetLocationCode() {
+        var searchCourts = new SearchCourts();
+        searchCourts.setLocationCode("ABC123");
+        assertEquals("ABC123", searchCourts.getLocationCode());
+
+        searchCourts.setLocationCode("");
+        assertNull(searchCourts.getLocationCode());
+
+        searchCourts.setLocationCode(null);
+        assertNull(searchCourts.getLocationCode());
+    }
+
+    @Test
+    public void testGetRegionName() {
+        var searchCourts = new SearchCourts();
+        searchCourts.setRegionName("North");
+        assertEquals("North", searchCourts.getRegionName());
+
+        searchCourts.setRegionName("");
+        assertNull(searchCourts.getRegionName());
+
+        searchCourts.setRegionName(null);
+        assertNull(searchCourts.getRegionName());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchInvitesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchInvitesTest.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchInvites;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchInvitesTest {
+    @Test
+    public void testGetFirstName() {
+        var searchInvites = new SearchInvites();
+        searchInvites.setFirstName("John");
+        assertEquals("John", searchInvites.getFirstName());
+
+        searchInvites.setFirstName("");
+        assertNull(searchInvites.getFirstName());
+
+        searchInvites.setFirstName(null);
+        assertNull(searchInvites.getFirstName());
+    }
+
+    @Test
+    public void testGetLastName() {
+        var searchInvites = new SearchInvites();
+        searchInvites.setLastName("Doe");
+        assertEquals("Doe", searchInvites.getLastName());
+
+        searchInvites.setLastName("");
+        assertNull(searchInvites.getLastName());
+
+        searchInvites.setLastName(null);
+        assertNull(searchInvites.getLastName());
+    }
+
+    @Test
+    public void testGetEmail() {
+        var searchInvites = new SearchInvites();
+        searchInvites.setEmail("john.doe@example.com");
+        assertEquals("john.doe@example.com", searchInvites.getEmail());
+
+        searchInvites.setEmail("");
+        assertNull(searchInvites.getEmail());
+
+        searchInvites.setEmail(null);
+        assertNull(searchInvites.getEmail());
+    }
+
+    @Test
+    public void testGetOrganisation() {
+        var searchInvites = new SearchInvites();
+        searchInvites.setOrganisation("ABC");
+        assertEquals("ABC", searchInvites.getOrganisation());
+
+        searchInvites.setOrganisation("");
+        assertNull(searchInvites.getOrganisation());
+
+        searchInvites.setOrganisation(null);
+        assertNull(searchInvites.getOrganisation());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchRecordingsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchRecordingsTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchRecordings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchRecordingsTest {
+
+    @Test
+    public void getCaseReference() {
+        var searchRecordings = new SearchRecordings();
+        searchRecordings.setCaseReference("123");
+        assertEquals("123", searchRecordings.getCaseReference());
+
+        searchRecordings.setCaseReference("");
+        assertNull(searchRecordings.getCaseReference());
+
+        searchRecordings.setCaseReference(null);
+        assertNull(searchRecordings.getCaseReference());
+    }
+
+    @Test
+    public void getWitnessName() {
+        var searchRecordings = new SearchRecordings();
+        searchRecordings.setWitnessName("John Doe");
+        assertEquals("John Doe", searchRecordings.getWitnessName());
+
+        searchRecordings.setWitnessName("");
+        assertNull(searchRecordings.getWitnessName());
+
+        searchRecordings.setWitnessName(null);
+        assertNull(searchRecordings.getWitnessName());
+    }
+
+    @Test
+    public void getDefendantName() {
+        var searchRecordings = new SearchRecordings();
+        searchRecordings.setDefendantName("Alice");
+        assertEquals("Alice", searchRecordings.getDefendantName());
+
+        searchRecordings.setDefendantName("");
+        assertNull(searchRecordings.getDefendantName());
+
+        searchRecordings.setDefendantName(null);
+        assertNull(searchRecordings.getDefendantName());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchUsersTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchUsersTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.preapi.controller.params;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchUsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchUsersTest {
+
+    @Test
+    public void getName() {
+        var searchUsers = new SearchUsers();
+        searchUsers.setName("John Doe");
+        assertEquals("John Doe", searchUsers.getName());
+
+        searchUsers.setName("");
+        assertNull(searchUsers.getName());
+
+        searchUsers.setName(null);
+        assertNull(searchUsers.getName());
+    }
+
+    @Test
+    public void getEmail() {
+        var searchUsers = new SearchUsers();
+        searchUsers.setEmail("john.doe@example.com");
+        assertEquals("john.doe@example.com", searchUsers.getEmail());
+
+        searchUsers.setEmail("");
+        assertNull(searchUsers.getEmail());
+
+        searchUsers.setEmail(null);
+        assertNull(searchUsers.getEmail());
+    }
+
+    @Test
+    public void getOrganisation() {
+        var searchUsers = new SearchUsers();
+        searchUsers.setOrganisation("ABC");
+        assertEquals("ABC", searchUsers.getOrganisation());
+
+        searchUsers.setOrganisation("");
+        assertNull(searchUsers.getOrganisation());
+
+        searchUsers.setOrganisation(null);
+        assertNull(searchUsers.getOrganisation());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2550


### Change description ###
- When a string param is empty `""` it is handled like as a `null` value


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
