### PR TITLE
Expire streaming locators at midnight today

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
@@ -60,7 +60,8 @@ import uk.gov.hmcts.reform.preapi.media.storage.AzureFinalStorageService;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -75,6 +76,7 @@ public class AzureMediaService implements IMediaService {
     private static final String LOCATION = "uksouth";
     private static final String ENCODE_TO_MP4_TRANSFORM = "EncodeToMP4";
     private static final String STREAMING_POLICY_CLEAR_KEY = "Predefined_ClearKey";
+    private static final String STREAMING_POLICY_CLEAR_STREAMING_ONLY = "Predefined_ClearStreamingOnly";
     private static final String DEFAULT_STREAMING_ENDPOINT = "default";
 
     private final String resourceGroup;
@@ -183,6 +185,8 @@ public class AzureMediaService implements IMediaService {
             }
         }
 
+        var now = OffsetDateTime.now();
+
         amsClient.getStreamingLocators()
             .create(
                 resourceGroup,
@@ -192,7 +196,8 @@ public class AzureMediaService implements IMediaService {
                     .withAssetName(assetName)
                     .withStreamingPolicyName(STREAMING_POLICY_CLEAR_KEY)
                     .withDefaultContentKeyPolicyName(userId)
-                    .withEndTime(Instant.now().plusSeconds(3600).atZone(ZoneId.of("UTC")).toOffsetDateTime())
+                    // set end time to midnight tonight as an offset
+                    .withEndTime(now.toLocalDate().atTime(LocalTime.MAX).atOffset(now.getOffset()))
             );
     }
 
@@ -394,7 +399,7 @@ public class AzureMediaService implements IMediaService {
             var sanitisedLiveEventId = getSanitisedId(liveEventId);
             var streamingLocatorProperties = new StreamingLocatorInner()
                 .withAssetName(sanitisedLiveEventId)
-                .withStreamingPolicyName("Predefined_ClearStreamingOnly")
+                .withStreamingPolicyName(STREAMING_POLICY_CLEAR_STREAMING_ONLY)
                 .withStreamingLocatorId(liveEventId);
 
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -69,8 +69,9 @@ import uk.gov.hmcts.reform.preapi.media.storage.AzureFinalStorageService;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,6 +98,7 @@ public class MediaKind implements IMediaService {
     private static final String LOCATION = "uksouth";
     private static final String ENCODE_TO_MP4_TRANSFORM = "EncodeToMp4";
     private static final String STREAMING_POLICY_CLEAR_KEY = "Predefined_ClearKey";
+    private static final String STREAMING_POLICY_CLEAR_STREAMING_ONLY = "Predefined_ClearStreamingOnly";
     private static final String DEFAULT_STREAMING_ENDPOINT = "default";
 
     @Autowired
@@ -154,6 +156,8 @@ public class MediaKind implements IMediaService {
     private void refreshStreamingLocatorForUser(String userId, String assetName) {
         mediaKindClient.deleteStreamingLocator(userId);
 
+        var now = OffsetDateTime.now();
+
         mediaKindClient.createStreamingLocator(
             userId,
             MkStreamingLocator.builder()
@@ -162,7 +166,13 @@ public class MediaKind implements IMediaService {
                         .assetName(assetName)
                         .streamingPolicyName(STREAMING_POLICY_CLEAR_KEY)
                         .defaultContentKeyPolicyName(userId)
-                        .endTime(Timestamp.from(ZonedDateTime.now().toInstant().plusSeconds(3600)))
+                        // set end time to midnight tonight
+                        .endTime(Timestamp.from(
+                            now.toLocalDate()
+                               .atTime(LocalTime.MAX)
+                               .atZone(now.getOffset())
+                               .toInstant()
+                        ))
                         .build())
                 .build()
         );
@@ -662,15 +672,16 @@ public class MediaKind implements IMediaService {
             log.info("Creating Streaming locator");
             var sanitisedLiveEventId = getSanitisedLiveEventId(liveEventId);
 
+            // Streaming Locator for a live event
             mediaKindClient.createStreamingLocator(
                 sanitisedLiveEventId,
                 MkStreamingLocator.builder()
-                                  .properties(MkStreamingLocatorProperties.builder()
-                                                                          .assetName(sanitisedLiveEventId)
-                                                                          .streamingLocatorId(sanitisedLiveEventId)
-                                                                          .streamingPolicyName(
-                                                                              "Predefined_ClearStreamingOnly")
-                                                                          .build()
+                                  .properties(MkStreamingLocatorProperties
+                                                  .builder()
+                                                  .assetName(sanitisedLiveEventId)
+                                                  .streamingLocatorId(sanitisedLiveEventId)
+                                                  .streamingPolicyName(STREAMING_POLICY_CLEAR_STREAMING_ONLY)
+                                                  .build()
                                   ).build()
             );
         } catch (ConflictException e) {


### PR DESCRIPTION
### JIRA ticket(s)

- S28-3173

### Change description

- Expire streaming locators for VOD at 1 second before midnight today

> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

- Watch a video on demand longer than an hour and you should still be able to play without your streaming locator expiring.