### PR TITLE
S28 2788: `NotPastDateValidator` Timezone Fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/validators/NotPastDateValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/validators/NotPastDateValidator.java
@@ -4,7 +4,8 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 public class NotPastDateValidator implements ConstraintValidator<NotPastDateConstraint, Timestamp> {
@@ -14,7 +15,10 @@ public class NotPastDateValidator implements ConstraintValidator<NotPastDateCons
 
     @Override
     public boolean isValid(Timestamp dateField, ConstraintValidatorContext cxt) {
-        var midnight = Instant.now().truncatedTo(ChronoUnit.DAYS).minusMillis(1);
+        var midnight = ZonedDateTime.now(ZoneId.of("Europe/London"))
+            .truncatedTo(ChronoUnit.DAYS)
+            .toInstant()
+            .minusMillis(1);
         return dateField != null && dateField.after(Timestamp.from(midnight));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -366,7 +367,8 @@ class BookingControllerTest {
         booking.setCaseId(caseId);
         booking.setParticipants(getCreateParticipantDTOs());
         booking.setScheduledFor(
-            Timestamp.from(ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS).toInstant().minusMillis(1))
+            Timestamp.from(ZonedDateTime.now(ZoneId.of("Europe/London"))
+                               .truncatedTo(ChronoUnit.DAYS).toInstant().minusMillis(1))
         );
 
         CaseDTO mockCaseDTO = new CaseDTO();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -36,6 +36,7 @@ import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
@@ -365,7 +366,7 @@ class BookingControllerTest {
         booking.setCaseId(caseId);
         booking.setParticipants(getCreateParticipantDTOs());
         booking.setScheduledFor(
-            Timestamp.from(Instant.now().truncatedTo(ChronoUnit.DAYS).minusMillis(1))
+            Timestamp.from(ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS).toInstant().minusMillis(1))
         );
 
         CaseDTO mockCaseDTO = new CaseDTO();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/validators/NotPastDateValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/validators/NotPastDateValidatorTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.preapi.dto.validators;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NotPastDateValidatorTest {
+    private NotPastDateValidator validator;
+    private ConstraintValidatorContext constraintValidatorContext;
+
+    @BeforeEach
+    void setUp() {
+        validator = new NotPastDateValidator();
+        constraintValidatorContext = null;
+    }
+
+    @DisplayName("Should return false when value is null")
+    @Test
+    void isValidWithDateNull() {
+        assertFalse(validator.isValid(null, constraintValidatorContext));
+    }
+
+    @DisplayName("Should return false when value is in the past")
+    @Test
+    void isValidWithDateInPast() {
+        ZonedDateTime pastDateTime = ZonedDateTime.now(ZoneId.of("Europe/London"))
+            .minusDays(1);
+        Timestamp pastTimestamp = Timestamp.from(pastDateTime.toInstant());
+        assertFalse(validator.isValid(pastTimestamp, constraintValidatorContext));
+    }
+
+    @DisplayName("Should return true when value is not in the past")
+    @Test
+    void isValidWithDateToday() {
+        ZonedDateTime currentDateTime = ZonedDateTime.now(ZoneId.of("Europe/London"));
+        Timestamp currentTimestamp = Timestamp.from(currentDateTime.toInstant());
+        assertTrue(validator.isValid(currentTimestamp, constraintValidatorContext));
+    }
+
+    @DisplayName("Should return true when value is in the future")
+    @Test
+    void givenFutureDate_ReturnsTrue() {
+        ZonedDateTime futureDateTime = ZonedDateTime.now(ZoneId.of("Europe/London"))
+            .plusDays(1);
+        Timestamp futureTimestamp = Timestamp.from(futureDateTime.toInstant());
+        assertTrue(validator.isValid(futureTimestamp, constraintValidatorContext));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2788


### Change description ###
- Fix issue highlighted by timezone change
- `NotPastDateValidator` now takes timezone into account


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
