### PR TITLE
Use hmcts ACR for postgres testcontainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Located in `./bin/init.sh`. Simply run and follow the explanation how to execute
 The project uses [Gradle](https://gradle.org) as a build tool. It already contains
 `./gradlew` wrapper script, so there's no need to install gradle.
 
+In order for integration tests to run, a docker image is needed for the
+postgres testcontainers.
+
+For this to pull from hmcts ACR you must login to the ACR first:
+```bash
+az login # if not logged in already
+az acr login --name hmctspublic
+```
+
 To build the project execute the following command:
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -291,6 +291,8 @@ dependencies {
   implementation group: 'com.azure', name: 'azure-identity', version: '1.13.0'
   implementation group: 'com.azure.resourcemanager', name: 'azure-resourcemanager-mediaservices', version: '2.4.0-beta.1'
 
+  implementation group: 'org.testcontainers', name: 'postgresql', version: '1.19.8'
+
   annotationProcessor('org.hibernate.orm:hibernate-jpamodelgen:6.5.2.Final')
 
 
@@ -305,13 +307,11 @@ dependencies {
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
-  integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.19.8'
   integrationTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.19.8'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
   functionalTestImplementation group: 'io.rest-assured', name: 'rest-assured'
-  functionalTestImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.19.8'
   functionalTestImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.19.8'
 
   smokeTestImplementation sourceSets.main.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -113,5 +113,21 @@
     <packageUrl regex="true">^pkg:maven/com\.microsoft\.azure/msal4j\-persistence\-extension@.*$</packageUrl>
     <cve>CVE-2024-35255</cve>
   </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: commons-compress-1.24.0.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+    <cve>CVE-2024-25710</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+   file name: commons-compress-1.24.0.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+    <cve>CVE-2024-26308</cve>
+  </suppress>
   <!--End of temporary suppression section -->
 </suppressions>

--- a/src/integrationTest/resources/application.properties
+++ b/src/integrationTest/resources/application.properties
@@ -1,2 +1,2 @@
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
-spring.datasource.url=jdbc:tc:postgresql:14://localhost/api
+spring.datasource.url=jdbc:tc:postgresql:16://localhost/api

--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/ContainerImageNameSubstitutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/ContainerImageNameSubstitutor.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.preapi.config;
+
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+public class ContainerImageNameSubstitutor extends ImageNameSubstitutor {
+
+    private final DockerImageName hmctsPostgresDockerImage = DockerImageName
+        .parse("hmctspublic.azurecr.io/imported/postgres:16-alpine")
+        .asCompatibleSubstituteFor("postgres");
+
+    @Override
+    public DockerImageName apply(DockerImageName original) {
+
+        if (original.asCanonicalNameString().contains("postgres")) {
+            return hmctsPostgresDockerImage;
+        }
+
+        return original;
+    }
+
+    @Override
+    protected String getDescription() {
+        return "hmcts acr substitutor";
+    }
+}

--- a/src/main/resources/testcontainers.properties
+++ b/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+image.substitutor=uk.gov.hmcts.reform.preapi.config.ContainerImageNameSubstitutor


### PR DESCRIPTION
### JIRA ticket(s)

- S28-3109

### Change description

- Workaround for the errors with pull limits from dockerhub
- This PR will get the app to pull the postgres image from the public hmcts ACR instead of directly from dockerhub.
