### PR TITLE
S28 3114: Fix 500 Error on `PUT /users/{id}` when `app_access[].role_id` is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/validators/PortalAppAccessValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/validators/PortalAppAccessValidator.java
@@ -46,6 +46,9 @@ public class PortalAppAccessValidator
     }
 
     private boolean isRolePortal(CreateAppAccessDTO dto) {
+        if (dto.getRoleId() == null) {
+            return false;
+        }
         return roleRepository.findById(dto.getRoleId()).map(r -> r.getName().equals("Level 3")).orElse(false);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/validators/PortalAppAccessValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/validators/PortalAppAccessValidatorTest.java
@@ -17,6 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PortalAppAccessValidatorTest {
@@ -110,6 +113,20 @@ public class PortalAppAccessValidatorTest {
         when(roleRepository.findById(dto2.getRoleId())).thenReturn(Optional.of(createRole(false)));
 
         assertFalse(validator.isValid(Set.of(dto1, dto2), context));
+    }
+
+    @DisplayName("Should ignore when role id is null")
+    @Test
+    void shouldBeValidWhenRoleIdIsNull() {
+        var dto1 = createAppAccessDTO(true);
+        var dto2 = createAppAccessDTO(false);
+        dto2.setRoleId(null);
+
+        when(roleRepository.findById(dto1.getRoleId())).thenReturn(Optional.of(createRole(false)));
+        assertTrue(validator.isValid(Set.of(dto1, dto2), context));
+
+        verify(roleRepository, times(1)).findById(dto1.getRoleId());
+        verify(roleRepository, never()).findById(dto2.getRoleId());
     }
 
 


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)

- S28-3114


### Change description
- Fix 500 error when attempting to create/update an app access with a null value in role_id


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Attempt to create a user with an app_access[].role_id as null. See no 500 error, see 400 error telling you to set the value of role_id to not null value



<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
