### PR TITLE
S28 3151: Asset Playback (AMS Implementation)

### DIFF
--- a/charts/pre-api/values.dev.template.yaml
+++ b/charts/pre-api/values.dev.template.yaml
@@ -16,7 +16,7 @@ java:
     AZURE_TENANT_ID: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
     MEDIA_KIND_SUBSCRIPTION: pre-mediakind-stg
     PLATFORM_ENV_TAG: Staging
-    MEDIA_SERVICE: MediaKind
+    MEDIA_SERVICE: AzureMediaService
     AZURE_INGEST_SA: preingestsatest
     AZURE_FINAL_SA: prefinalsatest
   # Don't modify below here

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
@@ -1,14 +1,27 @@
 package uk.gov.hmcts.reform.preapi.media;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.mediaservices.fluent.AzureMediaServices;
 import com.azure.resourcemanager.mediaservices.fluent.models.AssetInner;
+import com.azure.resourcemanager.mediaservices.fluent.models.ContentKeyPolicyInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.JobInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.ListPathsResponseInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.LiveEventInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.LiveOutputInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.StreamingEndpointInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.StreamingLocatorInner;
+import com.azure.resourcemanager.mediaservices.fluent.models.StreamingPolicyInner;
+import com.azure.resourcemanager.mediaservices.models.ArmStreamingEndpointCurrentSku;
+import com.azure.resourcemanager.mediaservices.models.ContentKeyPolicyClearKeyConfiguration;
+import com.azure.resourcemanager.mediaservices.models.ContentKeyPolicyOption;
+import com.azure.resourcemanager.mediaservices.models.ContentKeyPolicyRestrictionTokenType;
+import com.azure.resourcemanager.mediaservices.models.ContentKeyPolicySymmetricTokenKey;
+import com.azure.resourcemanager.mediaservices.models.ContentKeyPolicyTokenRestriction;
+import com.azure.resourcemanager.mediaservices.models.DefaultKey;
+import com.azure.resourcemanager.mediaservices.models.EnabledProtocols;
+import com.azure.resourcemanager.mediaservices.models.EnvelopeEncryption;
 import com.azure.resourcemanager.mediaservices.models.Hls;
 import com.azure.resourcemanager.mediaservices.models.IpAccessControl;
 import com.azure.resourcemanager.mediaservices.models.IpRange;
@@ -22,6 +35,8 @@ import com.azure.resourcemanager.mediaservices.models.LiveEventInputProtocol;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreview;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreviewAccessControl;
 import com.azure.resourcemanager.mediaservices.models.LiveEventResourceState;
