### PR TITLE
S28 2777: Undeleting Recording also Undeletes Related Capture Session

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -154,7 +154,7 @@ public class CaptureSessionService {
         return isUpdate ? UpsertResult.UPDATED : UpsertResult.CREATED;
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
     @PreAuthorize("@authorisationService.hasCaptureSessionAccess(authentication, #id)")
     public void undelete(UUID id) {
         var entity =

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.preapi.services;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -32,11 +32,15 @@ public class RecordingService {
     private final RecordingRepository recordingRepository;
     private final CaptureSessionRepository captureSessionRepository;
 
+    private final CaptureSessionService captureSessionService;
+
     @Autowired
     public RecordingService(RecordingRepository recordingRepository,
-                            CaptureSessionRepository captureSessionRepository) {
+                            CaptureSessionRepository captureSessionRepository,
+                            @Lazy CaptureSessionService captureSessionService) {
         this.recordingRepository = recordingRepository;
         this.captureSessionRepository = captureSessionRepository;
+        this.captureSessionService = captureSessionService;
     }
 
     @Transactional
@@ -147,6 +151,7 @@ public class RecordingService {
     @PreAuthorize("@authorisationService.hasRecordingAccess(authentication, #id)")
     public void undelete(UUID id) {
         var entity = recordingRepository.findById(id).orElseThrow(() -> new NotFoundException("Recording: " + id));
+        captureSessionService.undelete(entity.getCaptureSession().getId());
         if (!entity.isDeleted()) {
             return;
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2777


### Change description ###
- Undeleting recording also undeletes the related capture session


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
