### PR TITLE
Fix: `playLiveEvent` Error When `checkStream` Called First

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -213,7 +213,8 @@ public class MediaServiceController extends PreApiController {
         Logger.getAnonymousLogger().info("captureSession getLiveOutputUrl: " + captureSession.getLiveOutputUrl());
 
         // check if captureSession is in correct state
-        if (captureSession.getStatus() != RecordingStatus.STANDBY) {
+        if (captureSession.getStatus() != RecordingStatus.STANDBY
+            && captureSession.getStatus() != RecordingStatus.RECORDING) {
             throw new ResourceInWrongStateException(captureSession.getClass().getSimpleName(),
                                                     captureSessionId.toString(),
                                                     captureSession.getStatus().name(),


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)
- S28-0000
-->

### Change description
- Fix: `playLiveEvent` endpoint creates a streaming endpoint and locator when capture session's `status` is `RECORDING` but `liveOutputUrl` is `null`


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