+import com.azure.resourcemanager.mediaservices.models.StreamingEndpointResourceState;
+import com.azure.resourcemanager.mediaservices.models.StreamingPolicyContentKeys;
 import jakarta.transaction.Transactional;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,8 +58,12 @@ import uk.gov.hmcts.reform.preapi.exception.UnknownServerException;
 import uk.gov.hmcts.reform.preapi.media.storage.AzureFinalStorageService;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -54,17 +73,20 @@ import java.util.logging.Logger;
 @Service
 @Log4j2
 public class AzureMediaService implements IMediaService {
+    private static final String LOCATION = "uksouth";
+    private static final String ENCODE_TO_MP4_TRANSFORM = "EncodeToMP4";
+    private static final String STREAMING_POLICY_CLEAR_KEY = "Predefined_ClearKey";
+    private static final String DEFAULT_STREAMING_ENDPOINT = "default";
+
     private final String resourceGroup;
     private final String accountName;
     private final String ingestStorageAccount;
     private final String finalStorageAccount;
     private final String environmentTag;
-
+    private final String issuer;
+    private final String symmetricKey;
     private final AzureMediaServices amsClient;
     private final AzureFinalStorageService azureFinalStorageService;
-
-    private static final String LOCATION = "uksouth";
-    private static final String ENCODE_TO_MP4_TRANSFORM = "EncodeToMP4";
 
     @Autowired
     public AzureMediaService(
@@ -73,6 +95,8 @@ public class AzureMediaService implements IMediaService {
         @Value("${azure.ingestStorage.accountName}") String ingestStorageAccount,
         @Value("${azure.finalStorage.accountName}") String finalStorageAccount,
         @Value("${platform-env}") String env,
+        @Value("${mediakind.issuer:}") String issuer,
+        @Value("${mediakind.symmetricKey:}") String symmetricKey,
         AzureMediaServices amsClient,
         AzureFinalStorageService azureFinalStorageService) {
         this.resourceGroup = resourceGroup;
@@ -80,26 +104,186 @@ public class AzureMediaService implements IMediaService {
         this.ingestStorageAccount = ingestStorageAccount;
         this.finalStorageAccount = finalStorageAccount;
         this.environmentTag = env;
+        this.issuer = issuer;
+        this.symmetricKey = symmetricKey;
         this.amsClient = amsClient;
         this.azureFinalStorageService = azureFinalStorageService;
     }
 
     @Override
-    public PlaybackDTO playAsset(String assetId, String userId) {
-        throw new UnsupportedOperationException();
+    public PlaybackDTO playAsset(String assetName, String userId) {
+        getAsset(assetName);
+        // todo check asset has files
+        createContentKeyPolicy(userId, Base64.getEncoder().encodeToString(symmetricKey.getBytes()));
+        assertStreamingPolicyExists(userId);
+        refreshStreamingLocatorForUser(userId, assetName);
+
+        var hostName = "https://" + assertStreamingEndpointExists(DEFAULT_STREAMING_ENDPOINT).hostname();
+        var paths = amsClient.getStreamingLocators().listPaths(resourceGroup, accountName, userId);
+        var manifest = hostName + paths.streamingPaths().getFirst().paths().getFirst();
+
+        return new PlaybackDTO(
+            manifest,
+            manifest,
+            null,
+            JWT.create()
+                .withIssuer(issuer)
+                .withAudience(userId)
+                .withNotBefore(Instant.now().minus(5, ChronoUnit.MINUTES))
+                .withExpiresAt(Instant.now().plus(1, ChronoUnit.DAYS))
+                .sign(Algorithm.HMAC256(symmetricKey))
+        );
+    }
+
+    private StreamingEndpointInner assertStreamingEndpointExists(String endpointName) {
+        try {
+            var endpoint = amsClient.getStreamingEndpoints()
+                .get(resourceGroup, accountName, endpointName);
+            if (endpoint.resourceState() != StreamingEndpointResourceState.RUNNING) {
+                amsClient.getStreamingEndpoints()
+                    .start(resourceGroup, accountName, endpointName);
+                endpoint = amsClient.getStreamingEndpoints()
+                    .get(resourceGroup, accountName, endpointName);
+            }
+            return endpoint;
+        } catch (IllegalArgumentException e) {
+            throw new UnknownServerException("Unable to communicate with Azure.");
+        } catch (ManagementException e) {
+            if (e.getResponse().getStatusCode() == 404) {
+                var endpoint = amsClient.getStreamingEndpoints()
+                    .create(
+                        resourceGroup,
+                        accountName,
+                        DEFAULT_STREAMING_ENDPOINT,
+                        new StreamingEndpointInner()
+                            .withLocation(LOCATION)
+                            .withTags(Map.of(
+                                "environment", environmentTag,
+                                "application", "pre-recorded evidence"
+                            ))
+                            .withDescription("Default streaming endpoint")
+                            .withScaleUnits(0)
+                            // todo fix this
+                            .withSku(new ArmStreamingEndpointCurrentSku())
+                    );
+                amsClient.getStreamingEndpoints()
+                    .start(resourceGroup, accountName, endpointName);
+                return endpoint;
+            }
+            throw e;
+        }
+    }
+
+    private void refreshStreamingLocatorForUser(String userId, String assetName) {
+        try {
+            amsClient.getStreamingLocators().delete(resourceGroup, accountName, userId);
+        } catch (IllegalArgumentException e) {
+            throw new UnknownServerException("Unable to communicate with Azure. " + e.getMessage());
+        } catch (ManagementException e) {
+            if (e.getResponse().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+
+        amsClient.getStreamingLocators()
+            .create(
+                resourceGroup,
+                accountName,
+                userId,
+                new StreamingLocatorInner()
+                    .withAssetName(assetName)
+                    .withStreamingPolicyName(STREAMING_POLICY_CLEAR_KEY)
+                    .withDefaultContentKeyPolicyName(userId)
+                    .withEndTime(Instant.now().plusSeconds(3600).atZone(ZoneId.of("UTC")).toOffsetDateTime())
+            );
+    }
+
+    private void assertStreamingPolicyExists(String defaultContentKeyPolicy) {
+        try {
+            amsClient.getStreamingPolicies()
+                .get(resourceGroup, accountName, STREAMING_POLICY_CLEAR_KEY);
+        } catch (IllegalArgumentException e) {
+            throw new UnknownServerException("Unable to communicate with Azure. " + e.getMessage());
+        } catch (ManagementException e) {
+            if (e.getResponse().getStatusCode() == 404) {
+                amsClient.getStreamingPolicies()
+                    .create(
+                        resourceGroup,
+                        accountName,
+                        STREAMING_POLICY_CLEAR_KEY,
+                        new StreamingPolicyInner()
+                            .withDefaultContentKeyPolicyName(defaultContentKeyPolicy)
+                            .withEnvelopeEncryption(
+                                new EnvelopeEncryption()
+                                    .withEnabledProtocols(
+                                        new EnabledProtocols()
+                                            .withDash(true)
+                                            .withHls(true)
+                                            .withSmoothStreaming(false)
+                                            .withDownload(false))
+                                    .withContentKeys(
+                                        new StreamingPolicyContentKeys()
+                                            .withDefaultKey(new DefaultKey()
+                                                                .withLabel("ContentKey_AES")
+                                                                .withPolicyName(defaultContentKeyPolicy)))
+                            )
+                    );
+                return;
+            }
+            throw e;
+        }
+    }
+
+    private void createContentKeyPolicy(String userId, String key) {
+        try {
+            amsClient.getContentKeyPolicies()
+                .get(resourceGroup, accountName, userId);
+        } catch (IllegalArgumentException e) {
+            throw new UnknownServerException("Unable to communicate with Azure. " + e.getMessage());
+        } catch (ManagementException e) {
+            if (e.getResponse().getStatusCode() == 404) {
+                amsClient.getContentKeyPolicies()
+                    .createOrUpdate(
+                        resourceGroup,
+                        accountName,
+                        userId,
+                        new ContentKeyPolicyInner()
+                            .withDescription("Content key policy for user: " + userId)
+                            .withOptions(List.of(
+                                new ContentKeyPolicyOption()
+                                    .withName("key")
+                                    .withRestriction(
+                                        new ContentKeyPolicyTokenRestriction()
+                                            .withIssuer(issuer)
+                                            .withAudience(userId)
+                                            .withRestrictionTokenType(
+                                                ContentKeyPolicyRestrictionTokenType.JWT)
+                                            .withPrimaryVerificationKey(
+                                                new ContentKeyPolicySymmetricTokenKey()
+                                                    .withKeyValue(key.getBytes())))
+                                    .withConfiguration(new ContentKeyPolicyClearKeyConfiguration())))
+                    );
+                return;
+            }
+            throw e;
+        }
     }
 
     @Override
     public GenerateAssetResponseDTO importAsset(GenerateAssetDTO generateAssetDTO) throws InterruptedException {
-        createAsset(generateAssetDTO.getTempAsset(),
-                    generateAssetDTO.getDescription(),
-                    generateAssetDTO.getSourceContainer(),
-                    true);
+        createAsset(
+            generateAssetDTO.getTempAsset(),
+            generateAssetDTO.getDescription(),
+            generateAssetDTO.getSourceContainer(),
+            true
+        );
 
-        createAsset(generateAssetDTO.getFinalAsset(),
-                    generateAssetDTO.getDescription(),
-                    generateAssetDTO.getDestinationContainer(),
-                    true);
+        createAsset(
+            generateAssetDTO.getFinalAsset(),
+            generateAssetDTO.getDescription(),
+            generateAssetDTO.getDestinationContainer(),
+            true
+        );
 
         var jobName = encodeToMp4(generateAssetDTO.getTempAsset(), generateAssetDTO.getFinalAsset());
 
@@ -116,7 +300,7 @@ public class AzureMediaService implements IMediaService {
     @Override
     public AssetDTO getAsset(String assetName) {
         try {
-            return  new AssetDTO(amsClient.getAssets().get(resourceGroup, accountName, assetName));
+            return new AssetDTO(amsClient.getAssets().get(resourceGroup, accountName, assetName));
         } catch (IllegalArgumentException e) {
             throw new UnknownServerException("Unable to communicate with Azure. " + e.getMessage());
         } catch (ManagementException e) {
@@ -151,7 +335,7 @@ public class AzureMediaService implements IMediaService {
 
         assertStreamingLocatorExists(liveEventId);
         var paths = amsClient.getStreamingLocators()
-                             .listPaths(resourceGroup, accountName, getSanitisedId(liveEventId));
+            .listPaths(resourceGroup, accountName, getSanitisedId(liveEventId));
 
         return parseLiveOutputUrlFromStreamingLocatorPaths(hostname, paths);
     }
@@ -179,27 +363,27 @@ public class AzureMediaService implements IMediaService {
         log.info("Creating streaming endpoint: {}", streamingEndpointName);
         try {
             return amsClient.getStreamingEndpoints()
-                            .create(
-                                resourceGroup,
-                                accountName,
-                                streamingEndpointName,
-                                new StreamingEndpointInner()
-                                    .withLocation("UK South")
-                                    .withTags(Map.of(
-                                        "environment", this.environmentTag,
-                                        "application", "pre-recorded evidence",
-                                        "businessArea", "cross-cutting",
-                                        "builtFrom", "azure portal"
-                                    ))
-                                    .withDescription(
-                                        "Streaming Endpoint for " + streamingEndpointName
-                                    )
-                            );
+                .create(
+                    resourceGroup,
+                    accountName,
+                    streamingEndpointName,
+                    new StreamingEndpointInner()
+                        .withLocation("UK South")
+                        .withTags(Map.of(
+                            "environment", this.environmentTag,
+                            "application", "pre-recorded evidence",
+                            "businessArea", "cross-cutting",
+                            "builtFrom", "azure portal"
+                        ))
+                        .withDescription(
+                            "Streaming Endpoint for " + streamingEndpointName
+                        )
+                );
         } catch (ManagementException e) {
             if (e.getResponse().getStatusCode() == 409) {
                 log.info("Streaming endpoint {} already exists", streamingEndpointName);
                 return amsClient.getStreamingEndpoints()
-                                .get(resourceGroup, accountName, streamingEndpointName);
+                    .get(resourceGroup, accountName, streamingEndpointName);
             }
             throw e;
         }
@@ -215,10 +399,12 @@ public class AzureMediaService implements IMediaService {
                 .withStreamingPolicyName("Predefined_ClearStreamingOnly")
                 .withStreamingLocatorId(liveEventId);
 
-            amsClient.getStreamingLocators().create(resourceGroup,
-                                                    accountName,
-                                                    sanitisedLiveEventId,
-                                                    streamingLocatorProperties);
+            amsClient.getStreamingLocators().create(
+                resourceGroup,
+                accountName,
+                sanitisedLiveEventId,
+                streamingLocatorProperties
+            );
         } catch (ManagementException e) {
             if (e.getResponse().getStatusCode() == 409) {
                 Logger.getAnonymousLogger().info("Streaming locator already exists");
@@ -342,7 +528,8 @@ public class AzureMediaService implements IMediaService {
                     accountName,
                     liveEventName,
                     new LiveEventActionInput()
-                        .withRemoveOutputsOnStop(true));
+                        .withRemoveOutputsOnStop(true)
+                );
             log.info("Stopped live event: {}", liveEventName);
             log.info("Deleting live event: {}", liveEventName);
             amsClient.getLiveEvents().delete(resourceGroup, accountName, liveEventName);
@@ -443,8 +630,8 @@ public class AzureMediaService implements IMediaService {
             }
             job = amsClient.getJobs().get(resourceGroup, accountName, ENCODE_TO_MP4_TRANSFORM, jobName);
         } while (!job.state().equals(JobState.FINISHED)
-                 && !job.state().equals(JobState.ERROR)
-                 && !job.state().equals(JobState.CANCELED));
+            && !job.state().equals(JobState.ERROR)
+            && !job.state().equals(JobState.CANCELED));
 
         return job.state();
     }
@@ -493,10 +680,12 @@ public class AzureMediaService implements IMediaService {
                              CaptureSessionDTO captureSession,
                              String containerName,
                              boolean isFinal) {
-        createAsset(assetName,
-                    captureSession.getBookingId().toString(),
-                    containerName,
-                    isFinal);
+        createAsset(
+            assetName,
+            captureSession.getBookingId().toString(),
+            containerName,
+            isFinal
+        );
     }
 
     private void createAsset(String assetName,
@@ -570,7 +759,8 @@ public class AzureMediaService implements IMediaService {
                                                                        .withAddress("0.0.0.0")
                                                                        .withSubnetPrefixLength(0)
                                                 )))
-                            )));
+                            ))
+            );
         } catch (IllegalArgumentException e) {
             throw new UnknownServerException("Unable to communicate with Azure.  " + e.getMessage());
         } catch (ManagementException e) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
@@ -163,7 +163,6 @@ public class AzureMediaService implements IMediaService {
                             ))
                             .withDescription("Default streaming endpoint")
                             .withScaleUnits(0)
