### PR TITLE
Allow calling /health via APIm

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "51"
+  revision              = "52"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -2366,6 +2366,29 @@ paths:
       summary: Create or Update a Court
       tags:
         - court-controller
+  /health:
+    get:
+      operationId: health
+      parameters:
+        - description: The User Id of the User making the request
+          format: uuid
+          in: header
+          name: X-User-Id
+          required: false
+          type: string
+          x-example: 123e4567-e89b-12d3-a456-426614174000
+      produces:
+        - application/json
+        - application/vnd.spring-boot.actuator.v2+json
+        - application/vnd.spring-boot.actuator.v3+json
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+      summary: Actuator web endpoint 'health'
+      tags:
+        - Actuator
   /invites:
     get:
       operationId: searchInvites
@@ -3161,5 +3184,11 @@ securityDefinitions:
     name: Ocp-Apim-Subscription-Key
     type: apiKey
 swagger: '2.0'
+tags:
+  - description: Monitor and interact
+    externalDocs:
+      description: Spring Boot Actuator Web API Documentation
+      url: 'https://docs.spring.io/spring-boot/docs/current/actuator-api/html/'
+    name: Actuator
 x-components: {}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,8 +12,11 @@ management:
         include: health, info, prometheus
 
 springdoc:
-  packagesToScan: uk.gov.hmcts.reform.preapi.controllers
   writer-with-order-by-keys: true
+  show-actuator: true
+  paths-to-exclude:
+    - /info
+    - /health/*
 
 spring:
   config:


### PR DESCRIPTION
### Change description ###
This will allow services authenticated with APIm to call the /health endpoint of the API to include within their own health checks.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
