### PR TITLE
S28 2693: Throw Conflict Error on Booking Already Shared with User

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/ShareBookingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/ShareBookingRepository.java
@@ -70,4 +70,6 @@ public interface ShareBookingRepository extends SoftDeleteRepository<ShareBookin
     Page<ShareBooking> findAllByBooking_Id(UUID bookingId, Pageable pageable);
 
     List<ShareBooking> findAllBySharedWith_IdAndDeletedAtIsNull(UUID userId);
+
+    boolean existsBySharedWith_IdAndBooking_IdAndDeletedAtIsNull(UUID userId, UUID bookingId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
@@ -40,7 +40,11 @@ public class ShareBookingService {
     @Transactional
     @PreAuthorize("@authorisationService.hasUpsertAccess(authentication, #createShareBookingDTO)")
     public UpsertResult shareBookingById(CreateShareBookingDTO createShareBookingDTO) {
-        if (shareBookingRepository.existsById(createShareBookingDTO.getId())) {
+        if (shareBookingRepository.existsById(createShareBookingDTO.getId())
+            || shareBookingRepository.existsBySharedWith_IdAndBooking_IdAndDeletedAtIsNull(
+                createShareBookingDTO.getSharedWithUser(),
+                createShareBookingDTO.getBookingId()
+        )) {
             throw new ConflictException("Share booking already exists");
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
@@ -148,26 +148,13 @@ public class ShareBookingServiceTest {
 
     @DisplayName("Share a booking by its id when share booking already exists")
     @Test
-    void shareBookingFailureShareBookingAlreadyExists() {
+    void shareBookingFailureShareBookingIdAlreadyExists() {
         var shareBookingDTO = new CreateShareBookingDTO();
         shareBookingDTO.setId(UUID.randomUUID());
         shareBookingDTO.setBookingId(UUID.randomUUID());
         shareBookingDTO.setSharedByUser(UUID.randomUUID());
         shareBookingDTO.setSharedWithUser(UUID.randomUUID());
 
-        var bookingEntity = new Booking();
-        var sharedByUser = new User();
-        var sharedWithUser = new User();
-
-        when(
-            bookingRepository.findById(shareBookingDTO.getBookingId())
-        ).thenReturn(Optional.of(bookingEntity));
-        when(
-            userRepository.findById(shareBookingDTO.getSharedByUser())
-        ).thenReturn(Optional.of(sharedByUser));
-        when(
-            userRepository.findById(shareBookingDTO.getSharedWithUser())
-        ).thenReturn(Optional.of(sharedWithUser));
         when(
             shareBookingRepository.existsById(shareBookingDTO.getId())
         ).thenReturn(true);
@@ -177,6 +164,33 @@ public class ShareBookingServiceTest {
                 shareBookingService.shareBookingById(shareBookingDTO);
             })
             .withMessage("Conflict: Share booking already exists");
+    }
+
+    @DisplayName("Share a booking by its id when share booking already exists")
+    @Test
+    void shareBookingFailureShareBookingAlreadyExists() {
+        var shareBookingDTO = new CreateShareBookingDTO();
+        shareBookingDTO.setId(UUID.randomUUID());
+        shareBookingDTO.setBookingId(UUID.randomUUID());
+        shareBookingDTO.setSharedByUser(UUID.randomUUID());
+        shareBookingDTO.setSharedWithUser(UUID.randomUUID());
+
+        when(
+            shareBookingRepository.existsById(shareBookingDTO.getId())
+        ).thenReturn(false);
+        when(
+            shareBookingRepository.existsBySharedWith_IdAndBooking_IdAndDeletedAtIsNull(
+                shareBookingDTO.getSharedWithUser(),
+                shareBookingDTO.getBookingId()
+            )
+        ).thenReturn(true);
+
+        var message = assertThrows(
+            ConflictException.class,
+            () -> shareBookingService.shareBookingById(shareBookingDTO)
+        ).getMessage();
+
+        assertThat(message).isEqualTo("Conflict: Share booking already exists");
     }
 
     @DisplayName("Delete a share")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2693


### Change description ###
- Throw a 409 conflict error when booking has already been shared with a user (excluding deleted shares)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
