### PR TITLE
S28 2592: `PUT /user/{id}` Deletes App/Portal Access Correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/AppAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/AppAccessService.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CreateAppAccessDTO;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
@@ -12,6 +13,11 @@ import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CourtRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RoleRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
 
 @Service
 public class AppAccessService {
@@ -64,5 +70,17 @@ public class AppAccessService {
 
         var isUpdate = appAccess.isPresent();
         return isUpdate ? UpsertResult.UPDATED : UpsertResult.CREATED;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
+    public void deleteById(UUID portalId) {
+        appAccessRepository
+            .findById(portalId)
+            .ifPresent(
+                access -> {
+                    access.setActive(false);
+                    access.setDeletedAt(Timestamp.from(Instant.now()));
+                    appAccessRepository.save(access);
+                });
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/PortalAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/PortalAccessService.java
@@ -1,14 +1,18 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
+import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.PortalAccessRepository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
 
 @Service
 public class PortalAccessService {
@@ -35,4 +39,16 @@ public class PortalAccessService {
         return UpsertResult.UPDATED;
     }
 
+
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
+    public void deleteById(UUID portalId) {
+        portalAccessRepository
+            .findById(portalId)
+            .ifPresent(
+                access -> {
+                    access.setStatus(AccessStatus.INACTIVE);
+                    access.setDeletedAt(Timestamp.from(Instant.now()));
+                    portalAccessRepository.save(access);
+                });
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -139,7 +139,7 @@ public class UserService {
                 .map(AppAccess::getId)
                 .filter(id -> createUserDTO.getAppAccess().stream().map(CreateAppAccessDTO::getId)
                     .noneMatch(newAccessId -> newAccessId.equals(id)))
-                .forEach(appAccessRepository::deleteById);
+                .forEach(appAccessService::deleteById);
 
             entity
                 .getPortalAccess()
@@ -147,7 +147,7 @@ public class UserService {
                 .map(PortalAccess::getId)
                 .filter(id -> createUserDTO.getPortalAccess().stream().map(CreatePortalAccessDTO::getId)
                     .noneMatch(newAccessId -> newAccessId.equals(id)))
-                .forEach(portalAccessRepository::deleteById);
+                .forEach(portalAccessService::deleteById);
 
             createUserDTO.getPortalAccess().forEach(portalAccessService::update);
         }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/AppAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/AppAccessServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -196,5 +197,23 @@ public class AppAccessServiceTest {
         verify(appAccessRepository, never()).save(any());
     }
 
+    @DisplayName("Should mark app access entity as deleted and inactive")
+    @Test
+    void deleteByIdSuccess() {
+        var id = UUID.randomUUID();
+        var access = new AppAccess();
+        access.setId(id);
+        access.setActive(true);
+
+        when(appAccessRepository.findById(id)).thenReturn(Optional.of(access));
+
+        appAccessService.deleteById(id);
+
+        assertThat(access.getDeletedAt()).isNotNull();
+        assertFalse(access.isActive());
+
+        verify(appAccessRepository, times(1)).findById(id);
+        verify(appAccessRepository, times(1)).save(any());
+    }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
+import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
 import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
@@ -18,6 +19,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -74,6 +76,24 @@ public class PortalAccessServiceTest {
 
         verify(portalAccessRepository, times(1)).findByIdAndDeletedAtIsNull(model.getId());
         verify(portalAccessRepository, never()).save(any());
+    }
+
+    @DisplayName("Should mark app access entity as deleted and inactive")
+    @Test
+    void deleteByIdSuccess() {
+        var id = UUID.randomUUID();
+        var access = new PortalAccess();
+        access.setId(id);
+        access.setStatus(AccessStatus.ACTIVE);
+
+        when(portalAccessRepository.findById(id)).thenReturn(Optional.of(access));
+        portalAccessService.deleteById(id);
+
+        assertThat(access.getDeletedAt()).isNotNull();
+        assertThat(access.getStatus()).isEqualTo(AccessStatus.INACTIVE);
+
+        verify(portalAccessRepository, times(1)).findById(id);
+        verify(portalAccessRepository, times(1)).save(any());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/PortalAccessServiceTest.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.preapi.dto.CreatePortalAccessDTO;
-import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
 import uk.gov.hmcts.reform.preapi.enums.AccessStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
@@ -19,7 +18,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
@@ -578,7 +578,7 @@ public class UserServiceTest {
 
         verify(userRepository, times(1)).findById(model.getId());
         verify(userRepository, times(1)).saveAndFlush(any());
-        verify(appAccessRepository, times(1)).deleteById(accessEntity.getId());
+        verify(appAccessService, times(1)).deleteById(accessEntity.getId());
         verify(appAccessService, times(1)).upsert(accessModel);
         verify(portalAccessRepository, times(1)).existsById(portalModel.getId());
         verify(portalAccessService, times(1)).update(portalModel);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2592


### Change description ###
- Removing app access sets `active = false` as well as `deleted_at` (functionality like normal app access delete)
- Removing portal access set `status = INACTIVE` as well as `deleted_at` (functionality like normal portal access delete)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
