### PR TITLE
S28 3458: Disable access for app access when it is active=False

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserAuthenticationServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserAuthenticationServiceIT.java
@@ -137,4 +137,50 @@ public class UserAuthenticationServiceIT extends IntegrationTestBase {
 
         assertEquals(message, "Unauthorised user: " + id);
     }
+
+    @Test
+    @Transactional
+    public void loadUserByIdAppInactive() {
+        appAccess.setActive(false);
+        entityManager.persist(appAccess);
+        var id = appAccess.getId().toString();
+
+        var message = assertThrows(
+            BadCredentialsException.class,
+            () ->  userAuthenticationService.loadAppUserById(id)
+        ).getMessage();
+
+        assertEquals(message, "Unauthorised user: " + id);
+    }
+
+    @Test
+    @Transactional
+    public void loadUserByIdAppDeleted() {
+        appAccess.setDeletedAt(Timestamp.from(Instant.now()));
+        entityManager.persist(appAccess);
+        var id = appAccess.getId().toString();
+
+        var message = assertThrows(
+            BadCredentialsException.class,
+            () ->  userAuthenticationService.loadAppUserById(id)
+        ).getMessage();
+
+        assertEquals(message, "Unauthorised user: " + id);
+    }
+
+    @Test
+    @Transactional
+    public void loadUserByIdAppUserDeleted() {
+        var user = appAccess.getUser();
+        user.setDeletedAt(Timestamp.from(Instant.now()));
+        entityManager.persist(user);
+        var id = appAccess.getId().toString();
+
+        var message = assertThrows(
+            BadCredentialsException.class,
+            () ->  userAuthenticationService.loadAppUserById(id)
+        ).getMessage();
+
+        assertEquals(message, "Unauthorised user: " + id);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AppAccessRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AppAccessRepository.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.preapi.repositories;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 
@@ -17,5 +19,14 @@ public interface AppAccessRepository extends JpaRepository<AppAccess, UUID> {
 
     List<AppAccess> findAllByUser_IdAndDeletedAtIsNotNull(UUID id);
 
-    Optional<AppAccess> findByIdAndDeletedAtNullAndUser_DeletedAtNull(UUID userId);
+    @Query(
+        """
+        SELECT a FROM AppAccess a
+        WHERE a.id = :userId
+        AND a.deletedAt IS NULL
+        AND a.active IS TRUE
+        AND a.user.deletedAt IS NULL
+        """
+    )
+    Optional<AppAccess> findByIdValidUser(@Param("userId") UUID userId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/security/service/UserAuthenticationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/security/service/UserAuthenticationService.java
@@ -72,7 +72,7 @@ public class UserAuthenticationService {
         }
 
         var user = appAccessRepository
-            .findByIdAndDeletedAtNullAndUser_DeletedAtNull(id)
+            .findByIdValidUser(id)
             .map(this::getAuthentication);
 
         return user.isPresent()


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)

- S28-3458

### Change description
- Fix issue where app access's with active=False but not deleted is allowing user's access


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Create a user with app access, set the app access to active=False. See can no longer user app access id as X-User-Id


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