-                            // todo fix this
                             .withSku(new ArmStreamingEndpointCurrentSku())
                     );
                 amsClient.getStreamingEndpoints()

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/AzureMediaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/AzureMediaServiceTest.java
@@ -4,23 +4,29 @@ import com.azure.core.http.HttpResponse;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.mediaservices.fluent.AssetsClient;
 import com.azure.resourcemanager.mediaservices.fluent.AzureMediaServices;
+import com.azure.resourcemanager.mediaservices.fluent.ContentKeyPoliciesClient;
 import com.azure.resourcemanager.mediaservices.fluent.JobsClient;
 import com.azure.resourcemanager.mediaservices.fluent.LiveEventsClient;
 import com.azure.resourcemanager.mediaservices.fluent.LiveOutputsClient;
 import com.azure.resourcemanager.mediaservices.fluent.StreamingEndpointsClient;
 import com.azure.resourcemanager.mediaservices.fluent.StreamingLocatorsClient;
+import com.azure.resourcemanager.mediaservices.fluent.StreamingPoliciesClient;
 import com.azure.resourcemanager.mediaservices.fluent.models.AssetInner;
+import com.azure.resourcemanager.mediaservices.fluent.models.ContentKeyPolicyInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.JobInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.ListPathsResponseInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.LiveEventInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.LiveOutputInner;
 import com.azure.resourcemanager.mediaservices.fluent.models.StreamingEndpointInner;
