### PR TITLE
Save filename of edited recording in the DTO

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -328,7 +328,7 @@ public class MediaServiceController extends PreApiController {
 
         // 404s of there are no mp4 files in the container
         // this is called in the MK process anyway but AMS doesn't need the specific filename
-        var filename = azureFinalStorageService.getMp4FileName(generateAssetDTO.getSourceContainer());
+        azureFinalStorageService.getMp4FileName(generateAssetDTO.getSourceContainer());
 
         log.info("Attempting to generate asset: {}", generateAssetDTO);
 
@@ -341,7 +341,6 @@ public class MediaServiceController extends PreApiController {
             recording.setId(generateAssetDTO.getNewRecordingId());
             recording.setParentRecordingId(parentRecording.getId());
             recording.setCaptureSessionId(parentRecording.getCaptureSession().getId());
-            recording.setFilename(filename);
 
             var search = new SearchRecordings();
             search.setCaptureSessionId(parentRecording.getCaptureSession().getId());
@@ -351,7 +350,7 @@ public class MediaServiceController extends PreApiController {
                 Pageable.unpaged()
             ).getSize();
             recording.setVersion(numRecordingsForCaptureSession + 1);
-            recording.setFilename(""); // Field is deprecated
+            recording.setFilename(generateAssetDTO.getNewRecordingId() + ".mp4"); // filename is used
             recordingService.upsert(recording);
             return ResponseEntity.ok(result);
         }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -328,7 +328,7 @@ public class MediaServiceController extends PreApiController {
 
         // 404s of there are no mp4 files in the container
         // this is called in the MK process anyway but AMS doesn't need the specific filename
-        azureFinalStorageService.getMp4FileName(generateAssetDTO.getSourceContainer());
+        var filename = azureFinalStorageService.getMp4FileName(generateAssetDTO.getSourceContainer());
 
         log.info("Attempting to generate asset: {}", generateAssetDTO);
 
@@ -341,6 +341,7 @@ public class MediaServiceController extends PreApiController {
             recording.setId(generateAssetDTO.getNewRecordingId());
             recording.setParentRecordingId(parentRecording.getId());
             recording.setCaptureSessionId(parentRecording.getCaptureSession().getId());
+            recording.setFilename(filename);
 
             var search = new SearchRecordings();
             search.setCaptureSessionId(parentRecording.getCaptureSession().getId());


### PR DESCRIPTION
### JIRA ticket(s)

- S28-3550

### Change description

- Set the filename in the Recording of the edited file when generating the asset

> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

- Create an edit of a recording and then edit that new recording again
