### PR TITLE
S28 2972: Revert Making Check Stream Not Return Capture Session

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "80"
+  revision              = "81"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -2811,9 +2811,13 @@ paths:
           required: false
           type: string
           x-example: 123e4567-e89b-12d3-a456-426614174000
+      produces:
+        - application/octet-stream
       responses:
         '200':
           description: OK
+          schema:
+            $ref: '#/definitions/CaptureSessionDTO'
       summary: Check stream has started
       tags:
         - media-service-controller

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -244,10 +244,10 @@ public class MediaServiceController extends PreApiController {
         summary = "Check stream has started"
     )
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3', 'ROLE_LEVEL_4')")
-    public ResponseEntity<Void> checkStream(@PathVariable UUID captureSessionId) {
+    public ResponseEntity<CaptureSessionDTO> checkStream(@PathVariable UUID captureSessionId) {
         var captureSession = captureSessionService.findById(captureSessionId);
         if (captureSession.getStatus() == RecordingStatus.RECORDING) {
-            return ResponseEntity.noContent().build();
+            return ResponseEntity.ok(captureSession);
         }
 
         if (captureSession.getFinishedAt() != null) {
@@ -271,8 +271,8 @@ public class MediaServiceController extends PreApiController {
         }
 
         if (azureIngestStorageService.doesIsmFileExist(captureSession.getBookingId().toString())) {
-            captureSessionService.setCaptureSessionStatus(captureSessionId, RecordingStatus.RECORDING);
-            return ResponseEntity.noContent().build();
+            return ResponseEntity.ok(captureSessionService
+                                         .setCaptureSessionStatus(captureSessionId, RecordingStatus.RECORDING));
         }
         throw new NotFoundException("No stream found");
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/MediaServiceControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/MediaServiceControllerTest.java
@@ -716,7 +716,10 @@ public class MediaServiceControllerTest {
         when(captureSessionService.findById(dto.getId())).thenReturn(dto);
 
         mockMvc.perform(post("/media-service/live-event/check/" + dto.getId()))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(dto.getId().toString()))
+            .andExpect(jsonPath("$.status").value(RecordingStatus.RECORDING.toString()));
 
         verify(captureSessionService, times(1)).findById(dto.getId());
         verify(azureIngestStorageService, never()).doesIsmFileExist(any());
@@ -807,7 +810,10 @@ public class MediaServiceControllerTest {
         when(captureSessionService.setCaptureSessionStatus(dto.getId(), RecordingStatus.RECORDING)).thenReturn(dto2);
 
         mockMvc.perform(post("/media-service/live-event/check/" + dto.getId()))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(dto.getId().toString()))
+            .andExpect(jsonPath("$.status").value(RecordingStatus.RECORDING.toString()));
 
         verify(captureSessionService, times(1)).findById(dto.getId());
         verify(azureIngestStorageService, times(1)).doesIsmFileExist(dto.getBookingId().toString());


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)

- S28-2972


### Change description
- Update response when capture session is already RECORDING: 204 -> 200 + capture session
- Update response when capture session has been updated to RECORDING: 204 -> 200 + capture session

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
