### PR TITLE
S28 3182: Locator not Deleted on Stop Live Event (AMS Implementation)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/AzureMediaService.java
@@ -490,7 +490,7 @@ public class AzureMediaService implements IMediaService {
         stopAndDeleteLiveEvent(captureSessionNoHyphen);
         var captureSessionShort = getShortenedLiveEventId(captureSession.getId());
         stopAndDeleteStreamingEndpoint(captureSessionShort);
-        deleteStreamingLocator(captureSessionShort);
+        deleteStreamingLocator(captureSessionNoHyphen);
         deleteLiveOutput(captureSessionNoHyphen, captureSessionNoHyphen);
 
         return status;


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3182


### Change description
- Fix: locator name on create and delete didn't match so stop live event failed to delete streaming locator (AMS implementation)
-

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Test: streaming locator is deleted on stop live event endpoint called (AMS implementation)
-


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
