### PR TITLE
S28-2271: Add `created_at` field to BaseAppAccessDTO

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "68"
+  revision              = "69"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -71,6 +71,10 @@ definitions:
         type: boolean
       court:
         $ref: '#/definitions/CourtDTO'
+      created_at:
+        description: AppAccessCreatedAt
+        format: date-time
+        type: string
       default_court:
         description: AppAccessIsDefaultCourt
         type: boolean

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/base/BaseAppAccessDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/base/BaseAppAccessDTO.java
@@ -35,6 +35,9 @@ public class BaseAppAccessDTO {
     @Schema(description = "AppAccessActive")
     protected boolean active;
 
+    @Schema(description = "AppAccessCreatedAt")
+    private Timestamp createdAt;
+
     public BaseAppAccessDTO(AppAccess access) {
         id = access.getId();
         court = new CourtDTO(access.getCourt());
@@ -42,5 +45,6 @@ public class BaseAppAccessDTO {
         defaultCourt = access.isDefaultCourt();
         lastAccess = access.getLastAccess();
         active = access.isActive();
+        createdAt = access.getCreatedAt();
     }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)

- S28-2271


### Change description
- Add field `created_at` to all app access response objects


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Create a user with an app access. Get user via get endpoint, see app access object has `created_at` field



<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
