### PR TITLE
S28 2889: Participant Validation on `PUT /cases/{id}` and `PUT /bookings/{id}`

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
@@ -267,15 +267,6 @@ class BookingControllerFT extends FunctionalTestBase {
         return dto;
     }
 
-    private CreateParticipantDTO createParticipant(ParticipantType type) {
-        var dto = new CreateParticipantDTO();
-        dto.setId(UUID.randomUUID());
-        dto.setFirstName("Example");
-        dto.setLastName("Example");
-        dto.setParticipantType(type);
-        return dto;
-    }
-
     private Response putBooking(CreateBookingDTO dto) throws JsonProcessingException {
         return doPutRequest(
             BOOKINGS_ENDPOINT + "/" + dto.getId(),

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
@@ -227,6 +227,37 @@ class BookingControllerFT extends FunctionalTestBase {
             .isEqualTo("scheduled_for is required and must not be before today");
     }
 
+    @DisplayName("Create a booking with a participant that is not part of the case")
+    @Test
+    void createBookingWithParticipantNotInCase() throws JsonProcessingException {
+        var caseEntity = createCase();
+        var participant1 = createParticipant(ParticipantType.WITNESS);
+        var participant2 = createParticipant(ParticipantType.DEFENDANT);
+        var participants = Set.of(
+            participant1,
+            participant2
+        );
+        caseEntity.setParticipants(participants);
+
+        var putCase = doPutRequest(
+            CASES_ENDPOINT + "/" + caseEntity.getId(),
+            OBJECT_MAPPER.writeValueAsString(caseEntity),
+            true
+        );
+        assertResponseCode(putCase, 201);
+        var participant3 = createParticipant(ParticipantType.DEFENDANT);
+        var booking = createBooking(
+            caseEntity.getId(),
+            Set.of(participant1, participant2, participant3)
+        );
+
+        // create booking
+        var putBooking = putBooking(booking);
+        assertResponseCode(putBooking, 404);
+        assertThat(putBooking.body().jsonPath().getString("message"))
+            .isEqualTo("Not found: Participant: " + participant3.getId() + " in case: " + caseEntity.getId());
+    }
+
     @DisplayName("Scenario: Restore booking")
     @Test
     void undeleteBooking() throws JsonProcessingException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -28,22 +28,22 @@ class CaseControllerFT extends FunctionalTestBase {
         createCase.setCourtId(courtId);
         createCase.setReference(generateRandomCaseReference());
         var participant1 = new CreateParticipantDTO();
-        participant1.setId(java.util.UUID.randomUUID());
+        participant1.setId(UUID.randomUUID());
         participant1.setFirstName("John");
         participant1.setLastName("Smith");
         participant1.setParticipantType(ParticipantType.DEFENDANT);
         var participant2 = new CreateParticipantDTO();
-        participant2.setId(java.util.UUID.randomUUID());
+        participant2.setId(UUID.randomUUID());
         participant2.setFirstName("John");
         participant2.setLastName("Smith");
-        participant2.setParticipantType(ParticipantType.DEFENDANT);
-        createCase.setParticipants(java.util.Set.of(
+        participant2.setParticipantType(ParticipantType.WITNESS);
+        createCase.setParticipants(Set.of(
             participant1,
             participant2
         ));
 
         var putResponse = putCase(createCase);
-
+        System.out.println(putResponse.body().prettyPrint());
         assertResponseCode(putResponse, 201);
 
         var getResponse = assertCaseExists(createCase.getId(), true);
@@ -158,6 +158,10 @@ class CaseControllerFT extends FunctionalTestBase {
         caseDTO2.setCourtId(caseDTO1.getCourtId());
         caseDTO2.setParticipants(Set.of());
         caseDTO2.setTest(false);
+        caseDTO2.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT)
+        ));
 
         var putResponse2 = putCase(caseDTO2);
         assertResponseCode(putResponse2, 409);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -329,7 +329,7 @@ class CaseControllerFT extends FunctionalTestBase {
         assertThat(res).isNotNull();
         assertThat(res.getCourt().getId()).isEqualTo(dto.getCourtId());
         assertThat(res.getReference()).isEqualTo(dto.getReference());
-        assertThat(res.getParticipants()).isEmpty();
+        assertThat(res.getParticipants()).hasSize(dto.getParticipants().size());
         assertThat(res.isTest()).isEqualTo(dto.isTest());
         assertThat(res.getCreatedAt()).isNotNull();
         assertThat(res.getModifiedAt()).isNotNull();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -43,7 +43,6 @@ class CaseControllerFT extends FunctionalTestBase {
         ));
 
         var putResponse = putCase(createCase);
-        System.out.println(putResponse.body().prettyPrint());
         assertResponseCode(putResponse, 201);
 
         var getResponse = assertCaseExists(createCase.getId(), true);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
@@ -9,6 +9,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.reform.preapi.Application;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaseDTO;
+import uk.gov.hmcts.reform.preapi.dto.CreateParticipantDTO;
+import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 
 import java.util.Map;
 import java.util.Set;
@@ -153,10 +155,22 @@ public class FunctionalTestBase {
         caseDTO.setId(UUID.randomUUID());
         caseDTO.setCourtId(courtId);
         caseDTO.setReference(generateRandomCaseReference());
-        caseDTO.setParticipants(Set.of());
+        caseDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT)
+        ));
         caseDTO.setTest(false);
 
         return caseDTO;
+    }
+
+    protected CreateParticipantDTO createParticipant(ParticipantType type) {
+        var dto = new CreateParticipantDTO();
+        dto.setId(UUID.randomUUID());
+        dto.setFirstName("Example");
+        dto.setLastName("Person");
+        dto.setParticipantType(type);
+        return dto;
     }
 
     protected String generateRandomCaseReference() {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCaseDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCaseDTO.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.dto.validators.ParticipantTypeConstraint;
 import uk.gov.hmcts.reform.preapi.entities.Case;
 
 import java.util.Set;
@@ -32,6 +33,7 @@ public class CreateCaseDTO {
     private String reference;
 
     @Schema(description = "CaseParticipants")
+    @ParticipantTypeConstraint
     private Set<CreateParticipantDTO> participants;
 
     @Schema(description = "CreateCaseIsTest")

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/ParticipantRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/ParticipantRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 
 @Repository
 public interface ParticipantRepository extends SoftDeleteRepository<Participant, UUID> {
+    boolean existsByIdAndCaseId_Id(UUID id, UUID caseId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
@@ -44,8 +44,8 @@ public class BookingService {
     public BookingService(final BookingRepository bookingRepository,
                           final CaseRepository caseRepository,
                           final ParticipantRepository participantRepository,
-                          CaptureSessionService captureSessionService,
-                          ShareBookingService shareBookingService) {
+                          final CaptureSessionService captureSessionService,
+                          final ShareBookingService shareBookingService) {
         this.bookingRepository = bookingRepository;
         this.participantRepository = participantRepository;
         this.caseRepository = caseRepository;
@@ -108,6 +108,12 @@ public class BookingService {
         if (bookingAlreadyDeleted(createBookingDTO.getId())) {
             throw new ResourceInDeletedStateException("BookingDTO", createBookingDTO.getId().toString());
         }
+
+        createBookingDTO.getParticipants().forEach(p -> {
+            if (!participantRepository.existsByIdAndCaseId_Id(p.getId(), createBookingDTO.getCaseId())) {
+                throw new NotFoundException("Participant: " + p.getId() + " in case: " + createBookingDTO.getCaseId());
+            }
+        });
 
         var isUpdate = bookingRepository.existsById(createBookingDTO.getId());
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -248,7 +248,6 @@ class CaseControllerTest {
     @DisplayName("Should return 400 when creating case with path and payload mismatch")
     @Test
     void testCreateCasePathPayloadMismatch() throws Exception {
-        UUID caseId = UUID.randomUUID();
         var newCaseRequestDTO = new CreateCaseDTO();
         newCaseRequestDTO.setId(UUID.randomUUID());
         newCaseRequestDTO.setReference("EXAMPLE123");
@@ -257,7 +256,7 @@ class CaseControllerTest {
             createParticipant(ParticipantType.DEFENDANT))
         );
 
-        mockMvc.perform(put(CASES_ID_PATH, caseId)
+        mockMvc.perform(put(CASES_ID_PATH, UUID.randomUUID())
                             .with(csrf())
                             .content(OBJECT_MAPPER.writeValueAsString(newCaseRequestDTO))
                             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.preapi.controllers.CaseController;
 import uk.gov.hmcts.reform.preapi.dto.CaseDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaseDTO;
+import uk.gov.hmcts.reform.preapi.dto.CreateParticipantDTO;
+import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.ConflictException;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
@@ -24,6 +26,7 @@ import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.CaseService;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +121,11 @@ class CaseControllerTest {
         var caseDTO = new CreateCaseDTO();
         caseDTO.setId(caseId);
         caseDTO.setReference("TestCase1");
+        caseDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
+
 
         when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.CREATED);
 
@@ -140,6 +148,10 @@ class CaseControllerTest {
         var caseDTO = new CreateCaseDTO();
         caseDTO.setId(caseId);
         caseDTO.setReference("TestCase");
+        caseDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.CREATED);
 
@@ -162,6 +174,10 @@ class CaseControllerTest {
         var caseDTO = new CreateCaseDTO();
         caseDTO.setId(caseId);
         caseDTO.setReference("TestCase123456");
+        caseDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.CREATED);
 
@@ -184,6 +200,10 @@ class CaseControllerTest {
         var caseDTO = new CreateCaseDTO();
         caseDTO.setId(caseId);
         caseDTO.setReference(null);
+        caseDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.CREATED);
 
@@ -206,6 +226,10 @@ class CaseControllerTest {
         var caseDTO = new CreateCaseDTO();
         caseDTO.setId(caseId);
         caseDTO.setReference("EXAMPLE123");
+        caseDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         when(caseService.upsert(caseDTO)).thenReturn(UpsertResult.UPDATED);
 
@@ -225,9 +249,13 @@ class CaseControllerTest {
     @Test
     void testCreateCasePathPayloadMismatch() throws Exception {
         UUID caseId = UUID.randomUUID();
-        CaseDTO newCaseRequestDTO = new CaseDTO();
+        var newCaseRequestDTO = new CreateCaseDTO();
         newCaseRequestDTO.setId(UUID.randomUUID());
         newCaseRequestDTO.setReference("EXAMPLE123");
+        newCaseRequestDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         mockMvc.perform(put(CASES_ID_PATH, caseId)
                             .with(csrf())
@@ -239,6 +267,52 @@ class CaseControllerTest {
                            .value("Path id does not match payload property createCaseDTO.id"));
     }
 
+    @DisplayName("Should return 400 when participants does not contain a witness")
+    @Test
+    void createCaseNoWitnessParticipantBadRequest() throws Exception {
+        var caseId = UUID.randomUUID();
+        var courtId = UUID.randomUUID();
+        var newCaseRequestDTO = new CreateCaseDTO();
+        newCaseRequestDTO.setId(caseId);
+        newCaseRequestDTO.setCourtId(courtId);
+        newCaseRequestDTO.setReference("EXAMPLE123");
+        newCaseRequestDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.DEFENDANT))
+        );
+
+        mockMvc.perform(put(CASES_ID_PATH, caseId)
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(newCaseRequestDTO))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.participants")
+                           .value("Participants must consist of at least 1 defendant and 1 witness"));
+    }
+
+    @DisplayName("Should return 400 when participants does not contain a defendant")
+    @Test
+    void createCaseNoDefendantParticipantBadRequest() throws Exception {
+        var caseId = UUID.randomUUID();
+        var courtId = UUID.randomUUID();
+        var newCaseRequestDTO = new CreateCaseDTO();
+        newCaseRequestDTO.setId(caseId);
+        newCaseRequestDTO.setCourtId(courtId);
+        newCaseRequestDTO.setReference("EXAMPLE123");
+        newCaseRequestDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS))
+        );
+
+        mockMvc.perform(put(CASES_ID_PATH, caseId)
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(newCaseRequestDTO))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.participants")
+                           .value("Participants must consist of at least 1 defendant and 1 witness"));
+    }
+
     @DisplayName("Should return 400 when creating case with court that does not exist")
     @Test
     void testCreateCaseCourtNotFound() throws Exception {
@@ -248,6 +322,10 @@ class CaseControllerTest {
         newCaseRequestDTO.setId(caseId);
         newCaseRequestDTO.setCourtId(courtId);
         newCaseRequestDTO.setReference("EXAMPLE123");
+        newCaseRequestDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         doThrow(new NotFoundException("Court: " + courtId)).when(caseService).upsert(newCaseRequestDTO);
 
@@ -271,6 +349,10 @@ class CaseControllerTest {
         newCaseRequestDTO.setId(caseId);
         newCaseRequestDTO.setCourtId(courtId);
         newCaseRequestDTO.setReference("EXAMPLE123");
+        newCaseRequestDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
 
         doThrow(new ResourceInDeletedStateException("CaseDTO", caseId.toString()))
@@ -299,6 +381,10 @@ class CaseControllerTest {
         newCaseRequestDTO.setId(caseId);
         newCaseRequestDTO.setCourtId(courtId);
         newCaseRequestDTO.setReference("EXAMPLE123");
+        newCaseRequestDTO.setParticipants(Set.of(
+            createParticipant(ParticipantType.WITNESS),
+            createParticipant(ParticipantType.DEFENDANT))
+        );
 
         doThrow(new ConflictException("Case reference is already in use for this court"))
             .when(caseService).upsert(newCaseRequestDTO);
@@ -417,5 +503,14 @@ class CaseControllerTest {
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message")
                            .value("Not found: Case: " + caseId));
+    }
+
+    private CreateParticipantDTO createParticipant(ParticipantType type) {
+        var dto = new CreateParticipantDTO();
+        dto.setId(UUID.randomUUID());
+        dto.setFirstName("Example");
+        dto.setLastName("Person");
+        dto.setParticipantType(type);
+        return dto;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -192,7 +192,7 @@ class BookingServiceTest {
         when(bookingRepository.existsById(bookingModel.getId())).thenReturn(false);
         when(caseRepository.findByIdAndDeletedAtIsNull(bookingModel.getCaseId())).thenReturn(Optional.of(new Case()));
         when(bookingRepository.save(bookingEntity)).thenReturn(bookingEntity);
-
+        when(participantRepository.existsByIdAndCaseId_Id(participantModel.getId(), caseId)).thenReturn(true);
         when(participantRepository.findById(participantModel.getId())).thenReturn(Optional.empty());
         when(participantRepository.save(any())).thenReturn(participantEntity);
 
@@ -324,18 +324,18 @@ class BookingServiceTest {
         caseEntity.setId(caseId);
         bookingModel.setId(UUID.randomUUID());
         bookingModel.setCaseId(caseId);
-        bookingModel.setCaseId(caseId);
-        bookingModel.setParticipants(Set.of());
         var participantModel = new CreateParticipantDTO();
         participantModel.setId(UUID.randomUUID());
         participantModel.setParticipantType(ParticipantType.WITNESS);
         participantModel.setFirstName("John");
         participantModel.setLastName("Smith");
+
         bookingModel.setParticipants(Set.of(participantModel));
 
         var participantEntity = new Participant();
         participantEntity.setId(participantModel.getId());
         participantEntity.setDeletedAt(Timestamp.from(Instant.now()));
+        caseEntity.setParticipants(Set.of(participantEntity));
         var bookingEntity = new Booking();
 
         when(caseRepository.findByIdAndDeletedAtIsNull(caseId)).thenReturn(Optional.of(caseEntity));
@@ -344,6 +344,7 @@ class BookingServiceTest {
         when(bookingRepository.existsById(bookingModel.getId())).thenReturn(false);
         when(caseRepository.findByIdAndDeletedAtIsNull(bookingModel.getCaseId())).thenReturn(Optional.of(new Case()));
         when(bookingRepository.save(bookingEntity)).thenReturn(bookingEntity);
+        when(participantRepository.existsByIdAndCaseId_Id(participantModel.getId(), caseId)).thenReturn(true);
 
         when(participantRepository.findById(participantModel.getId())).thenReturn(Optional.of(participantEntity));
         assertThatExceptionOfType(ResourceInDeletedStateException.class)
@@ -353,6 +354,37 @@ class BookingServiceTest {
             .withMessage("Resource Participant("
                              + participantModel.getId().toString()
                              + ") is in a deleted state and cannot be updated");
+    }
+
+    @DisplayName("Create a booking with a participant not assigned to the case")
+    @Test
+    void createBookingWithParticipantNotAssignedToTheCase() {
+        var bookingModel = new CreateBookingDTO();
+        var caseId = UUID.randomUUID();
+        var caseEntity = new Case();
+        caseEntity.setId(caseId);
+        bookingModel.setId(UUID.randomUUID());
+        bookingModel.setCaseId(caseId);
+        var participantModel = new CreateParticipantDTO();
+        participantModel.setId(UUID.randomUUID());
+        participantModel.setParticipantType(ParticipantType.WITNESS);
+        participantModel.setFirstName("John");
+        participantModel.setLastName("Smith");
+
+        bookingModel.setParticipants(Set.of(participantModel));
+
+        when(caseRepository.findByIdAndDeletedAtIsNull(caseId)).thenReturn(Optional.of(caseEntity));
+        when(bookingRepository.findById(bookingModel.getId())).thenReturn(Optional.empty());
+        when(bookingRepository.existsByIdAndDeletedAtIsNotNull(bookingModel.getId())).thenReturn(false);
+        when(bookingRepository.existsById(bookingModel.getId())).thenReturn(false);
+        when(caseRepository.findByIdAndDeletedAtIsNull(bookingModel.getCaseId())).thenReturn(Optional.of(new Case()));
+        when(participantRepository.existsByIdAndCaseId_Id(participantModel.getId(), caseId)).thenReturn(false);
+
+        assertThatExceptionOfType(NotFoundException.class)
+            .isThrownBy(() -> {
+                bookingService.upsert(bookingModel);
+            })
+            .withMessage("Not found: Participant: " + participantModel.getId() + " in case: " + caseId);
     }
 
     @DisplayName("Delete a booking")


### PR DESCRIPTION
<!--
PR checklist:

- [x] Commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] Tests have been updated / new tests has been added (if needed)
- [x] QA have been notified to perform manual testing (if needed)
  - [x] Add the `enable_keep_helm` label to the PR
- [x] Power Platform team have been notified of any breaking changes to the API (if needed)
- [x] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->


### JIRA ticket(s)

- S28-2889


### Change description
- Add validation: `PUT /cases/{id}` request body must have at least one witness and one defendant in `participants` list
- Add validation: `PUT /bookings/{id}`- participants must be in the db and be linked to the same case as the booking. 

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Make request to API to create a new case without any participants- see you get a 400 error
- Make request to API to create a new case with one witness- see you get a 400 error
- Make request to API to create a new case with one defendant- see you get a 400 error
- Make request to API to create a new case with one witness and one defendant- see success 201
- Make request to API to create a new booking with participants that are not defined in the case attached to the booking- see you get a 404 error
- Make request to API to create a new booking with participants that are defined in the case attached to the booking- see success 201
- Any other tests related to the ticket
- Ensure there is enough test coverage in automated tests


<!-- If this PR contains a breaking change uncomment the following: -->


> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**
- In theory, not breaking since the app is already handling this constraint. Just need to ensure we are using the same ids for the participants sent in both create/update case and create/update booking

