### PR TITLE
S28 2592: Validation to `PUT /invite/{userId}` Request Body + Remove `invite_code`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/InviteController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/InviteController.java
@@ -115,7 +115,7 @@ public class InviteController extends PreApiController {
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_4')")
     public ResponseEntity<Void> upsertInvite(@PathVariable UUID userId,
                                              @Valid @RequestBody CreateInviteDTO createInviteDTO) {
-        if (createInviteDTO.getUserId() == null || !userId.toString().equals(createInviteDTO.getUserId().toString())) {
+        if (!userId.equals(createInviteDTO.getUserId())) {
             throw new PathPayloadMismatchException("userId", "createInviteDTO.userId");
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateInviteDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateInviteDTO.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.preapi.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,15 +18,20 @@ import java.util.UUID;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CreateInviteDTO {
     @Schema (description = "InviteUserId")
+    @NotNull
     protected UUID userId;
 
     @Schema(description = "InviteFirstName")
+    @NotBlank
     protected String firstName;
 
     @Schema(description = "InviteLastName")
+    @NotBlank
     protected String lastName;
 
     @Schema(description = "InviteEmail")
+    @NotBlank
+    @Email
     protected String email;
 
     @Schema(description = "InviteOrganisation")
@@ -30,8 +39,5 @@ public class CreateInviteDTO {
 
     @Schema(description = "InvitePhone")
     protected String phone;
-
-    @Schema(description = "InviteCode")
-    protected String code;
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/InviteDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/InviteDTO.java
@@ -41,6 +41,5 @@ public class InviteDTO {
         lastName = user.getLastName();
         email = user.getEmail();
         invitedAt = portalAccess.getInvitedAt();
-        code = portalAccess.getCode();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/PortalAccess.java
@@ -37,9 +37,6 @@ public class PortalAccess extends CreatedModifiedAtEntity {
     @Column(name = "status", nullable = false)
     private AccessStatus status = AccessStatus.INVITATION_SENT;
 
-    @Column(name = "invite_code", length = 45)
-    private String code;
-
     @Column(name = "invited_at")
     private Timestamp invitedAt;
 
@@ -62,7 +59,6 @@ public class PortalAccess extends CreatedModifiedAtEntity {
         details.put("portalAccessUserEmail", user.getEmail());
         details.put("portalAccessStatus", status);
         details.put("portalAccessInvitedAt", invitedAt);
-        details.put("portalAccessInviteCode", code);
         details.put("portalAccessRegisteredAt", registeredAt);
         details.put("deleted", deletedAt != null);
         return details;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -185,8 +185,7 @@ public class UserService {
 
         portalAccessEntity.setUser(userEntity);
         portalAccessEntity.setStatus(AccessStatus.INVITATION_SENT);
-        portalAccessEntity.setCode(createInviteDTO.getCode());
-        portalAccessEntity.setInvitedAt(Timestamp.from(java.time.Instant.now()));
+        portalAccessEntity.setInvitedAt(Timestamp.from(Instant.now()));
         portalAccessRepository.save(portalAccessEntity);
 
         return UpsertResult.CREATED;

--- a/src/main/resources/db/migration/V018__RemovePortalAccessInviteCode.sql
+++ b/src/main/resources/db/migration/V018__RemovePortalAccessInviteCode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.portal_access
+DROP COLUMN invite_code;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/InviteControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/InviteControllerTest.java
@@ -157,6 +157,9 @@ class InviteControllerTest {
         var userId = UUID.randomUUID();
         var invite =  new CreateInviteDTO();
         invite.setUserId(userId);
+        invite.setFirstName("Example");
+        invite.setLastName("Example");
+        invite.setEmail("example@example.com");
 
         MvcResult response = mockMvc.perform(put("/invites/" + UUID.randomUUID())
                                                  .with(csrf())
@@ -170,12 +173,143 @@ class InviteControllerTest {
             .isEqualTo("{\"message\":\"Path userId does not match payload property createInviteDTO.userId\"}");
     }
 
+    @DisplayName("Should fail to create/update an invite with 400 response code first name must not be blank")
+    @Test
+    void createInviteFirstNameBlank() throws Exception {
+        var userId = UUID.randomUUID();
+        var invite = new CreateInviteDTO();
+        invite.setUserId(userId);
+        invite.setLastName("Example");
+        invite.setEmail("example@example.com");
+
+        var response = mockMvc.perform(put("/invites/" + userId)
+                                           .with(csrf())
+                                           .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                           .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                           .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo("{\"firstName\":\"must not be blank\"}");
+
+
+        invite.setFirstName("");
+
+        var response2 = mockMvc.perform(put("/invites/" + userId)
+                                           .with(csrf())
+                                           .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                           .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                           .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response2.getResponse().getContentAsString())
+            .isEqualTo("{\"firstName\":\"must not be blank\"}");
+    }
+
+    @DisplayName("Should fail to create/update an invite with 400 response code last name must not be blank")
+    @Test
+    void createInviteLastNameBlank() throws Exception {
+        var userId = UUID.randomUUID();
+        var invite = new CreateInviteDTO();
+        invite.setUserId(userId);
+        invite.setFirstName("Example");
+        invite.setEmail("example@example.com");
+
+        var response = mockMvc.perform(put("/invites/" + userId)
+                                           .with(csrf())
+                                           .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                           .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                           .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo("{\"lastName\":\"must not be blank\"}");
+
+
+        invite.setLastName("");
+
+        var response2 = mockMvc.perform(put("/invites/" + userId)
+                                            .with(csrf())
+                                            .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response2.getResponse().getContentAsString())
+            .isEqualTo("{\"lastName\":\"must not be blank\"}");
+    }
+
+    @DisplayName("Should fail to create/update an invite with 400 response code email must not be blank")
+    @Test
+    void createInviteEmailBlank() throws Exception {
+        var userId = UUID.randomUUID();
+        var invite = new CreateInviteDTO();
+        invite.setUserId(userId);
+        invite.setFirstName("Example");
+        invite.setLastName("Example");
+
+        var response = mockMvc.perform(put("/invites/" + userId)
+                                           .with(csrf())
+                                           .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                           .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                           .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo("{\"email\":\"must not be blank\"}");
+
+
+        invite.setEmail("");
+
+        var response2 = mockMvc.perform(put("/invites/" + userId)
+                                            .with(csrf())
+                                            .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response2.getResponse().getContentAsString())
+            .isEqualTo("{\"email\":\"must not be blank\"}");
+    }
+
+    @DisplayName("Should fail to create/update an invite with 400 response code email must be a valid email")
+    @Test
+    void createInviteEmailValid() throws Exception {
+        var userId = UUID.randomUUID();
+        var invite = new CreateInviteDTO();
+        invite.setUserId(userId);
+        invite.setFirstName("Example");
+        invite.setLastName("Example");
+        invite.setEmail("not a valid email");
+
+        var response = mockMvc.perform(put("/invites/" + userId)
+                                           .with(csrf())
+                                           .content(OBJECT_MAPPER.writeValueAsString(invite))
+                                           .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                           .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo("{\"email\":\"must be a well-formed email address\"}");
+    }
+
+
     @DisplayName("Should create an invite with 201 response code")
     @Test
     void createUserCreated() throws Exception {
         var userId = UUID.randomUUID();
         var invite =  new CreateInviteDTO();
         invite.setUserId(userId);
+        invite.setFirstName("Example");
+        invite.setLastName("Example");
+        invite.setEmail("example@example.com");
 
         when(inviteService.upsert(invite)).thenReturn(UpsertResult.CREATED);
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/InviteDTOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/InviteDTOTest.java
@@ -29,7 +29,6 @@ class InviteDTOTest {
         portalAccess.setId(UUID.randomUUID());
         portalAccess.setInvitedAt(Timestamp.from(java.time.Instant.now()));
         portalAccess.setUser(user);
-        portalAccess.setCode("ABCDE");
         portalAccess.setCreatedAt(Timestamp.from(java.time.Instant.now()));
         portalAccess.setModifiedAt(Timestamp.from(java.time.Instant.now()));
     }
@@ -43,7 +42,6 @@ class InviteDTOTest {
         assertThat(model.getFirstName()).isEqualTo(user.getFirstName());
         assertThat(model.getLastName()).isEqualTo(user.getLastName());
         assertThat(model.getEmail()).isEqualTo(user.getEmail());
-        assertThat(model.getCode()).isEqualTo(portalAccess.getCode());
         assertThat(model.getInvitedAt()).isEqualTo(portalAccess.getInvitedAt());
     }
 }


### PR DESCRIPTION
### Change description ###
- Add validation constraints to `PUT /invites/{userId}`
    - `userId` must not be null
    - `firstName` must not be blank/null
    - `lastName` must not be blank/null
    - `email` must not be blank/null and must be a well-formed email address
- Remove `invite_code` column from `portal_access` table


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
