### PR TITLE
Change the filename used per media service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.preapi.services;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +21,7 @@ import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
+import uk.gov.hmcts.reform.preapi.media.MediaServiceBroker;
 import uk.gov.hmcts.reform.preapi.repositories.BookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
@@ -28,6 +30,7 @@ import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -40,18 +43,21 @@ public class CaptureSessionService {
     private final BookingRepository bookingRepository;
     private final UserRepository userRepository;
     private final BookingService bookingService;
+    private final String mediaService;
 
     @Autowired
     public CaptureSessionService(RecordingService recordingService,
                                  CaptureSessionRepository captureSessionRepository,
                                  BookingRepository bookingRepository,
                                  UserRepository userRepository,
-                                 @Lazy BookingService bookingService) {
+                                 @Lazy BookingService bookingService,
+                                 @Value("${media-service}") String mediaService) {
         this.recordingService = recordingService;
         this.captureSessionRepository = captureSessionRepository;
         this.bookingRepository = bookingRepository;
         this.userRepository = userRepository;
         this.bookingService = bookingService;
+        this.mediaService = mediaService;
     }
 
     @Transactional
@@ -209,7 +215,9 @@ public class CaptureSessionService {
     }
 
     @Transactional
-    public CaptureSessionDTO stopCaptureSession(UUID captureSessionId, RecordingStatus status, UUID recordingId) {
+    public CaptureSessionDTO stopCaptureSession(UUID captureSessionId,
+                                                RecordingStatus status,
+                                                UUID recordingId) {
         var captureSession = captureSessionRepository
             .findByIdAndDeletedAtIsNull(captureSessionId)
             .orElseThrow(() -> new NotFoundException("Capture Session: " + captureSessionId));
@@ -230,7 +238,9 @@ public class CaptureSessionService {
                 recording.setId(recordingId);
                 recording.setCaptureSessionId(captureSessionId);
                 recording.setVersion(1);
-                recording.setFilename("video_2000000_1280x720_4500.mp4");
+                recording.setFilename(Objects.equals(mediaService, MediaServiceBroker.MEDIA_SERVICE_AMS)
+                                          ? "video_2000000_1280x720_4500.mp4"
+                                          : "index_1280x720_4500k.mp4");
                 recordingService.upsert(recording);
             }
             default -> {

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -3,12 +3,14 @@ package uk.gov.hmcts.reform.preapi.services;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.dto.CreateCaptureSessionDTO;
+import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.User;
@@ -18,6 +20,7 @@ import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInDeletedStateException;
+import uk.gov.hmcts.reform.preapi.media.MediaServiceBroker;
 import uk.gov.hmcts.reform.preapi.repositories.BookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
@@ -593,16 +596,62 @@ public class CaptureSessionServiceTest {
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 
         var recordingId = UUID.randomUUID();
-        var model = captureSessionService.stopCaptureSession(
+
+        var captureSessionServiceAMS = new CaptureSessionService(recordingService,
+                                                                captureSessionRepository,
+                                                                bookingRepository,
+                                                                userRepository,
+                                                                bookingService,
+                                                                MediaServiceBroker.MEDIA_SERVICE_AMS);
+        var model = captureSessionServiceAMS.stopCaptureSession(
             captureSession.getId(),
             RecordingStatus.RECORDING_AVAILABLE,
             recordingId
         );
 
+        var createRecordingDTOArgument = ArgumentCaptor.forClass(CreateRecordingDTO.class);
+
         assertThat(model.getId()).isEqualTo(captureSession.getId());
         assertThat(model.getStatus()).isEqualTo(RecordingStatus.RECORDING_AVAILABLE);
 
-        verify(recordingService, times(1)).upsert(any());
+        verify(recordingService, times(1)).upsert(createRecordingDTOArgument.capture());
+        assertThat(createRecordingDTOArgument.getValue().getFilename()).isEqualTo("video_2000000_1280x720_4500.mp4");
+        verify(captureSessionRepository, times(1)).saveAndFlush(any());
+    }
+
+    @DisplayName("Should update capture session when status is RECORDING_AVAILABLE MK")
+    @Test
+    void stopCaptureSessionRecordingAvailableMk() {
+        captureSession.setStatus(RecordingStatus.STANDBY);
+        var mockAuth = mock(UserAuthentication.class);
+        when(mockAuth.getUserId()).thenReturn(user.getId());
+        SecurityContextHolder.getContext().setAuthentication(mockAuth);
+
+        when(captureSessionRepository.findByIdAndDeletedAtIsNull(captureSession.getId()))
+            .thenReturn(Optional.of(captureSession));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        var recordingId = UUID.randomUUID();
+        var captureSessionServiceMk = new CaptureSessionService(recordingService,
+                                                                captureSessionRepository,
+                                                                bookingRepository,
+                                                                userRepository,
+                                                                bookingService,
+                                                                MediaServiceBroker.MEDIA_SERVICE_MK);
+
+        var model = captureSessionServiceMk.stopCaptureSession(
+            captureSession.getId(),
+            RecordingStatus.RECORDING_AVAILABLE,
+            recordingId
+        );
+
+        var createRecordingDTOArgument = ArgumentCaptor.forClass(CreateRecordingDTO.class);
+
+        assertThat(model.getId()).isEqualTo(captureSession.getId());
+        assertThat(model.getStatus()).isEqualTo(RecordingStatus.RECORDING_AVAILABLE);
+
+        verify(recordingService, times(1)).upsert(createRecordingDTOArgument.capture());
+        assertThat(createRecordingDTOArgument.getValue().getFilename()).isEqualTo("index_1280x720_4500k.mp4");
         verify(captureSessionRepository, times(1)).saveAndFlush(any());
     }
 


### PR DESCRIPTION
### JIRA ticket(s)

- S28-3350

### Change description
Switch the filename used for capture sessions depending on whether the API is running under AMS or MK
This will need testing in staging so that you can see the change appearing in the App when the edit video button is clicked
