### PR TITLE
S28 2267: Fix Delete User Deletes Portal Access Correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/AppAccessService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/AppAccessService.java
@@ -73,9 +73,9 @@ public class AppAccessService {
     }
 
     @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
-    public void deleteById(UUID portalId) {
+    public void deleteById(UUID appId) {
         appAccessRepository
-            .findById(portalId)
+            .findById(appId)
             .ifPresent(
                 access -> {
                     access.setActive(false);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -204,7 +204,7 @@ public class UserService {
 
         portalAccessRepository
             .findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userId)
-            .ifPresent(portalAccess -> portalAccessRepository.deleteById(portalAccess.getId()));
+            .ifPresent(portalAccess -> portalAccessService.deleteById(portalAccess.getId()));
 
         appAccessRepository
             .findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userId)

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -208,11 +208,7 @@ public class UserService {
 
         appAccessRepository
             .findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userId)
-            .ifPresent(appAccess -> {
-                appAccess.setActive(false);
-                appAccess.setDeletedAt(Timestamp.from(Instant.now()));
-                appAccessRepository.save(appAccess);
-            });
+            .ifPresent(appAccess -> appAccessService.deleteById(appAccess.getId()));
 
         userRepository.deleteById(userId);
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
@@ -467,9 +467,9 @@ public class UserServiceTest {
 
         verify(userRepository, times(1)).existsByIdAndDeletedAtIsNull(userEntity.getId());
         verify(portalAccessRepository, times(1)).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(portalAccessRepository, times(1)).deleteById(portalAccessEntity.getId());
+        verify(portalAccessService, times(1)).deleteById(portalAccessEntity.getId());
         verify(appAccessRepository, times(1)).findByUser_IdAndDeletedAtNullAndUser_DeletedAtNull(userEntity.getId());
-        verify(appAccessRepository, times(1)).save(appAccessEntity);
+        verify(appAccessService, times(1)).deleteById(appAccessEntity.getId());
         verify(userRepository, times(1)).deleteById(userEntity.getId());
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2267


### Change description ###
- Use PortalAccessService.deleteById and AppAccessService.deleteById to make all deletions of portal_access and app_access entities act the same way. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
