### PR TITLE
S28 3276: Handle `ConflictException` instead of `FeignException.Conflict`

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -22,7 +22,6 @@ import com.azure.resourcemanager.mediaservices.models.LiveEventPreview;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreviewAccessControl;
 import com.azure.resourcemanager.mediaservices.models.LiveEventResourceState;
 import com.azure.resourcemanager.mediaservices.models.StreamingPolicyContentKeys;
-import feign.FeignException;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -554,7 +553,7 @@ public class MediaKind implements IMediaService {
                                                                            .build())
                             .build()
             );
-        } catch (FeignException.Conflict e) {
+        } catch (ConflictException e) {
             throw new ConflictException("Live Output: " + liveOutputName);
         } catch (NotFoundException e) {
             throw new NotFoundException("Live Event: " + liveEventName);
@@ -587,7 +586,7 @@ public class MediaKind implements IMediaService {
                                     .build())
                     .build()
             );
-        } catch (FeignException.Conflict e) {
+        } catch (ConflictException e) {
             throw new ConflictException("Asset: " + assetName);
         }
     }
@@ -646,7 +645,7 @@ public class MediaKind implements IMediaService {
                                         .build())
                            .build()
             );
-        } catch (FeignException.Conflict e) {
+        } catch (ConflictException e) {
             log.info("Live Event already exists. Continuing...");
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -340,7 +340,7 @@ public class MediaKindTest {
         var mockLiveEvent = mock(MkLiveEvent.class);
 
         when(mockClient.putLiveEvent(any(), any()))
-            .thenThrow(mock(FeignException.Conflict.class));
+            .thenThrow(mock(ConflictException.class));
         when(mockClient.getLiveEvent(liveEventName)).thenReturn(mockLiveEvent);
 
         mediaKind.startLiveEvent(captureSession);
@@ -378,7 +378,7 @@ public class MediaKindTest {
 
         when(mockClient.getLiveEvent(liveEventName)).thenReturn(mockLiveEvent);
         when(mockClient.putAsset(eq(liveEventName), any(MkAsset.class)))
-            .thenThrow(mock(FeignException.Conflict.class));
+            .thenThrow(mock(ConflictException.class));
 
         var message = assertThrows(
             ConflictException.class,
@@ -399,7 +399,7 @@ public class MediaKindTest {
 
         when(mockClient.getLiveEvent(liveEventName)).thenReturn(mockLiveEvent);
         when(mockClient.putLiveOutput(eq(liveEventName), eq(liveEventName), any()))
-            .thenThrow(mock(FeignException.Conflict.class));
+            .thenThrow(mock(ConflictException.class));
 
         var message = assertThrows(
             ConflictException.class,


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3276


### Change description
- After updating the FeignDecoder some errors are not getting caught/handled correctly- this has been resolved


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
