### PR TITLE
Fix: Add deserializer for timestamp (jackson config)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ def coverageExclusionList = [
   '**uk/gov/hmcts/reform/preapi/data/exception/PendingMigrationScriptException*',
   '**uk/gov/hmcts/reform/preapi/data/migration/FlywayNoOpStrategy*',
   '**uk/gov/hmcts/reform/preapi/controllers/TestingSupportController*',
+  '**uk/gov/hmcts/reform/preapi/config/JacksonConfiguration.java',
   '**/uk/gov/hmcts/reform/preapi/Application.java',
 ]
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.reform.preapi.dto.CreateUserDTO;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +49,11 @@ public class FunctionalTestBase {
 
     @Value("${TEST_URL:http://localhost:4550}")
     protected String testUrl;
+
+    @BeforeAll
+    static void beforeAll() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @BeforeEach
     void setUp() {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/JacksonConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/JacksonConfiguration.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.reform.preapi.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -12,7 +15,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
+import java.io.IOException;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 
 import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS;
 import static com.fasterxml.jackson.databind.MapperFeature.INFER_BUILDER_TYPE_BINDINGS;
@@ -35,11 +41,26 @@ public class JacksonConfiguration {
 
         JavaTimeModule datetime = new JavaTimeModule();
         datetime.addSerializer(LocalDateSerializer.INSTANCE);
+        datetime.addDeserializer(Timestamp.class, new TimestampDeserializer());
+
         mapper.registerModule(datetime);
         mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
 
         mapper.registerModule(new ParameterNamesModule());
 
         return mapper;
+    }
+
+    private static class TimestampDeserializer extends JsonDeserializer<Timestamp> {
+        @Override
+        public Timestamp deserialize(JsonParser p, DeserializationContext cxt) throws IOException {
+            String timestampStr = p.getText();
+            try {
+                var instant = Instant.parse(timestampStr);
+                return Timestamp.from(instant);
+            } catch (Exception e) {
+                throw new IOException("Failed to parse Date value '" + timestampStr + "'", e);
+            }
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/AuditControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.AuditService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
+import java.text.SimpleDateFormat;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,6 +50,11 @@ class AuditControllerTest {
     private ScheduledTaskRunner taskRunner;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @DisplayName("Should create an audit record with 201 response code")
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/BookingControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,10 +36,9 @@ import uk.gov.hmcts.reform.preapi.services.ShareBookingService;
 import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
@@ -88,6 +88,11 @@ class BookingControllerTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String TEST_URL = "http://localhost";
+
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @DisplayName("Should search for bookings")
     @Test
@@ -233,7 +238,6 @@ class BookingControllerTest {
     @DisplayName("Should create a booking with 201 response code")
     @Test
     void createBookingEndpointCreated() throws Exception {
-
         var caseId = UUID.randomUUID();
         var bookingId = UUID.randomUUID();
         var booking = new CreateBookingDTO();
@@ -246,7 +250,7 @@ class BookingControllerTest {
 
         CaseDTO mockCaseDTO = new CaseDTO();
         when(caseService.findById(caseId)).thenReturn(mockCaseDTO);
-        when(bookingService.upsert(booking)).thenReturn(UpsertResult.CREATED);
+        when(bookingService.upsert(any(CreateBookingDTO.class))).thenReturn(UpsertResult.CREATED);
 
         MvcResult response = mockMvc.perform(put(getPath(bookingId))
                                                  .with(csrf())
@@ -278,7 +282,7 @@ class BookingControllerTest {
 
         CaseDTO mockCaseDTO = new CaseDTO();
         when(caseService.findById(caseId)).thenReturn(mockCaseDTO);
-        when(bookingService.upsert(booking)).thenReturn(UpsertResult.UPDATED);
+        when(bookingService.upsert(any(CreateBookingDTO.class))).thenReturn(UpsertResult.UPDATED);
 
         MvcResult response = mockMvc.perform(put(getPath(bookingId))
                                                  .with(csrf())
@@ -370,10 +374,7 @@ class BookingControllerTest {
         booking.setId(bookingId);
         booking.setCaseId(caseId);
         booking.setParticipants(getCreateParticipantDTOs());
-        booking.setScheduledFor(
-            Timestamp.from(ZonedDateTime.now(ZoneId.of("Europe/London"))
-                               .truncatedTo(ChronoUnit.DAYS).toInstant().minusMillis(1))
-        );
+        booking.setScheduledFor(Timestamp.from(OffsetDateTime.now().minusWeeks(1).toInstant()));
 
         CaseDTO mockCaseDTO = new CaseDTO();
         when(caseService.findById(caseId)).thenReturn(mockCaseDTO);
@@ -383,7 +384,7 @@ class BookingControllerTest {
                                                  .content(OBJECT_MAPPER.writeValueAsString(booking))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
                                                  .accept(MediaType.APPLICATION_JSON_VALUE))
-                                    .andExpect(status().is4xxClientError())
+                                    .andExpect(status().isBadRequest())
                                     .andReturn();
 
         assertThat(response.getResponse().getContentAsString())
@@ -409,7 +410,7 @@ class BookingControllerTest {
 
         CaseDTO mockCaseDTO = new CaseDTO();
         when(caseService.findById(caseId)).thenReturn(mockCaseDTO);
-        when(bookingService.upsert(booking)).thenReturn(UpsertResult.CREATED);
+        when(bookingService.upsert(any(CreateBookingDTO.class))).thenReturn(UpsertResult.CREATED);
 
         mockMvc.perform(put(getPath(bookingId))
                             .with(csrf())
@@ -435,7 +436,7 @@ class BookingControllerTest {
 
         CaseDTO mockCaseDTO = new CaseDTO();
         when(caseService.findById(caseId)).thenReturn(mockCaseDTO);
-        when(bookingService.upsert(booking))
+        when(bookingService.upsert(any(CreateBookingDTO.class)))
             .thenThrow(new ResourceInDeletedStateException("BookingDTO", bookingId.toString()));
 
         MvcResult response = mockMvc.perform(put(getPath(bookingId))

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -304,12 +304,50 @@ public class CaptureSessionControllerTest {
                                                  .content(OBJECT_MAPPER.writeValueAsString(dto))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
                                                  .accept(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isNoContent())
+                                    .andExpect(status().isNoContent())
+                                    .andReturn();
+
+        assertThat(response.getResponse().getContentAsString()).isEqualTo("");
+        assertThat(response.getResponse().getHeaderValue("Location"))
+            .isEqualTo(TEST_URL + "/capture-sessions/" + id);
+    }
+
+    @DisplayName("Should update capture session with 204 response code using raw input")
+    @Test
+    void updateCaptureSessionSuccessRaw() throws Exception {
+        var id = UUID.randomUUID();
+        var dto =  new CreateCaptureSessionDTO();
+        dto.setId(id);
+        dto.setBookingId(UUID.randomUUID());
+        dto.setOrigin(RecordingOrigin.PRE);
+        dto.setStatus(RecordingStatus.RECORDING_AVAILABLE);
+        dto.setStartedAt(Timestamp.from(Instant.parse("2024-07-09T10:58:55Z")));
+
+        when(captureSessionService.upsert(dto)).thenReturn(UpsertResult.UPDATED);
+
+        var response = mockMvc.perform(put(CAPTURE_SESSION_ID_PATH, id)
+                            .with(csrf())
+                            .content("{"
+                                         + "\"id\": \"" + id + "\",\n"
+                                         + "\"booking_id\": \"" + dto.getBookingId().toString() + "\","
+                                         + "\"origin\": \"PRE\",\n"
+                                         + "\"ingest_address\": null,\n"
+                                         + "\"live_output_url\": null,\n"
+                                         + "\"started_at\": \"2024-07-09T10:58:55Z\",\n"
+                                         + "\"started_by_user_id\": null,\n"
+                                         + "\"finished_at\": null,\n"
+                                         + "\"finished_by_user_id\": null,\n"
+                                         + "\"status\": \"RECORDING_AVAILABLE\"\n"
+                                         + "}")
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+               .andExpect(status().isNoContent())
             .andReturn();
 
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
         assertThat(response.getResponse().getHeaderValue("Location"))
             .isEqualTo(TEST_URL + "/capture-sessions/" + id);
+
     }
 
     @DisplayName("Should fail create/update capture session with 400 error when id is null")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -287,6 +288,7 @@ public class CaptureSessionControllerTest {
         dto.setBookingId(UUID.randomUUID());
         dto.setOrigin(RecordingOrigin.PRE);
         dto.setStatus(RecordingStatus.RECORDING_AVAILABLE);
+        dto.setStartedAt(Timestamp.from(Instant.parse("2024-07-09T10:58:55Z")));
 
         when(captureSessionService.upsert(dto)).thenReturn(UpsertResult.UPDATED);
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaptureSessionControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -67,6 +69,11 @@ public class CaptureSessionControllerTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String CAPTURE_SESSION_ID_PATH = "/capture-sessions/{id}";
+
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @DisplayName("Should get capture session by id with 200 response code")
     @Test
@@ -290,7 +297,7 @@ public class CaptureSessionControllerTest {
         dto.setStatus(RecordingStatus.RECORDING_AVAILABLE);
         dto.setStartedAt(Timestamp.from(Instant.parse("2024-07-09T10:58:55Z")));
 
-        when(captureSessionService.upsert(dto)).thenReturn(UpsertResult.UPDATED);
+        when(captureSessionService.upsert(any(CreateCaptureSessionDTO.class))).thenReturn(UpsertResult.UPDATED);
 
         MvcResult response = mockMvc.perform(put(CAPTURE_SESSION_ID_PATH, id)
                                                  .with(csrf())

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CaseControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +27,7 @@ import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.CaseService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -71,6 +73,10 @@ class CaseControllerTest {
 
     private static final String CASES_ID_PATH = "/cases/{id}";
 
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @DisplayName("Should get case by ID with 200 response code")
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/CourtControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.preapi.controller;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.CourtService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.UUID;
 
@@ -55,6 +57,11 @@ public class CourtControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String TEST_URL = "http://localhost";
+
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @DisplayName("Should get court by id with 200 response code")
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.preapi.controller;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.reform.preapi.services.RecordingService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.UUID;
 
@@ -64,6 +66,11 @@ class RecordingControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String TEST_URL = "http://localhost";
+
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
 
     @DisplayName("Should get recording by ID with 200 response code")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.preapi.controller;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.preapi.services.UserService;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -76,6 +78,11 @@ public class UserControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String TEST_URL = "http://localhost";
+
+    @BeforeAll
+    static void setUp() {
+        OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
+    }
 
     @DisplayName("Should get user by id with 200 response code")
     @Test


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-0000
-->

### Change description
- Add deserializer for timestamps (fix parse error for create/update endpoints with timestamp body params)

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
