### PR TITLE
Fix: Invite search by status

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/InviteController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/InviteController.java
@@ -99,7 +99,7 @@ public class InviteController extends PreApiController {
             params.getLastName(),
             params.getEmail(),
             params.getOrganisation(),
-            params.getAccessStatus(),
+            params.getStatus(),
             pageable
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchInvites.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchInvites.java
@@ -9,7 +9,7 @@ public class SearchInvites {
     private String lastName;
     private String email;
     private String organisation;
-    private AccessStatus accessStatus;
+    private AccessStatus status;
 
     public String getFirstName() {
         return firstName != null && !firstName.isEmpty() ? firstName : null;


### PR DESCRIPTION
### Change description ###
- Fix issue where `GET /invites` search param `status` was incorrectly mapped with `SearchInvites` class (with param name `accessStatus`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
