### PR TITLE
S28 3102: `GET /users` Search Param `appActive`

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "66"
+  revision              = "67"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "67"
+  revision              = "68"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -3263,6 +3263,10 @@ paths:
           in: query
           name: includeDeleted
           type: boolean
+        - description: Filter by users with active app access
+          in: query
+          name: appActive
+          type: boolean
         - description: The page number of search result to return
           format: int32
           in: query

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CourtControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CourtControllerFT.java
@@ -1,15 +1,9 @@
 package uk.gov.hmcts.reform.preapi.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.reform.preapi.dto.CreateCourtDTO;
-import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.util.FunctionalTestBase;
-
-import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,23 +25,5 @@ public class CourtControllerFT extends FunctionalTestBase {
         assertResponseCode(updateResponse, 204);
         var courtResponse2 = assertCourtExists(dto.getId(), true);
         assertThat(courtResponse2.body().jsonPath().getString("name")).isEqualTo(dto.getName());
-    }
-
-    private CreateCourtDTO createCourt() {
-        var roomId = doPostRequest("/testing-support/create-room", false).body().jsonPath().getUUID("roomId");
-        var regionId = doPostRequest("/testing-support/create-region", false).body().jsonPath().getUUID("regionId");
-
-        var dto = new CreateCourtDTO();
-        dto.setId(UUID.randomUUID());
-        dto.setName("Example Court");
-        dto.setCourtType(CourtType.CROWN);
-        dto.setRooms(List.of(roomId));
-        dto.setRegions(List.of(regionId));
-        dto.setLocationCode("123456789");
-        return dto;
-    }
-
-    private Response putCourt(CreateCourtDTO dto) throws JsonProcessingException {
-        return doPutRequest(COURTS_ENDPOINT + "/" + dto.getId(), OBJECT_MAPPER.writeValueAsString(dto), true);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
@@ -160,6 +160,21 @@ public class UserControllerFT extends FunctionalTestBase {
         assertResponseCode(responseActiveFalseByCourt2, 200);
         assertThat(responseActiveFalseByCourt2.body().jsonPath().getUUID("_embedded.userDTOList[0].id"))
             .isEqualTo(user.getId());
+
+        // delete app access
+        user.setAppAccess(Set.of(access1));
+        putUser(user);
+        assertUserExists(user.getId(), true);
+
+        // app access deleted, filter by appActive=false response empty
+        var responseActiveTrueForDeletedCourtAccess = doGetRequest(
+            USERS_ENDPOINT + "?appActive=false&courtId=" + court2.getId() + "&email=" + user.getEmail(),
+            true
+        );
+        assertResponseCode(responseActiveTrueForDeletedCourtAccess, 200);
+        responseActiveTrueForDeletedCourtAccess.prettyPrint();
+        assertThat(responseActiveTrueForDeletedCourtAccess.body().jsonPath().getInt("page.totalElements"))
+            .isEqualTo(0);
     }
 
     private void assertPutResponseMatchesDto(CreateUserDTO dto) {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.preapi.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.preapi.dto.CreateAppAccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;
 import uk.gov.hmcts.reform.preapi.util.FunctionalTestBase;
 
@@ -92,6 +93,75 @@ public class UserControllerFT extends FunctionalTestBase {
         assertThat(getResponse2.body().jsonPath().getUUID("user.id")).isEqualTo(user1.getId());
     }
 
+    @DisplayName("Get users by app active status")
+    @Test
+    void userFilteredByAppActiveStatus() throws JsonProcessingException {
+        var user = createUserDto();
+        var roleId = createRole();
+        var court1 = createCourt();
+        var court2 = createCourt();
+        var access1 = createAppAccessDto(user.getId(), court1.getId(), roleId);
+        var access2 = createAppAccessDto(user.getId(), court2.getId(), roleId);
+        access2.setActive(false);
+        access2.setDefaultCourt(false);
+        user.setAppAccess(Set.of(access1, access2));
+        putCourt(court1);
+        assertCourtExists(court1.getId(), true);
+
+        putCourt(court2);
+        assertCourtExists(court2.getId(), true);
+
+        putUser(user);
+        assertUserExists(user.getId(), true);
+
+        // has at least one active app access
+        var responseActiveTrue = doGetRequest(USERS_ENDPOINT + "?appActive=true&email=" + user.getId(), true);
+        assertResponseCode(responseActiveTrue, 200);
+        assertThat(responseActiveTrue.body().jsonPath().getUUID("_embedded.userDTOList[0].id")).isEqualTo(user.getId());
+
+        // app access for court is active
+        var responseActiveTrueByCourt = doGetRequest(
+            USERS_ENDPOINT + "?appActive=true&courtId=" + court1.getId() + "&email=" + user.getId(),
+            true
+        );
+        assertResponseCode(responseActiveTrueByCourt, 200);
+        assertThat(responseActiveTrueByCourt.body().jsonPath().getUUID("_embedded.userDTOList[0].id"))
+            .isEqualTo(user.getId());
+
+        // app access for court is inactive (searching for active)
+        var responseActiveTrueByCourt2 = doGetRequest(
+            USERS_ENDPOINT + "?appActive=true&courtId=" + court2.getId() + "&email=" + user.getId(),
+            true
+        );
+        assertResponseCode(responseActiveTrueByCourt2, 200);
+        assertThat(responseActiveTrueByCourt2.body().jsonPath().getInt("page.totalElements"))
+            .isEqualTo(0);
+
+        // has at least one inactive app access
+        var responseActiveFalse = doGetRequest(USERS_ENDPOINT + "?appActive=false&email=" + user.getId(), true);
+        assertResponseCode(responseActiveFalse, 200);
+        assertThat(responseActiveFalse.body().jsonPath().getUUID("_embedded.userDTOList[0].id"))
+            .isEqualTo(user.getId());
+
+        // app access for court is active (searching for inactive)
+        var responseActiveFalseByCourt = doGetRequest(
+            USERS_ENDPOINT + "?appActive=false&courtId=" + court1.getId() + "&email=" + user.getId(),
+            true
+        );
+        assertResponseCode(responseActiveFalseByCourt, 200);
+        assertThat(responseActiveFalseByCourt.body().jsonPath().getInt("page.totalElements"))
+            .isEqualTo(0);
+
+        // app access for court is inactive
+        var responseActiveFalseByCourt2 = doGetRequest(
+            USERS_ENDPOINT + "?appActive=false&courtId=" + court2.getId() + "&email=" + user.getId(),
+            true
+        );
+        assertResponseCode(responseActiveFalseByCourt2, 200);
+        assertThat(responseActiveFalseByCourt2.body().jsonPath().getUUID("_embedded.userDTOList[0].id"))
+            .isEqualTo(user.getId());
+    }
+
     private void assertPutResponseMatchesDto(CreateUserDTO dto) {
         var getResponse = doGetRequest(USERS_ENDPOINT + "/" + dto.getId(), true);
         assertResponseCode(getResponse, 200);
@@ -113,5 +183,22 @@ public class UserControllerFT extends FunctionalTestBase {
         dto.setOrganisation("Example Organisation");
         dto.setPhoneNumber("1234567890");
         return dto;
+    }
+
+    private CreateAppAccessDTO createAppAccessDto(UUID userId, UUID courtId, UUID roleId) {
+        var dto = new CreateAppAccessDTO();
+        dto.setId(UUID.randomUUID());
+        dto.setUserId(userId);
+        dto.setCourtId(courtId);
+        dto.setRoleId(roleId);
+        dto.setActive(true);
+        dto.setDefaultCourt(true);
+        return dto;
+    }
+
+    private UUID createRole() {
+        return doPostRequest("/testing-support/create-role?roleName=SUPER_USER", true)
+            .body()
+            .jsonPath().getUUID("roleId");
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
@@ -10,10 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.reform.preapi.Application;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaseDTO;
+import uk.gov.hmcts.reform.preapi.dto.CreateCourtDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateParticipantDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;
+import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -175,6 +178,20 @@ public class FunctionalTestBase {
         return dto;
     }
 
+    protected CreateCourtDTO createCourt() {
+        var roomId = doPostRequest("/testing-support/create-room", false).body().jsonPath().getUUID("roomId");
+        var regionId = doPostRequest("/testing-support/create-region", false).body().jsonPath().getUUID("regionId");
+
+        var dto = new CreateCourtDTO();
+        dto.setId(UUID.randomUUID());
+        dto.setName("Example Court");
+        dto.setCourtType(CourtType.CROWN);
+        dto.setRooms(List.of(roomId));
+        dto.setRegions(List.of(regionId));
+        dto.setLocationCode("123456789");
+        return dto;
+    }
+
     protected String generateRandomCaseReference() {
         return UUID.randomUUID()
             .toString()
@@ -230,5 +247,9 @@ public class FunctionalTestBase {
 
     protected Response putUser(CreateUserDTO dto) throws JsonProcessingException {
         return doPutRequest(USERS_ENDPOINT + "/" + dto.getId(), OBJECT_MAPPER.writeValueAsString(dto), true);
+    }
+
+    protected Response putCourt(CreateCourtDTO dto) throws JsonProcessingException {
+        return doPutRequest(COURTS_ENDPOINT + "/" + dto.getId(), OBJECT_MAPPER.writeValueAsString(dto), true);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserServiceIT.java
@@ -114,14 +114,14 @@ public class UserServiceIT extends IntegrationTestBase {
         entityManager.persist(userEntity);
         entityManager.flush();
 
-        var users = userService.findAllBy(null, null, null, null, null, null, false, Pageable.unpaged()).toList();
+        var users = userService.findAllBy(null, null, null, null, null, null, false, null, Pageable.unpaged()).toList();
 
         Assertions.assertEquals(users.size(), 2);
         Assertions.assertTrue(users.stream().anyMatch(user -> user.getId().equals(portalUserEntity.getId())));
         Assertions.assertTrue(users.stream().anyMatch(user -> user.getId().equals(appUserEntity.getId())));
         Assertions.assertFalse(users.stream().anyMatch(user -> user.getId().equals(userEntity.getId())));
 
-        var users2 = userService.findAllBy(null, null, null, null, null, null, true, Pageable.unpaged()).toList();
+        var users2 = userService.findAllBy(null, null, null, null, null, null, true, null, Pageable.unpaged()).toList();
 
         Assertions.assertEquals(users2.size(), 3);
         Assertions.assertTrue(users2.stream().anyMatch(user -> user.getId().equals(portalUserEntity.getId())));
@@ -137,7 +137,7 @@ public class UserServiceIT extends IntegrationTestBase {
         entityManager.persist(userEntity);
         entityManager.flush();
 
-        var users = userService.findAllBy(null, null, null, null, null, null, false, Pageable.unpaged()).toList();
+        var users = userService.findAllBy(null, null, null, null, null, null, false, null, Pageable.unpaged()).toList();
 
         Assertions.assertEquals(users.size(), 2);
         Assertions.assertTrue(users.stream().anyMatch(user -> user.getId().equals(portalUserEntity.getId())));
@@ -146,7 +146,7 @@ public class UserServiceIT extends IntegrationTestBase {
 
         var message = Assertions.assertThrows(
             AccessDeniedException.class,
-            () -> userService.findAllBy(null, null, null, null, null, null, true, Pageable.unpaged()).toList()
+            () -> userService.findAllBy(null, null, null, null, null, null, true, null, Pageable.unpaged()).toList()
         ).getMessage();
 
         Assertions.assertEquals(message, "Access Denied");
@@ -164,6 +164,7 @@ public class UserServiceIT extends IntegrationTestBase {
             null,
             AccessType.APP,
             false,
+            null,
             PageRequest.of(0, 20)
         );
         Assertions.assertEquals(2, resultApp.getContent().size());
@@ -180,6 +181,7 @@ public class UserServiceIT extends IntegrationTestBase {
             null,
             AccessType.PORTAL,
             false,
+            null,
             PageRequest.of(0, 20)
         );
         Assertions.assertEquals(2, resultPortal.getContent().size());
@@ -188,7 +190,7 @@ public class UserServiceIT extends IntegrationTestBase {
         Assertions.assertEquals(userEntity.getFirstName(), usersPortal.get(0).getFirstName());
         Assertions.assertEquals(portalUserEntity.getId(), usersPortal.get(1).getId());
 
-        var resultAll = userService.findAllBy(null, null, null, null, null, null, false, PageRequest.of(0, 20));
+        var resultAll = userService.findAllBy(null, null, null, null, null, null, false,null, PageRequest.of(0, 20));
         Assertions.assertEquals(3, resultAll.getContent().size());
         var usersAll = resultAll.getContent().stream()
                                 .sorted(Comparator.comparing(BaseUserDTO::getFirstName)).toList();
@@ -205,6 +207,7 @@ public class UserServiceIT extends IntegrationTestBase {
             null,
             AccessType.PORTAL,
             false,
+            null,
             PageRequest.of(0, 20)
         );
         Assertions.assertEquals(1, resultPortal2.getContent().size());

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/UserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/UserController.java
@@ -106,6 +106,11 @@ public class UserController extends PreApiController {
         schema = @Schema(implementation = Boolean.class)
     )
     @Parameter(
+        name = "appActive",
+        description = "Filter by users with active app access",
+        schema = @Schema(implementation = Boolean.class)
+    )
+    @Parameter(
         name = "page",
         description = "The page number of search result to return",
         schema = @Schema(implementation = Integer.class),
@@ -131,6 +136,7 @@ public class UserController extends PreApiController {
             params.getRoleId(),
             params.getAccessType(),
             params.getIncludeDeleted() != null && params.getIncludeDeleted(),
+            params.getAppActive(),
             pageable
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchUsers.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchUsers.java
@@ -14,6 +14,7 @@ public class SearchUsers {
     private UUID roleId;
     private AccessType accessType;
     private Boolean includeDeleted;
+    private Boolean appActive;
 
     public String getName() {
         return name != null && !name.isEmpty() ? name : null;

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/UserRepository.java
@@ -21,6 +21,11 @@ public interface UserRepository extends SoftDeleteRepository<User, UUID> {
         """
         SELECT u FROM User u
         WHERE (:includeDeleted = TRUE OR u.deletedAt IS NULL)
+        AND (:isAppActive IS NULL OR EXISTS(
+            SELECT 1 FROM u.appAccess aa
+            WHERE aa.active = :isAppActive
+            AND (CAST(:courtId as uuid) IS NULL OR aa.court.id = :courtId)
+        ))
         AND (
             CASE
                 WHEN :name IS NULL AND :email IS NULL THEN 1
@@ -56,6 +61,7 @@ public interface UserRepository extends SoftDeleteRepository<User, UUID> {
         @Param("isPortalUser") Boolean isPortalUser,
         @Param("isAppUser") Boolean isAppUser,
         boolean includeDeleted,
+        @Param("isAppActive") Boolean isAppActive,
         Pageable pageable
     );
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/UserRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/UserRepository.java
@@ -25,6 +25,7 @@ public interface UserRepository extends SoftDeleteRepository<User, UUID> {
             SELECT 1 FROM u.appAccess aa
             WHERE aa.active = :isAppActive
             AND (CAST(:courtId as uuid) IS NULL OR aa.court.id = :courtId)
+            AND aa.deletedAt IS NULL
         ))
         AND (
             CASE

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserService.java
@@ -85,6 +85,7 @@ public class UserService {
         UUID role,
         AccessType accessType,
         boolean includeDeleted,
+        Boolean isAppActive,
         Pageable pageable
     ) {
         if (court != null && !courtRepository.existsById(court)) {
@@ -104,6 +105,7 @@ public class UserService {
             accessType == AccessType.PORTAL,
             accessType == AccessType.APP,
             includeDeleted,
+            isAppActive,
             pageable
         ).map(UserDTO::new);
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
@@ -966,8 +966,7 @@ public class UserControllerTest {
             anyBoolean(),
             isNull(),
             any()
-        ))
-            .thenReturn(new PageImpl<>(List.of()));
+        )).thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/users")
                             .with(csrf())

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
@@ -118,6 +118,7 @@ public class UserControllerTest {
             isNull(),
             isNull(),
             eq(false),
+            isNull(),
             any()
         )).thenReturn(userList);
 
@@ -134,6 +135,7 @@ public class UserControllerTest {
             isNull(),
             isNull(),
             eq(false),
+            isNull(),
             any()
         );
     }
@@ -144,7 +146,7 @@ public class UserControllerTest {
         UUID courtId = UUID.randomUUID();
         doThrow(new NotFoundException("Court: " + courtId))
             .when(userService)
-            .findAllBy(isNull(), isNull(), isNull(), eq(courtId), isNull(), isNull(), eq(false), any());
+            .findAllBy(isNull(), isNull(), isNull(), eq(courtId), isNull(), isNull(), eq(false), isNull(), any());
 
         mockMvc.perform(get("/users")
                             .param("courtId", courtId.toString()))
@@ -158,7 +160,7 @@ public class UserControllerTest {
         UUID roleId = UUID.randomUUID();
         doThrow(new NotFoundException("Role: " + roleId))
             .when(userService)
-            .findAllBy(any(), any(), any(), any(), eq(roleId), any(), eq(false), any());
+            .findAllBy(any(), any(), any(), any(), eq(roleId), any(), eq(false), any(), any());
 
         mockMvc.perform(get("/users")
                             .param("roleId", roleId.toString()))
@@ -910,6 +912,7 @@ public class UserControllerTest {
             isNull(),
             isNull(),
             anyBoolean(),
+            isNull(),
             any()
         ))
             .thenReturn(new PageImpl<>(List.of()));
@@ -921,7 +924,7 @@ public class UserControllerTest {
             .andReturn();
 
         verify(userService, times(1))
-            .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(false), any());
+            .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(false), isNull(), any());
     }
 
     @DisplayName("Should set include deleted param to false when set to false")
@@ -935,6 +938,7 @@ public class UserControllerTest {
             isNull(),
             isNull(),
             anyBoolean(),
+            isNull(),
             any()
         )).thenReturn(new PageImpl<>(List.of()));
 
@@ -946,7 +950,7 @@ public class UserControllerTest {
             .andReturn();
 
         verify(userService, times(1))
-            .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(false), any());
+            .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(false), isNull(), any());
     }
 
     @DisplayName("Should set include deleted param to true when set to true")
@@ -960,6 +964,7 @@ public class UserControllerTest {
             isNull(),
             isNull(),
             anyBoolean(),
+            isNull(),
             any()
         ))
             .thenReturn(new PageImpl<>(List.of()));
@@ -972,7 +977,7 @@ public class UserControllerTest {
             .andReturn();
 
         verify(userService, times(1))
-            .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(true), any());
+            .findAllBy(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq(true), isNull(), any());
     }
 
     @DisplayName("Should undelete a user by id and return a 200 response")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
@@ -185,11 +185,12 @@ public class UserServiceTest {
                 false,
                 false,
                 false,
+                null,
                 null
             )
         ).thenReturn(new PageImpl<>(List.of(userEntity, portalUserEntity, appUserEntity)));
 
-        var models = userService.findAllBy(null, null, null, null, null, null, false, null);
+        var models = userService.findAllBy(null, null, null, null, null, null, false, null, null);
         assertThat(models.isEmpty()).isFalse();
         assertThat(models.getTotalElements()).isEqualTo(3);
 
@@ -200,10 +201,10 @@ public class UserServiceTest {
     @Test
     void findAllUsersFirstNameFilterSuccess() {
         when(
-            userRepository.searchAllBy(userEntity.getFirstName(), null, null, null, null, false, false, false, null)
+            userRepository.searchAllBy(userEntity.getFirstName(), null, null, null, null, false, false, false, null, null)
         ).thenReturn(new PageImpl<>(List.of(userEntity)));
 
-        var models = userService.findAllBy(userEntity.getFirstName(), null, null, null, null, null, false, null);
+        var models = userService.findAllBy(userEntity.getFirstName(), null, null, null, null, null, false, null, null);
         assertThat(models.isEmpty()).isFalse();
         assertThat(models.getTotalElements()).isEqualTo(1);
 
@@ -224,10 +225,10 @@ public class UserServiceTest {
         when(courtRepository.existsById(appAccessEntity.getCourt().getId())).thenReturn(true);
         when(roleRepository.existsById(appAccessEntity.getRole().getId())).thenReturn(true);
         when(
-            userRepository.searchAllBy(null, userEntity.getEmail(), null, null, null, false, false, false, null)
+            userRepository.searchAllBy(null, userEntity.getEmail(), null, null, null, false, false, false, null,null)
         ).thenReturn(new PageImpl<>(List.of(userEntity)));
 
-        var models = userService.findAllBy(null, userEntity.getEmail(), null, null, null, null, false, null);
+        var models = userService.findAllBy(null, userEntity.getEmail(), null, null, null, null, false, null, null);
         assertThat(models.isEmpty()).isFalse();
         assertThat(models.getTotalElements()).isEqualTo(1);
 
@@ -257,6 +258,7 @@ public class UserServiceTest {
                 false,
                 false,
                 false,
+                null,
                 null
             )
         ).thenReturn(new PageImpl<>(List.of(userEntity)));
@@ -269,6 +271,7 @@ public class UserServiceTest {
             null,
             null,
             false,
+            null,
             null
         );
         assertThat(models.isEmpty()).isFalse();
@@ -300,6 +303,7 @@ public class UserServiceTest {
                 false,
                 false,
                 false,
+                null,
                 null
             )
         ).thenReturn(new PageImpl<>(List.of(userEntity, appUserEntity)));
@@ -312,6 +316,7 @@ public class UserServiceTest {
             null,
             null,
             false,
+            null,
             null
         );
         assertThat(models.isEmpty()).isFalse();
@@ -356,6 +361,7 @@ public class UserServiceTest {
                 false,
                 false,
                 false,
+                null,
                 null
             )
         ).thenReturn(new PageImpl<>(List.of(userEntity, appUserEntity)));
@@ -368,6 +374,7 @@ public class UserServiceTest {
             appAccessEntity.getRole().getId(),
             null,
             false,
+            null,
             null
         );
         assertThat(models.isEmpty()).isFalse();
@@ -405,7 +412,7 @@ public class UserServiceTest {
 
         assertThrows(
             NotFoundException.class,
-            () -> userService.findAllBy(null, null, null, courtId, null, null, false, null)
+            () -> userService.findAllBy(null, null, null, courtId, null, null, false, null, null)
         );
 
         verify(courtRepository, times(1)).existsById(courtId);
@@ -419,6 +426,7 @@ public class UserServiceTest {
             any(),
             any(),
             eq(false),
+            any(),
             any()
         );
     }
@@ -436,7 +444,7 @@ public class UserServiceTest {
 
         assertThrows(
             NotFoundException.class,
-            () -> userService.findAllBy(null, null, null, null, roleId, null, false, null)
+            () -> userService.findAllBy(null, null, null, null, roleId, null, false, null, null)
         );
 
         verify(courtRepository, never()).existsById(any());
@@ -450,6 +458,7 @@ public class UserServiceTest {
             any(),
             any(),
             eq(false),
+            any(),
             any()
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserServiceTest.java
@@ -201,8 +201,18 @@ public class UserServiceTest {
     @Test
     void findAllUsersFirstNameFilterSuccess() {
         when(
-            userRepository.searchAllBy(userEntity.getFirstName(), null, null, null, null, false, false, false, null, null)
-        ).thenReturn(new PageImpl<>(List.of(userEntity)));
+            userRepository.searchAllBy(
+                userEntity.getFirstName(),
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                false,
+                null,
+                null
+            )).thenReturn(new PageImpl<>(List.of(userEntity)));
 
         var models = userService.findAllBy(userEntity.getFirstName(), null, null, null, null, null, false, null, null);
         assertThat(models.isEmpty()).isFalse();


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)
- S28-3102


### Change description
- Add optional search param `appActive` to `GET /users` endpoint. Filters results by `active` status of app access entities

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- If you use the `email` search param for all of the tests then you will ensure you only get the user you are testing with (instead of having to search through all results to find your test user). 
- For all of the tests you should be able to use the same user with the following details app accesses:
  - App access 1:
    - court= court A 
    - active = true
    - default court = true
  - App access 2: 
    - court: court b
    - active = false
    - default court = false
 - Test: Search users by appActive=true, should see user
 - Test: Search users by appActive=true and courtId = court A, should see user
 - Test: Search user by appActive=true and courtId = court b, should not see user
 - Test: Search user by appActive=false, should see user
 - Test: Search user by appActive=false and courtId = court A, should not see user
 - Test: Search user by appActive=false and courtId = court b, should see user

All above tests are tested via newly implemented functional tests


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

- not breaking- TODO update power apps connector once merged
-
-->
