### PR TITLE
Fix: Enable RTMPS on MK

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/media/LiveEventDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/media/LiveEventDTO.java
@@ -58,10 +58,9 @@ public class LiveEventDTO {
         inputRtmp = Stream.ofNullable(liveEvent
                 .getProperties()
                 .getInput()
-                .endpoints())
+                .getEndpoints())
             .flatMap(Collection::stream)
-            // todo uncomment once added by mk
-            // .filter(e -> e.url().startsWith("rtmps://"))
+            .filter(e -> e.url().startsWith("rtmps://"))
             .findFirst()
             .map(LiveEventEndpoint::url)
             .orElse(null);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -17,9 +17,7 @@ import com.azure.resourcemanager.mediaservices.models.JobOutputAsset;
 import com.azure.resourcemanager.mediaservices.models.JobState;
 import com.azure.resourcemanager.mediaservices.models.LiveEventEncoding;
 import com.azure.resourcemanager.mediaservices.models.LiveEventEncodingType;
-import com.azure.resourcemanager.mediaservices.models.LiveEventInput;
 import com.azure.resourcemanager.mediaservices.models.LiveEventInputAccessControl;
-import com.azure.resourcemanager.mediaservices.models.LiveEventInputProtocol;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreview;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreviewAccessControl;
 import com.azure.resourcemanager.mediaservices.models.LiveEventResourceState;
@@ -604,11 +602,11 @@ public class MediaKind implements IMediaService {
                                         )
                                         .description(captureSession.getBookingId().toString())
                                         .useStaticHostname(true)
-                                        .input(new LiveEventInput()
-                                                   .withStreamingProtocol(LiveEventInputProtocol.RTMP)
-                                                   .withKeyFrameIntervalDuration("PT6S")
-                                                   .withAccessToken(accessToken.toString())
-                                                   .withAccessControl(
+                                        .input(MkLiveEventProperties.MkLiveEventInput.builder()
+                                                   .streamingProtocol(MkLiveEventProperties.StreamingProtocol.RTMPS)
+                                                   .keyFrameIntervalDuration("PT6S")
+                                                   .accessToken(accessToken.toString())
+                                                   .accessControl(
                                                        new LiveEventInputAccessControl()
                                                            .withIp(new IpAccessControl()
                                                                        .withAllow(
@@ -620,6 +618,7 @@ public class MediaKind implements IMediaService {
                                                                        )
                                                            )
                                                    )
+                                                   .build()
                                         )
                                         .preview(new LiveEventPreview()
                                                      .withAccessControl(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/dto/MkLiveEventProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/dto/MkLiveEventProperties.java
@@ -1,7 +1,8 @@
 package uk.gov.hmcts.reform.preapi.media.dto;
 
 import com.azure.resourcemanager.mediaservices.models.LiveEventEncoding;
-import com.azure.resourcemanager.mediaservices.models.LiveEventInput;
+import com.azure.resourcemanager.mediaservices.models.LiveEventEndpoint;
+import com.azure.resourcemanager.mediaservices.models.LiveEventInputAccessControl;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreview;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;
@@ -18,7 +19,7 @@ public class MkLiveEventProperties {
     private String description;
     private LiveEventEncoding encoding;
     private String hostnamePrefix;
-    private LiveEventInput input;
+    private MkLiveEventInput input;
     private String lastModified;
     private LiveEventPreview preview;
     private String provisioningState;
@@ -32,5 +33,22 @@ public class MkLiveEventProperties {
     public static class CrossSiteAccessPolicies {
         private String clientAccessPolicy;
         private String crossDomainPolicy;
+    }
+
+    @Data
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MkLiveEventInput {
+        private StreamingProtocol streamingProtocol;
+        private String keyFrameIntervalDuration;
+        private String accessToken;
+        private LiveEventInputAccessControl accessControl;
+        private List<LiveEventEndpoint> endpoints;
+    }
+
+    public enum StreamingProtocol {
+        RTMP,
+        RTMPS,
+        SRT
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.preapi.media;
 
 import com.azure.resourcemanager.mediaservices.models.JobState;
 import com.azure.resourcemanager.mediaservices.models.LiveEventEndpoint;
-import com.azure.resourcemanager.mediaservices.models.LiveEventInput;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreview;
 import com.azure.resourcemanager.mediaservices.models.LiveEventResourceState;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -220,7 +219,8 @@ public class MediaKindTest {
         assertThat(result.getDescription()).isEqualTo(liveEvent.getProperties().getDescription());
         assertThat(result.getResourceState()).isEqualTo(liveEvent.getProperties().getResourceState());
         assertThat(result.getId()).isEqualTo(liveEvent.getId());
-        assertThat(result.getInputRtmp()).isEqualTo(liveEvent.getProperties().getInput().endpoints().getFirst().url());
+        assertThat(result.getInputRtmp())
+            .isEqualTo(liveEvent.getProperties().getInput().getEndpoints().getFirst().url());
     }
 
     @DisplayName("Should throw a NotFoundException null when get live event returns 404")
@@ -279,10 +279,12 @@ public class MediaKindTest {
                                              .description("description: " + name)
                                              .useStaticHostname(true)
                                              .resourceState("Stopped")
-                                             .input(new LiveEventInput()
-                                       .withEndpoints(List.of(new LiveEventEndpoint()
-                                                                  .withProtocol("RTMP")
-                                                                  .withUrl("rtmps://example url"))))
+                                             .input(MkLiveEventProperties.MkLiveEventInput.builder()
+                                                    .endpoints(List.of(
+                                                        new LiveEventEndpoint()
+                                                            .withProtocol("RTMP")
+                                                            .withUrl("rtmps://example url")))
+                                                        .build())
                                              .preview(new LiveEventPreview())
                                              .build())
             .build();


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)

- S28-3185


### Change description
- MediaKind live events are created with RTMPS ingest


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Test the returned ingest url returned by endpoints works with MK. 
- Ensure make sure MK ingest url starts with `rtmps://`


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
