### PR TITLE
S28 3171: Check stream MK not looking for `gc_state`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -270,7 +270,8 @@ public class MediaServiceController extends PreApiController {
                                                         + " state. Expected state is STANDBY.");
         }
 
-        if (azureIngestStorageService.doesIsmFileExist(captureSession.getBookingId().toString())) {
+        if (azureIngestStorageService.doesIsmFileExist(captureSession.getBookingId().toString())
+            || azureIngestStorageService.doesBlobExist(captureSession.getBookingId().toString(), "gc_state")) {
             return ResponseEntity.ok(captureSessionService
                                          .setCaptureSessionStatus(captureSessionId, RecordingStatus.RECORDING));
         }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/MediaServiceControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/MediaServiceControllerTest.java
@@ -820,6 +820,35 @@ public class MediaServiceControllerTest {
         verify(captureSessionService, times(1)).setCaptureSessionStatus(dto.getId(), RecordingStatus.RECORDING);
     }
 
+    @DisplayName("Should return 200 with updated capture session when gc_state exists")
+    @Test
+    void checkStreamCaptureSessionGcStateExists() throws Exception {
+        var dto = new CaptureSessionDTO();
+        dto.setId(UUID.randomUUID());
+        dto.setStatus(RecordingStatus.STANDBY);
+        dto.setStartedAt(Timestamp.from(Instant.now()));
+        dto.setBookingId(UUID.randomUUID());
+
+        var dto2 = new CaptureSessionDTO();
+        dto2.setId(dto.getId());
+        dto2.setStatus(RecordingStatus.RECORDING);
+
+        when(captureSessionService.findById(dto.getId())).thenReturn(dto);
+        when(azureIngestStorageService.doesIsmFileExist(dto.getBookingId().toString())).thenReturn(false);
+        when(azureIngestStorageService.doesBlobExist(dto.getBookingId().toString(), "gc_state")).thenReturn(true);
+        when(captureSessionService.setCaptureSessionStatus(dto.getId(), RecordingStatus.RECORDING)).thenReturn(dto2);
+
+        mockMvc.perform(post("/media-service/live-event/check/" + dto.getId()))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.id").value(dto.getId().toString()))
+            .andExpect(jsonPath("$.status").value(RecordingStatus.RECORDING.toString()));
+
+        verify(captureSessionService, times(1)).findById(dto.getId());
+        verify(azureIngestStorageService, times(1)).doesIsmFileExist(dto.getBookingId().toString());
+        verify(captureSessionService, times(1)).setCaptureSessionStatus(dto.getId(), RecordingStatus.RECORDING);
+    }
+
     @DisplayName("Should return 200 with updated capture session when .ism file does not exist")
     @Test
     void checkStreamCaptureSessionIsmFileNotExists() throws Exception {
@@ -831,6 +860,7 @@ public class MediaServiceControllerTest {
 
         when(captureSessionService.findById(dto.getId())).thenReturn(dto);
         when(azureIngestStorageService.doesIsmFileExist(dto.getBookingId().toString())).thenReturn(false);
+        when(azureIngestStorageService.doesBlobExist(dto.getBookingId().toString(), "gc_state")).thenReturn(false);
 
         mockMvc.perform(post("/media-service/live-event/check/" + dto.getId()))
             .andExpect(status().isNotFound())


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3171

### Change description
- Check stream endpoint checks for `gc_state` if cannot find `.ism` file- fix issue where check stream endpoint was not finding a stream


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Start live event, start CVP recording, run check stream and see it finds the stream (status=RECORDING). MK has a slight delay so might have to wait a few seconds
- Start live event, do NOT start CVP recording, run check stream and is it does not find a stream (status=STANDBY)


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
