### PR TITLE
S28 2511: Fix `scheduledFor` Search Param to `LocalDate`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.reform.preapi.services.BookingService;
 import uk.gov.hmcts.reform.preapi.services.ShareBookingService;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -76,7 +77,7 @@ public class BookingController extends PreApiController {
     @Parameter(
         name = "scheduledFor",
         description = "The Date the Booking is scheduled for",
-        schema = @Schema(implementation = String.class, format = "date"),
+        schema = @Schema(implementation = LocalDate.class, format = "date"),
         example = "2024-04-27"
     )
     @Parameter(
@@ -119,7 +120,7 @@ public class BookingController extends PreApiController {
             params.getCaseReference(),
             params.getCourtId(),
             params.getScheduledFor() != null
-                ? Optional.of(Timestamp.from(params.getScheduledFor().toInstant()))
+                ? Optional.of(Timestamp.valueOf(params.getScheduledFor().atStartOfDay()))
                 : Optional.empty(),
             params.getParticipantId(),
             params.getHasRecordings(),

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionController.java
@@ -32,6 +32,7 @@ import uk.gov.hmcts.reform.preapi.exception.RequestedPageOutOfRangeException;
 import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -80,7 +81,7 @@ public class CaptureSessionController extends PreApiController {
     @Parameter(
         name = "scheduledFor",
         description = "The Date the Booking was scheduled for",
-        schema = @Schema(implementation = String.class, format = "date"),
+        schema = @Schema(implementation = LocalDate.class, format = "date"),
         example = "2024-04-27"
     )
     @Parameter(
@@ -113,7 +114,7 @@ public class CaptureSessionController extends PreApiController {
             params.getOrigin(),
             params.getRecordingStatus(),
             params.getScheduledFor() != null
-                ? Optional.of(Timestamp.from(params.getScheduledFor().toInstant()))
+                ? Optional.of(Timestamp.valueOf(params.getScheduledFor().atStartOfDay()))
                 : Optional.empty(),
             params.getCourtId(),
             pageable

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchBookings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchBookings.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.preapi.controllers.params;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.UUID;
 
@@ -12,7 +13,7 @@ public class SearchBookings {
     private String caseReference;
     private UUID courtId;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private Date scheduledFor;
+    private LocalDate scheduledFor;
     private UUID participantId;
     private Boolean hasRecordings;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchBookings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchBookings.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.UUID;
 
 @Data

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCaptureSessions.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchCaptureSessions.java
@@ -5,7 +5,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.UUID;
 
 @Data
@@ -15,7 +15,7 @@ public class SearchCaptureSessions {
     private RecordingOrigin origin;
     private RecordingStatus recordingStatus;
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private Date scheduledFor;
+    private LocalDate scheduledFor;
     private UUID courtId;
 
     public String getCaseReference() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2511


### Change description ###
- Change search param `scheduledFor` for `GET /bookings` to type `LocalDate`
- Change search param `scheduledFor` for `GET /capture-sessions` to type `LocalDate`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
