### PR TITLE
S28 2981: Remove Recordings URL

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/entities/CreateRecordingDTOTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/entities/CreateRecordingDTOTest.java
@@ -58,7 +58,6 @@ class CreateRecordingDTOTest {
         Recording testRecording = new Recording();
         testRecording.setCaptureSession(captureSession);
         testRecording.setVersion(1);
-        testRecording.setUrl("TestUrl");
         testRecording.setFilename("TestFilename");
         testRecording.setCreatedAt(new Timestamp(System.currentTimeMillis()));
         testRecording.setEditInstruction("{\"instruction\":\"TestInstruction\"}");
@@ -84,7 +83,6 @@ class CreateRecordingDTOTest {
             "Parent recording should match"
         );
         assertEquals(testRecording.getVersion(), retrievedRecording.getVersion(), "Version should match");
-        assertEquals(testRecording.getUrl(), retrievedRecording.getUrl(), "Url should match");
         assertEquals(
             testRecording.getFilename(),
             retrievedRecording.getFilename(),

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/BookingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/BookingServiceIT.java
@@ -157,7 +157,6 @@ class BookingServiceIT extends IntegrationTestBase {
             captureSession,
             null,
             1,
-            null,
             "example",
             null
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
@@ -185,7 +185,7 @@ public class CaseServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession);
 
-        var recording = HelperFactory.createRecording(captureSession, null, 1, "url", "filename", null);
+        var recording = HelperFactory.createRecording(captureSession, null, 1, "filename", null);
         entityManager.persist(recording);
 
         var message = Assertions.assertThrows(

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
@@ -61,14 +61,13 @@ public class RecordingServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession);
 
-        var recording1 = HelperFactory.createRecording(captureSession, null, 1, null, "filename", null);
+        var recording1 = HelperFactory.createRecording(captureSession, null, 1, "filename", null);
         entityManager.persist(recording1);
 
         var recording2 = HelperFactory.createRecording(
             captureSession,
             null,
             2,
-            null,
             "filename",
             Timestamp.from(Instant.now())
         );
@@ -112,14 +111,13 @@ public class RecordingServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession);
 
-        var recording1 = HelperFactory.createRecording(captureSession, null, 1, null, "filename", null);
+        var recording1 = HelperFactory.createRecording(captureSession, null, 1, "filename", null);
         entityManager.persist(recording1);
 
         var recording2 = HelperFactory.createRecording(
             captureSession,
             null,
             2,
-            null,
             "filename",
             Timestamp.from(Instant.now())
         );

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/ReportServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/ReportServiceIT.java
@@ -112,7 +112,7 @@ public class ReportServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession);
 
-        var recording = HelperFactory.createRecording(captureSession, null, 1, null, "example.file", null);
+        var recording = HelperFactory.createRecording(captureSession, null, 1, "example.file", null);
         entityManager.persist(recording);
 
         var user = HelperFactory.createUser("Example", "One", "example1@example.com", null, null, null);
@@ -170,7 +170,7 @@ public class ReportServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession);
 
-        var recording = HelperFactory.createRecording(captureSession, null, 1, null, "example.file", null);
+        var recording = HelperFactory.createRecording(captureSession, null, 1, "example.file", null);
         entityManager.persist(recording);
 
         var response = reportService.reportRecordingParticipants();
@@ -253,13 +253,13 @@ public class ReportServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession3);
 
-        var recording1 = HelperFactory.createRecording(captureSession1, null, 1, null, "example.file", null);
+        var recording1 = HelperFactory.createRecording(captureSession1, null, 1, "example.file", null);
         entityManager.persist(recording1);
-        var recording2 = HelperFactory.createRecording(captureSession2, null, 1, null, "example.file", null);
+        var recording2 = HelperFactory.createRecording(captureSession2, null, 1, "example.file", null);
         entityManager.persist(recording2);
-        var recording3 = HelperFactory.createRecording(captureSession3, null, 1, null, "example.file", null);
+        var recording3 = HelperFactory.createRecording(captureSession3, null, 1, "example.file", null);
         entityManager.persist(recording3);
-        var recording4 = HelperFactory.createRecording(captureSession3, recording3, 2, null, "example.file", null);
+        var recording4 = HelperFactory.createRecording(captureSession3, recording3, 2, "example.file", null);
         entityManager.persist(recording4);
 
         var report = reportService.reportRecordingsPerCase();
@@ -341,13 +341,12 @@ public class ReportServiceIT extends IntegrationTestBase {
         );
         entityManager.persist(captureSession3);
 
