### PR TITLE
S28 3259: Fix Stop Live Event Cron Errors

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -22,6 +22,7 @@ import com.azure.resourcemanager.mediaservices.models.LiveEventPreview;
 import com.azure.resourcemanager.mediaservices.models.LiveEventPreviewAccessControl;
 import com.azure.resourcemanager.mediaservices.models.LiveEventResourceState;
 import com.azure.resourcemanager.mediaservices.models.StreamingPolicyContentKeys;
+import feign.FeignException;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -416,6 +417,9 @@ public class MediaKind implements IMediaService {
             mediaKindClient.stopLiveEvent(liveEventName);
         } catch (NotFoundException e) {
             throw new NotFoundException("Live Event: " + liveEventName);
+        } catch (FeignException.BadRequest e) {
+            // live output still exists (only occurs on manually created live events)
+            log.info("Skipped stopping live event. The live event will be cleaned up by deletion.");
         }
         mediaKindClient.deleteLiveEvent(liveEventName);
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -62,11 +62,15 @@ public class CaptureSessionService {
 
     @Transactional
     public CaptureSessionDTO findByLiveEventId(String liveEventId) {
-        var liveEventUUID = new UUID(
-            Long.parseUnsignedLong(liveEventId.substring(0, 16), 16),
-            Long.parseUnsignedLong(liveEventId.substring(16), 16)
-        );
-        return this.findById(liveEventUUID);
+        try {
+            var liveEventUUID = new UUID(
+                Long.parseUnsignedLong(liveEventId.substring(0, 16), 16),
+                Long.parseUnsignedLong(liveEventId.substring(16), 16)
+            );
+            return this.findById(liveEventUUID);
+        } catch (Exception e) {
+            throw new NotFoundException("CaptureSession: " + liveEventId);
+        }
     }
 
     @Transactional

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -1314,4 +1314,18 @@ public class MediaKindTest {
         verify(mockClient, times(1)).getContentKeyPolicies(anyInt());
         verify(mockClient, times(3)).deleteContentKeyPolicy(anyString());
     }
+
+    @Test
+    @DisplayName("Should not error when stopping live event when live output has not been deleted")
+    void cleanupStoppedLiveEventLiveOutputNotDeletedSuccess() {
+        var liveEventId = UUID.randomUUID().toString().replace("-", "");
+
+        doThrow(FeignException.BadRequest.class).when(mockClient).stopLiveEvent(liveEventId);
+
+        mediaKind.cleanupStoppedLiveEvent(liveEventId);
+
+        verify(mockClient, times(1)).deleteLiveOutput(liveEventId, liveEventId);
+        verify(mockClient, times(1)).stopLiveEvent(liveEventId);
+        verify(mockClient, times(1)).deleteLiveEvent(liveEventId);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -747,7 +747,7 @@ public class CaptureSessionServiceTest {
             () -> captureSessionService.findByLiveEventId(liveEventId)
         ).getMessage();
 
-        assertThat(message).isEqualTo("Not found: CaptureSession: " + captureSessionId);
+        assertThat(message).isEqualTo("Not found: CaptureSession: " + liveEventId);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionServiceTest.java
@@ -749,4 +749,17 @@ public class CaptureSessionServiceTest {
 
         assertThat(message).isEqualTo("Not found: CaptureSession: " + captureSessionId);
     }
+
+    @Test
+    @DisplayName("Should throw not found when live event name cannot be turned into a UUID")
+    void findCaptureSessionByLiveEventIdNotFoundUnparseable() {
+        var liveEventId = "this-is-a-test";
+
+        var message = assertThrows(
+            NotFoundException.class,
+            () -> captureSessionService.findByLiveEventId(liveEventId)
+        ).getMessage();
+
+        assertThat(message).isEqualTo("Not found: CaptureSession: " + liveEventId);
+    }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3259


### Change description
- Fix issue causing live events with names that cannot be parsed to UUIDs not being cleaned up correctly
    - UUID parsing caused an error which meant the API was skipping the cleanup of the live event
- Fix issue causing live events created manually to not get cleaned up
    - The naming convention of the live output created when you create a live event via the dashboard is different to the live outputs created via the API so it was not getting caught by the API to delete. This resulted in the call to the MK stop live event API returning a 400 error (making the API skip cleanup).  

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
