### PR TITLE
S28 2901: Fix 504 Errors on Reports

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/ConcurrentCaptureSessionReportDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/ConcurrentCaptureSessionReportDTO.java
@@ -44,16 +44,8 @@ public class ConcurrentCaptureSessionReportDTO {
     @Schema(description = "CaptureSessionRegionName")
     private Set<RegionDTO> region;
 
-    public ConcurrentCaptureSessionReportDTO(Recording entity) {
-        initCaptureSessionValues(entity.getCaptureSession());
-        duration = entity.getDuration();
-    }
 
     public ConcurrentCaptureSessionReportDTO(CaptureSession entity) {
-        initCaptureSessionValues(entity);
-    }
-
-    private void initCaptureSessionValues(CaptureSession entity) {
         id = entity.getId();
         startTime = entity.getStartedAt();
         endTime = entity.getFinishedAt();
@@ -64,5 +56,11 @@ public class ConcurrentCaptureSessionReportDTO {
         region = Stream.ofNullable(caseEntity.getCourt().getRegions())
             .flatMap(regions -> regions.stream().map(RegionDTO::new))
             .collect(Collectors.toSet());
+
+        Stream.ofNullable(entity.getRecordings())
+            .flatMap(Set::stream)
+            .filter(r -> r.getVersion() == 1 && !r.isDeleted())
+            .findFirst()
+            .ifPresent(r -> duration = r.getDuration());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/ConcurrentCaptureSessionReportDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/ConcurrentCaptureSessionReportDTO.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.preapi.dto.RegionDTO;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
-import uk.gov.hmcts.reform.preapi.entities.Recording;
 
 import java.sql.Timestamp;
 import java.time.Duration;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/CaptureSession.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/CaptureSession.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
@@ -20,6 +21,7 @@ import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -65,6 +67,9 @@ public class CaptureSession extends BaseEntity {
 
     @Transient
     private boolean deleted;
+
+    @OneToMany(mappedBy = "captureSession")
+    private Set<Recording> recordings;
 
     public boolean isDeleted() {
         return deletedAt != null;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CaptureSessionRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/CaptureSessionRepository.java
@@ -72,4 +72,12 @@ public interface CaptureSessionRepository extends SoftDeleteRepository<CaptureSe
         @Param("authCourtId") UUID authCourtId,
         Pageable pageable
     );
+
+    @Query("""
+        SELECT cs FROM CaptureSession cs
+        WHERE cs.deletedAt IS NULL
+        AND cs.startedAt IS NOT NULL
+        """
+    )
+    List<CaptureSession> reportConcurrentCaptureSessions();
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -107,4 +107,18 @@ public interface RecordingRepository extends SoftDeleteRepository<Recording, UUI
     @Modifying
     @Transactional
     void deleteAllByCaptureSession(CaptureSession captureSession);
+
+    @Query("""
+        SELECT c, COUNT(c)
+        FROM Recording r
+        LEFT JOIN CaptureSession cs ON r.captureSession.id=cs.id
+        LEFT JOIN Booking b ON cs.booking.id=b.id
+        LEFT JOIN Case c ON b.caseId.id=c.id
+        WHERE r.version = 1
+        AND r.deletedAt IS NULL
+        GROUP BY c
+        ORDER BY count(c) DESC
+        """
+    )
+    List<Object[]> countRecordingsPerCase();
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.preapi.dto.reports.ScheduleReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.SharedReportDTO;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
 import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
@@ -76,17 +77,10 @@ public class ReportService {
 
     @Transactional
     public List<RecordingsPerCaseReportDTO> reportRecordingsPerCase() {
-        return caseRepository
-            .findAll()
+        return recordingRepository
+            .countRecordingsPerCase()
             .stream()
-            .map(c -> new RecordingsPerCaseReportDTO(
-                c,
-                captureSessionRepository.countAllByBooking_CaseId_IdAndStatus(
-                    c.getId(),
-                    RecordingStatus.RECORDING_AVAILABLE
-                )
-            ))
-            .sorted((case1, case2) -> Integer.compare(case2.getCount(), case1.getCount()))
+            .map(data -> new RecordingsPerCaseReportDTO((Case) data[0], ((Long) data[1]).intValue()))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
 import uk.gov.hmcts.reform.preapi.repositories.AuditRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
-import uk.gov.hmcts.reform.preapi.repositories.CaseRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RecordingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.ShareBookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
@@ -37,7 +36,6 @@ public class ReportService {
 
     private final CaptureSessionRepository captureSessionRepository;
     private final RecordingRepository recordingRepository;
-    private final CaseRepository caseRepository;
     private final ShareBookingRepository shareBookingRepository;
     private final AuditRepository auditRepository;
     private final UserRepository userRepository;
@@ -46,14 +44,12 @@ public class ReportService {
     @Autowired
     public ReportService(CaptureSessionRepository captureSessionRepository,
                          RecordingRepository recordingRepository,
-                         CaseRepository caseRepository,
                          ShareBookingRepository shareBookingRepository,
                          AuditRepository auditRepository,
                          UserRepository userRepository,
                          AppAccessRepository appAccessRepository) {
         this.captureSessionRepository = captureSessionRepository;
         this.recordingRepository = recordingRepository;
-        this.caseRepository = caseRepository;
         this.shareBookingRepository = shareBookingRepository;
         this.auditRepository = auditRepository;
         this.userRepository = userRepository;
@@ -63,15 +59,9 @@ public class ReportService {
     @Transactional
     public List<ConcurrentCaptureSessionReportDTO> reportCaptureSessions() {
         return captureSessionRepository
-            .findAll()
+            .reportConcurrentCaptureSessions()
             .stream()
-            .map(c -> {
-                var recordings = recordingRepository
-                    .findAllByCaptureSessionAndDeletedAtIsNullAndVersionOrderByCreatedAt(c, 1);
-                return (recordings.isEmpty())
-                    ? new ConcurrentCaptureSessionReportDTO(c)
-                    : new ConcurrentCaptureSessionReportDTO(recordings.getFirst());
-            })
+            .map(ConcurrentCaptureSessionReportDTO::new)
             .collect(Collectors.toList());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -135,19 +135,12 @@ public class ReportServiceTest {
     void captureSessionReportCaptureSessionIncompleteSuccess() {
         captureSessionEntity.setStartedAt(Timestamp.from(Instant.now()));
         captureSessionEntity.setFinishedAt(Timestamp.from(Instant.now()));
-        when(captureSessionRepository.findAll()).thenReturn(List.of(captureSessionEntity));
-        when(recordingRepository
-                 .findAllByCaptureSessionAndDeletedAtIsNullAndVersionOrderByCreatedAt(
-                     captureSessionEntity,
-                     1
-                 )
-        ).thenReturn(List.of());
+        captureSessionEntity.setRecordings(Set.of());
+        when(captureSessionRepository.reportConcurrentCaptureSessions()).thenReturn(List.of(captureSessionEntity));
 
         var report = reportService.reportCaptureSessions();
 
-        verify(captureSessionRepository, times(1)).findAll();
-        verify(recordingRepository, times(1))
-            .findAllByCaptureSessionAndDeletedAtIsNullAndVersionOrderByCreatedAt(any(), eq(1));
+        verify(captureSessionRepository, times(1)).reportConcurrentCaptureSessions();
 
         assertThat(report.size()).isEqualTo(1);
         var first = report.getFirst();
@@ -162,25 +155,18 @@ public class ReportServiceTest {
         assertThat(first.getRegion().stream().findFirst().get().getName()).isEqualTo(regionEntity.getName());
     }
 
-    @DisplayName("Find all capture sessions and return a list of models as a report when capture session is complete")
+    @DisplayName("Find all capture sessions and return a list of models as a report on concurrent capture sessions")
     @Test
-    void captureSessionReportCaptureSessionCompleteSuccess() {
+    void captureSessionReportConcurrentCaptureSessionsSuccess() {
         recordingEntity.setDuration(Duration.ofMinutes(3));
         captureSessionEntity.setStartedAt(Timestamp.from(Instant.now()));
         captureSessionEntity.setFinishedAt(Timestamp.from(Instant.now()));
-        when(captureSessionRepository.findAll()).thenReturn(List.of(captureSessionEntity));
-        when(recordingRepository
-                 .findAllByCaptureSessionAndDeletedAtIsNullAndVersionOrderByCreatedAt(
-                     captureSessionEntity,
-                     1
-                 )
-        ).thenReturn(List.of(recordingEntity));
+        captureSessionEntity.setRecordings(Set.of(recordingEntity));
+        when(captureSessionRepository.reportConcurrentCaptureSessions()).thenReturn(List.of(captureSessionEntity));
 
         var report = reportService.reportCaptureSessions();
 
-        verify(captureSessionRepository, times(1)).findAll();
-        verify(recordingRepository, times(1))
-            .findAllByCaptureSessionAndDeletedAtIsNullAndVersionOrderByCreatedAt(any(), eq(1));
+        verify(captureSessionRepository, times(1)).reportConcurrentCaptureSessions();
 
         assertThat(report.size()).isEqualTo(1);
         var first = report.getFirst();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
 import uk.gov.hmcts.reform.preapi.repositories.AuditRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
-import uk.gov.hmcts.reform.preapi.repositories.CaseRepository;
 import uk.gov.hmcts.reform.preapi.repositories.RecordingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.ShareBookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
@@ -62,9 +61,6 @@ public class ReportServiceTest {
 
     @MockBean
     private RecordingRepository recordingRepository;
-
-    @MockBean
-    private CaseRepository caseRepository;
 
     @MockBean
     private ShareBookingRepository shareBookingRepository;
@@ -207,19 +203,8 @@ public class ReportServiceTest {
         anotherCase.setCourt(courtEntity);
         anotherCase.setReference("XYZ456");
 
-        when(caseRepository.findAll()).thenReturn(List.of(anotherCase, caseEntity));
-        when(
-            captureSessionRepository.countAllByBooking_CaseId_IdAndStatus(
-                anotherCase.getId(),
-                RecordingStatus.RECORDING_AVAILABLE
-            )
-        ).thenReturn(0);
-        when(
-            captureSessionRepository.countAllByBooking_CaseId_IdAndStatus(
-                caseEntity.getId(),
-                RecordingStatus.RECORDING_AVAILABLE
-            )
-        ).thenReturn(1);
+        when(recordingRepository.countRecordingsPerCase())
+            .thenReturn(List.of(new Object[] { caseEntity, (long) 1 }, new Object[]{ anotherCase, (long) 0 }));
 
         var report = reportService.reportRecordingsPerCase();
 


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)

- S28-2901
- S28-2902


### Change description
- Fix: Decrease time taken to get response from `GET /reports/recordings-per-case`
- Fix: Decrease time taken to get response from `GET /reports/concurrent-capture-sessions`


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

- Ensure the functionality has been preserved for the newly updated reports 
- `GET /reports/recordings-per-case`
    - Reports on the number of recordings per case (per court)
- `GET /reports/concurrent-capture-sessions`
    - Reports on the capture sessions that have been started (and/or finished)



<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

- no
-
-->