+import com.azure.resourcemanager.mediaservices.fluent.models.StreamingLocatorInner;
+import com.azure.resourcemanager.mediaservices.fluent.models.StreamingPolicyInner;
 import com.azure.resourcemanager.mediaservices.models.JobInputAsset;
 import com.azure.resourcemanager.mediaservices.models.JobOutputAsset;
 import com.azure.resourcemanager.mediaservices.models.JobState;
 import com.azure.resourcemanager.mediaservices.models.LiveEventEndpoint;
 import com.azure.resourcemanager.mediaservices.models.LiveEventInput;
 import com.azure.resourcemanager.mediaservices.models.LiveEventResourceState;
+import com.azure.resourcemanager.mediaservices.models.StreamingEndpointResourceState;
 import com.azure.resourcemanager.mediaservices.models.StreamingPath;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,21 +61,22 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = AzureMediaService.class)
 public class AzureMediaServiceTest {
-    @MockBean
-    private AzureMediaServices amsClient;
-
-    @MockBean
-    private AzureFinalStorageService azureFinalStorageService;
-
     private final String resourceGroup = "test-resource-group";
     private final String accountName = "test-account-name";
     private final String ingestSa = "test-ingest-sa";
     private final String finalSa = "test-final-sa";
     private final String env = "test-env";
+    private final String issuer = "test-issuer";
+    private final String symmetricKey = "abc";
 
     private AzureMediaService mediaService;
-
     private CaptureSessionDTO captureSession;
+
+    @MockBean
+    private AzureMediaServices amsClient;
+
+    @MockBean
+    private AzureFinalStorageService azureFinalStorageService;
 
     @BeforeEach
     void setUp() {
@@ -79,6 +86,8 @@ public class AzureMediaServiceTest {
             ingestSa,
             finalSa,
             env,
+            issuer,
+            symmetricKey,
             amsClient,
             azureFinalStorageService
         );
@@ -170,15 +179,6 @@ public class AzureMediaServiceTest {
         assertThat(models.getFirst().getStorageAccountName()).isEqualTo("storage-account-name");
     }
 
-    @DisplayName("Should throw Unsupported Operation Exception when method is not defined")
-    @Test
-    void unsupportedOperationException() {
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> mediaService.playAsset("test-asset-name", "test-user-id")
-        );
-    }
-
     @DisplayName("Should accept a request to import an asset and return a job response for encoding to mp4")
     @Test
     void importAssetSuccess() throws InterruptedException {
@@ -192,11 +192,13 @@ public class AzureMediaServiceTest {
         var mockAssetsClient = mock(AssetsClient.class);
         when(amsClient.getAssets()).thenReturn(mockAssetsClient);
 
-        var generateAssetDTO  = new GenerateAssetDTO("my-source-container",
-                                                     "my-destination-container",
-                                                     "tmp-asset",
-                                                     "final-asset",
-                                                     "unit test import asset");
+        var generateAssetDTO = new GenerateAssetDTO(
+            "my-source-container",
+            "my-destination-container",
+            "tmp-asset",
+            "final-asset",
+            "unit test import asset"
+        );
 
         var result = mediaService.importAsset(generateAssetDTO);
 
@@ -205,20 +207,24 @@ public class AzureMediaServiceTest {
         var sourceContainerArgument = ArgumentCaptor.forClass(AssetInner.class);
 
         verify(mockAssetsClient, times(1))
-                                   .createOrUpdate(eq(resourceGroup),
-                                                   eq(accountName),
-                                                   eq(generateAssetDTO.getTempAsset()),
-                                                   sourceContainerArgument.capture());
+            .createOrUpdate(
+                eq(resourceGroup),
+                eq(accountName),
+                eq(generateAssetDTO.getTempAsset()),
+                sourceContainerArgument.capture()
+            );
 
         assertThat(sourceContainerArgument.getValue().container()).isEqualTo(generateAssetDTO.getSourceContainer());
 
         var destinationContainerArgument = ArgumentCaptor.forClass(AssetInner.class);
 
         verify(mockAssetsClient, times(1))
-                                   .createOrUpdate(eq(resourceGroup),
-                                                   eq(accountName),
-                                                   eq(generateAssetDTO.getFinalAsset()),
-                                                   destinationContainerArgument.capture());
+            .createOrUpdate(
+                eq(resourceGroup),
+                eq(accountName),
+                eq(generateAssetDTO.getFinalAsset()),
+                destinationContainerArgument.capture()
+            );
 
         assertThat(destinationContainerArgument.getValue().container())
             .isEqualTo(generateAssetDTO.getDestinationContainer());
@@ -256,11 +262,13 @@ public class AzureMediaServiceTest {
         var mockAssetsClient = mock(AssetsClient.class);
         when(amsClient.getAssets()).thenReturn(mockAssetsClient);
 
-        var generateAssetDTO  = new GenerateAssetDTO("my-source-container",
-                                                     "my-destination-container",
-                                                     "tmp-asset",
-                                                     "final-asset",
-                                                     "unit test import asset");
+        var generateAssetDTO = new GenerateAssetDTO(
+            "my-source-container",
+            "my-destination-container",
+            "tmp-asset",
+            "final-asset",
+            "unit test import asset"
+        );
 
         var result = mediaService.importAsset(generateAssetDTO);
 
@@ -269,20 +277,24 @@ public class AzureMediaServiceTest {
         var sourceContainerArgument = ArgumentCaptor.forClass(AssetInner.class);
 
         verify(mockAssetsClient, times(1))
-            .createOrUpdate(eq(resourceGroup),
-                            eq(accountName),
-                            eq(generateAssetDTO.getTempAsset()),
-                            sourceContainerArgument.capture());
+            .createOrUpdate(
+                eq(resourceGroup),
+                eq(accountName),
+                eq(generateAssetDTO.getTempAsset()),
+                sourceContainerArgument.capture()
+            );
 
         assertThat(sourceContainerArgument.getValue().container()).isEqualTo(generateAssetDTO.getSourceContainer());
 
         var destinationContainerArgument = ArgumentCaptor.forClass(AssetInner.class);
 
         verify(mockAssetsClient, times(1))
-            .createOrUpdate(eq(resourceGroup),
-                            eq(accountName),
-                            eq(generateAssetDTO.getFinalAsset()),
-                            destinationContainerArgument.capture());
+            .createOrUpdate(
+                eq(resourceGroup),
+                eq(accountName),
+                eq(generateAssetDTO.getFinalAsset()),
+                destinationContainerArgument.capture()
+            );
 
         assertThat(destinationContainerArgument.getValue().container())
             .isEqualTo(generateAssetDTO.getDestinationContainer());
@@ -422,10 +434,12 @@ public class AzureMediaServiceTest {
         var shortenedLiveEventId = sanitisedLiveEventId.substring(0, 23);
 
         when(mockStreamingEndpointsClient
-                 .create(eq(resourceGroup),
-                         eq(accountName),
-                         eq("c154d36ecab44aaaa4c711d"),
-                         any(StreamingEndpointInner.class))
+                 .create(
+                     eq(resourceGroup),
+                     eq(accountName),
+                     eq("c154d36ecab44aaaa4c711d"),
+                     any(StreamingEndpointInner.class)
+                 )
         ).thenReturn(mockStreamingEndpointInner);
 
         var mockStreamingLocatorsClient = mock(StreamingLocatorsClient.class);
@@ -444,13 +458,15 @@ public class AzureMediaServiceTest {
         assertThat(response).isEqualTo("https://pre-example.com/path1");
 
         Mockito.verify(mockStreamingEndpointsClient, Mockito.times(1))
-               .start(resourceGroup, accountName, shortenedLiveEventId);
+            .start(resourceGroup, accountName, shortenedLiveEventId);
 
         Mockito.verify(mockStreamingLocatorsClient, Mockito.times(1))
-               .create(eq(resourceGroup),
-                       eq(accountName),
-                       eq(sanitisedLiveEventId),
-                       any());
+            .create(
+                eq(resourceGroup),
+                eq(accountName),
+                eq(sanitisedLiveEventId),
+                any()
+            );
     }
 
     @DisplayName("Should complete play live event successfully, all required resources already exist")
@@ -476,10 +492,12 @@ public class AzureMediaServiceTest {
         when(mockHttpResponse.getStatusCode()).thenReturn(409);
 
         when(mockStreamingEndpointsClient
-                 .create(eq(resourceGroup),
-                         eq(accountName),
-                         eq("c154d36ecab44aaaa4c711d"),
-                         any(StreamingEndpointInner.class))
+                 .create(
+                     eq(resourceGroup),
+                     eq(accountName),
+                     eq("c154d36ecab44aaaa4c711d"),
+                     any(StreamingEndpointInner.class)
+                 )
         ).thenThrow(new ManagementException("Already exists", mockHttpResponse));
 
         when(mockStreamingEndpointsClient.get(resourceGroup, accountName, shortenedLiveEventId))
@@ -577,10 +595,12 @@ public class AzureMediaServiceTest {
         when(amsClient.getStreamingEndpoints()).thenReturn(mockStreamingEndpointsClient);
 
         when(mockStreamingEndpointsClient
-                 .create(eq(resourceGroup),
-                         eq(accountName),
-                         eq("c154d36ecab44aaaa4c711d"),
-                         any(StreamingEndpointInner.class))
+                 .create(
+                     eq(resourceGroup),
+                     eq(accountName),
+                     eq("c154d36ecab44aaaa4c711d"),
+                     any(StreamingEndpointInner.class)
+                 )
         ).thenThrow(new ManagementException("bad request", mock(HttpResponse.class)));
 
         assertThrows(ManagementException.class, () -> mediaService.playLiveEvent(liveEventId));
@@ -605,10 +625,12 @@ public class AzureMediaServiceTest {
         when(amsClient.getStreamingEndpoints()).thenReturn(mockStreamingEndpointsClient);
 
         when(mockStreamingEndpointsClient
-                 .create(eq(resourceGroup),
-                         eq(accountName),
-                         eq("c154d36ecab44aaaa4c711d"),
-                         any(StreamingEndpointInner.class))
+                 .create(
+                     eq(resourceGroup),
+                     eq(accountName),
+                     eq("c154d36ecab44aaaa4c711d"),
+                     any(StreamingEndpointInner.class)
+                 )
         ).thenReturn(mockStreamingEndpointInner);
 
         var mockStreamingLocatorsClient = mock(StreamingLocatorsClient.class);
@@ -1138,7 +1160,7 @@ public class AzureMediaServiceTest {
     @DisplayName("Should throw error when error occurs deleting streaming locator")
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     @Test
-    void stopLiveEventStreamingLocatorError()  {
+    void stopLiveEventStreamingLocatorError() {
         var liveEventName = captureSession.getId().toString().replace("-", "");
         var recordingId = UUID.randomUUID();
         var assetsClient = mockAssetsClient();
@@ -1244,6 +1266,328 @@ public class AzureMediaServiceTest {
         verify(liveOutputClient, times(1)).delete(any(), any(), any(), any());
     }
 
+    @DisplayName("Should return playback details for asset")
+    @Test
+    void playAssetSuccess() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+        var contentKeyPolicyClient = mockContentKeyPoliciesClient();
+        var streamingPolicyClient = mockStreamingPoliciesClient();
+        var streamingLocatorClient = mockStreamingLocatorClient();
+        var streamingEndpointClient = mockStreamingEndpointClient();
+
+        when(assetClient.get(resourceGroup, accountName, assetName))
+            .thenReturn(mock(AssetInner.class));
+        when(contentKeyPolicyClient.get(resourceGroup, accountName, userId))
+            .thenReturn(mock(ContentKeyPolicyInner.class));
+        when(streamingPolicyClient.get(resourceGroup, accountName, "Predefined_ClearKey"))
+            .thenReturn(mock(StreamingPolicyInner.class));
+        when(streamingLocatorClient.create(
+                 eq(resourceGroup),
+                 eq(accountName),
+                 eq("Predefined_ClearKey"),
+                 any(StreamingLocatorInner.class)
+             )
+        ).thenReturn(mock(StreamingLocatorInner.class));
+        var mockEndpoint = mock(StreamingEndpointInner.class);
+        when(streamingEndpointClient.get(resourceGroup, accountName, "default"))
+            .thenReturn(mockEndpoint);
+        when(mockEndpoint.resourceState()).thenReturn(StreamingEndpointResourceState.RUNNING);
+        when(mockEndpoint.hostname()).thenReturn("example.com");
+        var streamingPaths = List.of(
+            new StreamingPath()
+                .withPaths(List.of("/example.ism"))
+        );
+        when(streamingLocatorClient.listPaths(resourceGroup, accountName, userId))
+            .thenReturn(new ListPathsResponseInner().withStreamingPaths(streamingPaths));
+
+        var response = mediaService.playAsset(assetName, userId);
+
+        assertThat(response.getDashUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getHlsUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getLicenseUrl()).isNull();
+        assertThat(response.getToken()).isNotNull();
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+        verify(contentKeyPolicyClient, times(1)).get(resourceGroup, accountName, userId);
+        verify(streamingPolicyClient, times(1)).get(resourceGroup, accountName, "Predefined_ClearKey");
+        verify(streamingLocatorClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq(userId), any(StreamingLocatorInner.class));
+        verify(streamingEndpointClient, times(1)).get(resourceGroup, accountName, "default");
+        verify(streamingLocatorClient, times(1)).listPaths(resourceGroup, accountName, userId);
+    }
+
+    @DisplayName("Should throw not found when asset does not exist")
+    @Test
+    void playAssetAssetNotFound() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+
+        var amsError = mockAmsError(404);
+        ;
+        doThrow(amsError).when(assetClient).get(resourceGroup, accountName, assetName);
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> mediaService.playAsset(assetName, userId)
+        ).getMessage();
+        assertThat(message).isEqualTo("Not found: Asset with name: " + assetName);
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+    }
+
+    @DisplayName("Should create new content key policy if one doesn't exist and the return playback data")
+    @Test
+    void playAssetSuccessWhenContentKeyPolicyDoesNotExist() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+        var contentKeyPolicyClient = mockContentKeyPoliciesClient();
+        var streamingPolicyClient = mockStreamingPoliciesClient();
+        var streamingLocatorClient = mockStreamingLocatorClient();
+        var streamingEndpointClient = mockStreamingEndpointClient();
+
+        when(assetClient.get(resourceGroup, accountName, assetName))
+            .thenReturn(mock(AssetInner.class));
+        var amsError = mockAmsError(404);
+        doThrow(amsError).when(contentKeyPolicyClient).get(resourceGroup, accountName, userId);
+        when(streamingLocatorClient.create(
+                 eq(resourceGroup),
+                 eq(accountName),
+                 eq("Predefined_ClearKey"),
+                 any(StreamingLocatorInner.class)
+             )
+        ).thenReturn(mock(StreamingLocatorInner.class));
+        var mockEndpoint = mock(StreamingEndpointInner.class);
+        when(streamingEndpointClient.get(resourceGroup, accountName, "default"))
+            .thenReturn(mockEndpoint);
+        when(mockEndpoint.resourceState()).thenReturn(StreamingEndpointResourceState.RUNNING);
+        when(mockEndpoint.hostname()).thenReturn("example.com");
+        var streamingPaths = List.of(
+            new StreamingPath()
+                .withPaths(List.of("/example.ism"))
+        );
+        when(streamingLocatorClient.listPaths(resourceGroup, accountName, userId))
+            .thenReturn(new ListPathsResponseInner().withStreamingPaths(streamingPaths));
+
+        var response = mediaService.playAsset(assetName, userId);
+
+        assertThat(response.getDashUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getHlsUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getLicenseUrl()).isNull();
+        assertThat(response.getToken()).isNotNull();
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+        verify(contentKeyPolicyClient, times(1)).get(resourceGroup, accountName, userId);
+        verify(contentKeyPolicyClient, times(1))
+            .createOrUpdate(eq(resourceGroup), eq(accountName), eq(userId), any(ContentKeyPolicyInner.class));
+        verify(streamingPolicyClient, times(1)).get(resourceGroup, accountName, "Predefined_ClearKey");
+        verify(streamingLocatorClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq(userId), any(StreamingLocatorInner.class));
+        verify(streamingEndpointClient, times(1)).get(resourceGroup, accountName, "default");
+        verify(streamingLocatorClient, times(1)).listPaths(resourceGroup, accountName, userId);
+    }
+
+    @DisplayName("Should return playback details for asset when streaming policy does not exist")
+    @Test
+    void playAssetSuccessWhenStreamingPolicyDoesNotExist() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+        var contentKeyPolicyClient = mockContentKeyPoliciesClient();
+        var streamingPolicyClient = mockStreamingPoliciesClient();
+        var streamingLocatorClient = mockStreamingLocatorClient();
+        var streamingEndpointClient = mockStreamingEndpointClient();
+
+        when(assetClient.get(resourceGroup, accountName, assetName))
+            .thenReturn(mock(AssetInner.class));
+        when(contentKeyPolicyClient.get(resourceGroup, accountName, userId))
+            .thenReturn(mock(ContentKeyPolicyInner.class));
+        var amsError = mockAmsError(404);
+        doThrow(amsError).when(streamingPolicyClient).get(resourceGroup, accountName, "Predefined_ClearKey");
+        when(streamingLocatorClient.create(
+                 eq(resourceGroup),
+                 eq(accountName),
+                 eq("Predefined_ClearKey"),
+                 any(StreamingLocatorInner.class)
+             )
+        ).thenReturn(mock(StreamingLocatorInner.class));
+        var mockEndpoint = mock(StreamingEndpointInner.class);
+        when(streamingEndpointClient.get(resourceGroup, accountName, "default"))
+            .thenReturn(mockEndpoint);
+        when(mockEndpoint.resourceState()).thenReturn(StreamingEndpointResourceState.RUNNING);
+        when(mockEndpoint.hostname()).thenReturn("example.com");
+        var streamingPaths = List.of(
+            new StreamingPath()
+                .withPaths(List.of("/example.ism"))
+        );
+        when(streamingLocatorClient.listPaths(resourceGroup, accountName, userId))
+            .thenReturn(new ListPathsResponseInner().withStreamingPaths(streamingPaths));
+
+        var response = mediaService.playAsset(assetName, userId);
+
+        assertThat(response.getDashUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getHlsUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getLicenseUrl()).isNull();
+        assertThat(response.getToken()).isNotNull();
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+        verify(contentKeyPolicyClient, times(1)).get(resourceGroup, accountName, userId);
+        verify(streamingPolicyClient, times(1)).get(resourceGroup, accountName, "Predefined_ClearKey");
+        verify(streamingPolicyClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq("Predefined_ClearKey"), any(StreamingPolicyInner.class));
+        verify(streamingLocatorClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq(userId), any(StreamingLocatorInner.class));
+        verify(streamingEndpointClient, times(1)).get(resourceGroup, accountName, "default");
+        verify(streamingLocatorClient, times(1)).listPaths(resourceGroup, accountName, userId);
+    }
+
+    @DisplayName("Should throw error when a non 404 error occurs when deleting streaming locator")
+    @Test
+    void playAssetErrorDeleteStreamingLocator() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+        var contentKeyPolicyClient = mockContentKeyPoliciesClient();
+        var streamingPolicyClient = mockStreamingPoliciesClient();
+        var streamingLocatorClient = mockStreamingLocatorClient();
+
+        when(assetClient.get(resourceGroup, accountName, assetName))
+            .thenReturn(mock(AssetInner.class));
+        when(contentKeyPolicyClient.get(resourceGroup, accountName, userId))
+            .thenReturn(mock(ContentKeyPolicyInner.class));
+        when(streamingPolicyClient.get(resourceGroup, accountName, "Predefined_ClearKey"))
+            .thenReturn(mock(StreamingPolicyInner.class));
+        var amsError = mockAmsError(400);
+        doThrow(amsError).when(streamingLocatorClient).delete(any(), any(), any());
+
+        assertThrows(
+            ManagementException.class,
+            () -> mediaService.playAsset(assetName, userId)
+        );
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+        verify(contentKeyPolicyClient, times(1)).get(resourceGroup, accountName, userId);
+        verify(streamingPolicyClient, times(1)).get(resourceGroup, accountName, "Predefined_ClearKey");
+        verify(streamingLocatorClient, times(1)).delete(any(), any(), any());
+    }
+
+    @DisplayName("Should return playback details and start streaming endpoint when not started")
+    @Test
+    void playAssetSuccessWhenStreamingEndpointNotStarted() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+        var contentKeyPolicyClient = mockContentKeyPoliciesClient();
+        var streamingPolicyClient = mockStreamingPoliciesClient();
+        var streamingLocatorClient = mockStreamingLocatorClient();
+        var streamingEndpointClient = mockStreamingEndpointClient();
+
+        when(assetClient.get(resourceGroup, accountName, assetName))
+            .thenReturn(mock(AssetInner.class));
+        when(contentKeyPolicyClient.get(resourceGroup, accountName, userId))
+            .thenReturn(mock(ContentKeyPolicyInner.class));
+        when(streamingPolicyClient.get(resourceGroup, accountName, "Predefined_ClearKey"))
+            .thenReturn(mock(StreamingPolicyInner.class));
+        when(streamingLocatorClient.create(
+                 eq(resourceGroup),
+                 eq(accountName),
+                 eq("Predefined_ClearKey"),
+                 any(StreamingLocatorInner.class)
+             )
+        ).thenReturn(mock(StreamingLocatorInner.class));
+        var mockEndpoint = mock(StreamingEndpointInner.class);
+        when(streamingEndpointClient.get(resourceGroup, accountName, "default"))
+            .thenReturn(mockEndpoint);
+        when(mockEndpoint.resourceState()).thenReturn(StreamingEndpointResourceState.STOPPED);
+        when(mockEndpoint.hostname()).thenReturn("example.com");
+        var streamingPaths = List.of(
+            new StreamingPath()
+                .withPaths(List.of("/example.ism"))
+        );
+        when(streamingLocatorClient.listPaths(resourceGroup, accountName, userId))
+            .thenReturn(new ListPathsResponseInner().withStreamingPaths(streamingPaths));
+
+        var response = mediaService.playAsset(assetName, userId);
+
+        assertThat(response.getDashUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getHlsUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getLicenseUrl()).isNull();
+        assertThat(response.getToken()).isNotNull();
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+        verify(contentKeyPolicyClient, times(1)).get(resourceGroup, accountName, userId);
+        verify(streamingPolicyClient, times(1)).get(resourceGroup, accountName, "Predefined_ClearKey");
+        verify(streamingLocatorClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq(userId), any(StreamingLocatorInner.class));
+        verify(streamingEndpointClient, times(2)).get(resourceGroup, accountName, "default");
+        verify(streamingEndpointClient, times(1)).start(resourceGroup, accountName, "default");
+        verify(streamingLocatorClient, times(1)).listPaths(resourceGroup, accountName, userId);
+    }
+
+    @DisplayName("Should return playback details for asset when streaming endpoint does not exist")
+    @Test
+    void playAssetSuccessWhenEndpointDoesNotExist() {
+        var assetName = "example-asset_output";
+        var userId = UUID.randomUUID().toString();
+        var assetClient = mockAssetsClient();
+        var contentKeyPolicyClient = mockContentKeyPoliciesClient();
+        var streamingPolicyClient = mockStreamingPoliciesClient();
+        var streamingLocatorClient = mockStreamingLocatorClient();
+        var streamingEndpointClient = mockStreamingEndpointClient();
+
+        when(assetClient.get(resourceGroup, accountName, assetName))
+            .thenReturn(mock(AssetInner.class));
+        when(contentKeyPolicyClient.get(resourceGroup, accountName, userId))
+            .thenReturn(mock(ContentKeyPolicyInner.class));
+        when(streamingPolicyClient.get(resourceGroup, accountName, "Predefined_ClearKey"))
+            .thenReturn(mock(StreamingPolicyInner.class));
+        when(streamingLocatorClient.create(
+                 eq(resourceGroup),
+                 eq(accountName),
+                 eq("Predefined_ClearKey"),
+                 any(StreamingLocatorInner.class)
+             )
+        ).thenReturn(mock(StreamingLocatorInner.class));
+        var amsError = mockAmsError(404);
+        doThrow(amsError).when(streamingEndpointClient).get(any(), any(), any());
+        var mockEndpoint = mock(StreamingEndpointInner.class);
+        when(streamingEndpointClient.create(
+            eq(resourceGroup),
+            eq(accountName),
+            eq("default"),
+            any(StreamingEndpointInner.class)
+        )).thenReturn(mockEndpoint);
+        when(mockEndpoint.resourceState()).thenReturn(StreamingEndpointResourceState.RUNNING);
+        when(mockEndpoint.hostname()).thenReturn("example.com");
+        var streamingPaths = List.of(
+            new StreamingPath()
+                .withPaths(List.of("/example.ism"))
+        );
+        when(streamingLocatorClient.listPaths(resourceGroup, accountName, userId))
+            .thenReturn(new ListPathsResponseInner().withStreamingPaths(streamingPaths));
+
+        var response = mediaService.playAsset(assetName, userId);
+
+        assertThat(response.getDashUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getHlsUrl()).isEqualTo("https://example.com/example.ism");
+        assertThat(response.getLicenseUrl()).isNull();
+        assertThat(response.getToken()).isNotNull();
+
+        verify(assetClient, times(1)).get(resourceGroup, accountName, assetName);
+        verify(contentKeyPolicyClient, times(1)).get(resourceGroup, accountName, userId);
+        verify(streamingPolicyClient, times(1)).get(resourceGroup, accountName, "Predefined_ClearKey");
+        verify(streamingLocatorClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq(userId), any(StreamingLocatorInner.class));
+        verify(streamingEndpointClient, times(1)).get(resourceGroup, accountName, "default");
+        verify(streamingEndpointClient, times(1))
+            .create(eq(resourceGroup), eq(accountName), eq("default"), any(StreamingEndpointInner.class));
+        verify(streamingEndpointClient, times(1)).start(resourceGroup, accountName, "default");
+        verify(streamingLocatorClient, times(1)).listPaths(resourceGroup, accountName, userId);
+    }
+
     private LiveEventsClient mockLiveEventClient() {
         var client = mock(LiveEventsClient.class);
         when(amsClient.getLiveEvents()).thenReturn(client);
@@ -1259,6 +1603,18 @@ public class AzureMediaServiceTest {
     private LiveOutputsClient mockLiveOutputClient() {
         var client = mock(LiveOutputsClient.class);
         when(amsClient.getLiveOutputs()).thenReturn(client);
+        return client;
+    }
+
+    private ContentKeyPoliciesClient mockContentKeyPoliciesClient() {
+        var client = mock(ContentKeyPoliciesClient.class);
+        when(amsClient.getContentKeyPolicies()).thenReturn(client);
+        return client;
+    }
+
+    private StreamingPoliciesClient mockStreamingPoliciesClient() {
+        var client = mock(StreamingPoliciesClient.class);
+        when(amsClient.getStreamingPolicies()).thenReturn(client);
         return client;
     }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)
- S28-3151


### Change description
- Add AMS implementation for `/media-service/vod` endpoint


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Look on AMS, see there is NOT a content key policy with a name matching your user id. Call endpoint, see one is created.
- Call endpoint for valid asset, on asset you are trying to watch, see a new locator with a name that matches the user's id.
- See start time is now, end time is one hours time. Call the endpoint again after one minute. See times update.
  -  _NOTE: The time displayed on AMS is UTC so times will be -1 hour of actual time_
- Check response works for viewing the asset (see steps below)
- Call endpoint for a recording that the user does not have access to
- Call endpoint for a recording that does not exist
- Call endpoint for a recording that has been marked as deleted
- On AMS, turn off default endpoint. See when endpoint called, the streaming endpoint is turned back on.

**How to test response works**
1. Go to this website: https://ampdemo.azureedge.net/ 
2. Set URL to either DASH or HLS URL from response
3. Turn on advanced settings
4. Turn on AES Protected
5. In AES token field enter: `Bearer <token>` where `<token>` is the token from the endpoint response
6. Click Update Player
7. See video loads and is playable

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