-        var recording1 = HelperFactory.createRecording(captureSession1, null, 1, null, "example.file", null);
+        var recording1 = HelperFactory.createRecording(captureSession1, null, 1, "example.file", null);
         entityManager.persist(recording1);
         var recording3 = HelperFactory.createRecording(
             captureSession3,
             null,
             1,
-            null,
             "example.file",
             Timestamp.from(Instant.now())
         );

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -252,7 +252,6 @@ class TestingSupportController {
         recording.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        recording.setUrl("http://localhost:8080/recording");
         recording.setFilename("recording.mp4");
         recording.setDuration(Duration.ofMinutes(30));
         recording.setEditInstruction("{\"foo\": \"bar\"}");

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateRecordingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateRecordingDTO.java
@@ -31,7 +31,7 @@ public class CreateRecordingDTO extends BaseRecordingDTO {
             ? recording.getParentRecording().getId()
             : null;
         version = recording.getVersion();
-        url = recording.getUrl();
+        url = null;
         filename = recording.getFilename();
         duration = recording.getDuration();
         editInstructions = recording.getEditInstruction();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateRecordingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateRecordingDTO.java
@@ -31,7 +31,6 @@ public class CreateRecordingDTO extends BaseRecordingDTO {
             ? recording.getParentRecording().getId()
             : null;
         version = recording.getVersion();
-        url = null;
         filename = recording.getFilename();
         duration = recording.getDuration();
         editInstructions = recording.getEditInstruction();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTO.java
@@ -53,7 +53,7 @@ public class RecordingDTO extends BaseRecordingDTO {
             ? recording.getParentRecording().getId()
             : null;
         version = recording.getVersion();
-        url = recording.getUrl();
+        url = null;
         filename = recording.getFilename();
         duration = recording.getDuration();
         editInstructions = recording.getEditInstruction();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTO.java
@@ -53,7 +53,6 @@ public class RecordingDTO extends BaseRecordingDTO {
             ? recording.getParentRecording().getId()
             : null;
         version = recording.getVersion();
-        url = null;
         filename = recording.getFilename();
         duration = recording.getDuration();
         editInstructions = recording.getEditInstruction();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Recording.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Recording.java
@@ -37,9 +37,6 @@ public class Recording extends BaseEntity {
     @Column(name = "version", nullable = false)
     private int version;
 
-    @Column(name = "url")
-    private String url;
-
     @Column(name = "filename", nullable = false)
     private String filename;
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -114,7 +114,6 @@ public class RecordingService {
             recordingEntity.setParentRecording(null);
         }
         recordingEntity.setVersion(createRecordingDTO.getVersion());
-        recordingEntity.setUrl(createRecordingDTO.getUrl());
         recordingEntity.setFilename(createRecordingDTO.getFilename());
         recordingEntity.setDuration(createRecordingDTO.getDuration());
         recordingEntity.setEditInstruction(createRecordingDTO.getEditInstructions());

--- a/src/main/resources/db/migration/V020__RemoveRecordingUrl.sql
+++ b/src/main/resources/db/migration/V020__RemoveRecordingUrl.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.recordings
+DROP COLUMN url;

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/CreateRecordingDTOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/CreateRecordingDTOTest.java
@@ -24,7 +24,6 @@ class CreateRecordingDTOTest {
         captureSession.setId(UUID.randomUUID());
         recordingEntity.setCaptureSession(captureSession);
         recordingEntity.setVersion(1);
-        recordingEntity.setUrl("http://localhost");
         recordingEntity.setFilename("example-filename.txt");
         recordingEntity.setCreatedAt(Timestamp.from(Instant.now()));
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTOTest.java
@@ -51,7 +51,6 @@ public class RecordingDTOTest {
         recordingEntity = new Recording();
         recordingEntity.setId(UUID.randomUUID());
         recordingEntity.setVersion(1);
-        recordingEntity.setUrl("http://localhost:8080");
         recordingEntity.setFilename("test.mp4");
         recordingEntity.setCaptureSession(captureSession);
     }
@@ -96,7 +95,6 @@ public class RecordingDTOTest {
         );
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        recording.setUrl("http://localhost");
         recording.setFilename("example-filename.txt");
         recording.setCreatedAt(Timestamp.from(Instant.now()));
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -88,7 +88,6 @@ class RecordingServiceTest {
 
         recordingEntity.setCaptureSession(captureSession);
         recordingEntity.setVersion(1);
-        recordingEntity.setUrl("http://localhost");
         recordingEntity.setFilename("example-filename.txt");
         recordingEntity.setCreatedAt(Timestamp.from(Instant.now()));
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -105,7 +105,6 @@ public class ReportServiceTest {
 
         recordingEntity.setCaptureSession(captureSessionEntity);
         recordingEntity.setVersion(1);
-        recordingEntity.setUrl("http://localhost");
         recordingEntity.setFilename("example-filename.txt");
         recordingEntity.setCreatedAt(Timestamp.from(Instant.now()));
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/util/HelperFactory.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/util/HelperFactory.java
@@ -180,14 +180,12 @@ public class HelperFactory {
     public Recording createRecording(CaptureSession captureSession,
                                      @Nullable Recording parentRecording,
                                      int version,
-                                     String url,
                                      String filename,
                                      @Nullable Timestamp deletedAt) {
         var recording = new Recording();
         recording.setCaptureSession(captureSession);
         recording.setParentRecording(parentRecording);
         recording.setVersion(version);
-        recording.setUrl(url);
         recording.setFilename(filename);
         recording.setDeletedAt(deletedAt);
         return recording;


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-2981
-->

### Change description
- Remove recordings.url from db
- Ignore URL value in requests attempting to set the value
- Return for URL value RecordingDTO is always null

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Ensure db migration is non breaking (copy current staging + see the running migration on the db is non-breaking)
- Make PUT /recordings/{id} request and set the value of URL in the request body- see no error (value is ignored) -> 20x response
- Make GET /recordings request, see url is null
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
