### PR TITLE
Fix: Stop Live Event Cron Job Null Errors

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/CleanupLiveEvents.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/CleanupLiveEvents.java
@@ -161,33 +161,15 @@ public class CleanupLiveEvents implements Runnable {
                               log.error("Error stopping live event {}", liveEventDTO.getName(), e);
                               return;
                           }
-                          stopLiveEventForMissingCaptureSession(mediaService, liveEventDTO.getName());
+                          log.info("Stopping live event without associated capture session: {}",
+                                   liveEventDTO.getName());
+                          mediaService.cleanupStoppedLiveEvent(liveEventDTO.getName());
                       } catch (Exception e) {
                           log.error("Error stopping live event {}", liveEventDTO.getName(), e);
                       }
                   });
 
         log.info("Completed CleanupLiveEvents task");
-    }
-
-    private void stopLiveEventForMissingCaptureSession(IMediaService mediaService, String liveEventId) {
-        log.info("Stopping live event without associated capture session: {}", liveEventId);
-        var id = generateUuidFromLiveEventName(liveEventId);
-        var bookingId = UUID.fromString(mediaService.getAsset(id.toString()).getDescription());
-
-        var dto = new CaptureSessionDTO();
-        dto.setId(id);
-        dto.setBookingId(bookingId);
-
-        try {
-            mediaService.stopLiveEvent(dto, UUID.randomUUID());
-            log.info("Stopped live event {}", liveEventId);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Failed to stop live event {}", liveEventId, e);
-        } catch (Exception e) {
-            log.error("Failed to stop live event {}", liveEventId, e);
-        }
     }
 
     private boolean stopLiveEvent(IMediaService mediaService,

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/CleanupLiveEventsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/CleanupLiveEventsTest.java
@@ -427,8 +427,7 @@ public class CleanupLiveEventsTest {
         verify(mediaService, times(1)).getLiveEvents();
         verify(captureSessionService, times(1)).findByLiveEventId(liveEventDTO.getName());
         verify(recordingService, never()).findAll(any(), eq(false), any());
-        verify(mediaService, times(1)).getAsset(captureSessionId.toString());
-        verify(mediaService, times(1)).stopLiveEvent(any(CaptureSessionDTO.class), any(UUID.class));
+        verify(mediaService, times(1)).cleanupStoppedLiveEvent(liveEventDTO.getName());
     }
 
     @DisplayName("Should not stop live event when capture session cannot be found (in prod)")


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3259


### Change description
- Stop live event when capture session does not exist (in non-prod) now stops/deletes live event, live output and locator and no longer runs transforms

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
