### PR TITLE
Functional Test: `PUT /cases/{id}` Case Reference Tests

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "57"
+  revision              = "58"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -525,6 +525,8 @@ definitions:
       test:
         description: CreateCaseIsTest
         type: boolean
+    required:
+      - reference
     type: object
   CreateCourtDTO:
     description: CreateCourtDTO

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -120,4 +120,28 @@ class CaseControllerFT extends FunctionalTestBase {
         var deleteResponse = doDeleteRequest(CASES_ENDPOINT + "/" + UUID.randomUUID(), true);
         assertResponseCode(deleteResponse, 404);
     }
+
+    @DisplayName("Scenario: Remove Case Reference")
+    @Test
+    void shouldFailToRemoveCaseReference() throws JsonProcessingException {
+        var caseDTO = createCase();
+
+        caseDTO.setReference(null);
+        var putResponse1 = doPutRequest(
+            CASES_ENDPOINT + "/" + caseDTO.getId(),
+            OBJECT_MAPPER.writeValueAsString(caseDTO),
+            true
+        );
+        assertResponseCode(putResponse1, 400);
+        assertThat(putResponse1.getBody().jsonPath().getString("reference")).isEqualTo("must not be null");
+
+        caseDTO.setReference("");
+        var putResponse2 = doPutRequest(
+            CASES_ENDPOINT + "/" + caseDTO.getId(),
+            OBJECT_MAPPER.writeValueAsString(caseDTO),
+            true
+        );
+        assertResponseCode(putResponse2, 400);
+        assertThat(putResponse2.getBody().jsonPath().getString("reference")).isEqualTo("size must be between 9 and 13");
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCaseDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCaseDTO.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.preapi.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,7 @@ public class CreateCaseDTO {
     private UUID courtId;
 
     @Schema(description = "CreateCaseReference")
+    @NotNull
     @Size(min = 9, max = 13)
     private String reference;
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -177,12 +177,35 @@ class CaseControllerTest {
             .isEqualTo("{\"reference\":\"size must be between 9 and 13\"}");
     }
 
+    @DisplayName("Should fail create/update case with 400 error message when case reference is null")
+    @Test
+    void testCreateCaseReferenceNullRequest() throws Exception {
+        UUID caseId = UUID.randomUUID();
+        var caseDTO = new CreateCaseDTO();
+        caseDTO.setId(caseId);
+        caseDTO.setReference(null);
+
+        when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.CREATED);
+
+        MvcResult response = mockMvc.perform(put(CASES_ID_PATH, caseId)
+                                                 .with(csrf())
+                                                 .content(OBJECT_MAPPER.writeValueAsString(caseDTO))
+                                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                 .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertThat(response.getResponse().getContentAsString())
+            .isEqualTo("{\"reference\":\"must not be null\"}");
+    }
+
     @DisplayName("Should update case with 204 response code")
     @Test
     void testUpdateCase() throws Exception {
         UUID caseId = UUID.randomUUID();
         var caseDTO = new CreateCaseDTO();
         caseDTO.setId(caseId);
+        caseDTO.setReference("EXAMPLE123");
 
         when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.UPDATED);
 
@@ -204,6 +227,7 @@ class CaseControllerTest {
         UUID caseId = UUID.randomUUID();
         CaseDTO newCaseRequestDTO = new CaseDTO();
         newCaseRequestDTO.setId(UUID.randomUUID());
+        newCaseRequestDTO.setReference("EXAMPLE123");
 
         mockMvc.perform(put(CASES_ID_PATH, caseId)
                             .with(csrf())
@@ -223,6 +247,7 @@ class CaseControllerTest {
         var newCaseRequestDTO = new CreateCaseDTO();
         newCaseRequestDTO.setId(caseId);
         newCaseRequestDTO.setCourtId(courtId);
+        newCaseRequestDTO.setReference("EXAMPLE123");
 
         doThrow(new NotFoundException("Court: " + courtId)).when(caseService).upsert(newCaseRequestDTO);
 
@@ -245,6 +270,8 @@ class CaseControllerTest {
         var newCaseRequestDTO = new CreateCaseDTO();
         newCaseRequestDTO.setId(caseId);
         newCaseRequestDTO.setCourtId(courtId);
+        newCaseRequestDTO.setReference("EXAMPLE123");
+
 
         doThrow(new ResourceInDeletedStateException("CaseDTO", caseId.toString()))
             .when(caseService).upsert(newCaseRequestDTO);
@@ -271,6 +298,7 @@ class CaseControllerTest {
         var newCaseRequestDTO = new CreateCaseDTO();
         newCaseRequestDTO.setId(caseId);
         newCaseRequestDTO.setCourtId(courtId);
+        newCaseRequestDTO.setReference("EXAMPLE123");
 
         doThrow(new ConflictException("Case reference is already in use for this court"))
             .when(caseService).upsert(newCaseRequestDTO);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/S28-2356
https://tools.hmcts.net/jira/browse/S28-2359
https://tools.hmcts.net/jira/browse/S28-2360


### Change description ###
- Add not-null check to case reference field on `CreateCaseDTO`
- Add functional tests:
    - Remove Case Reference
    - Cannot create a case with reference of more than 13 characters
    - Cannot create a case with reference of less that 9 characters
    - Create a case with a duplicate case reference in the same court
    - Create a case with a duplicate case reference in different court


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - not null check on case reference field for `CreateCaseDTO` could break power apps 
[ ] No
```
