### PR TITLE
Fix: `GET /reports/playback` Error In Caused by Malformed `audit_details`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -182,7 +182,7 @@ public class ReportService {
                             .map(AppAccess::getUser)
                             .orElse(null))
                 : null,
-            audit.getAuditDetails() != null && audit.getAuditDetails().has("recordingId")
+            audit.getAuditDetails() != null && audit.getAuditDetails().hasNonNull("recordingId")
                 ? recordingRepository
                 .findById(UUID.fromString(audit.getAuditDetails().get("recordingId").asText()))
                 .orElse(null)


### PR DESCRIPTION
### Change description ###
- Add check to `GET /reports/playback` to check that `audit_details` has a not null value for `recordingId` before attempting to search by the value.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
