### PR TITLE
S28 3434: Add `totalVersionCount` to `RecordingDTO`

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "88"
+  revision              = "89"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1102,6 +1102,10 @@ definitions:
         items:
           $ref: '#/definitions/ParticipantDTO'
         type: array
+      total_version_count:
+        description: RecordingTotalVersionCount
+        format: int32
+        type: integer
       url:
         description: RecordingURL
         type: string
@@ -1604,6 +1608,10 @@ definitions:
         items:
           $ref: '#/definitions/ParticipantDTO'
         type: array
+      total_version_count:
+        description: RecordingTotalVersionCount
+        format: int32
+        type: integer
       url:
         description: RecordingURL
         type: string

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/RecordingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/RecordingControllerFT.java
@@ -249,6 +249,29 @@ public class RecordingControllerFT extends FunctionalTestBase {
         assertThat(recordings2.getFirst().getCreatedAt()).isBefore(recordings2.getLast().getCreatedAt());
     }
 
+    @Test
+    @DisplayName("Should show correct total version count")
+    void getRecordingTotalVersionCount() throws JsonProcessingException {
+        // create parent recording
+        var details = createRecording();
+        var getRecording1 = assertRecordingExists(details.recordingId, true);
+        getRecording1.prettyPrint();
+        assertThat(getRecording1.getBody().as(RecordingDTO.class).getTotalVersionCount()).isEqualTo(1);
+
+        // create child recording
+        var recording2 = createRecording(details.captureSessionId);
+        recording2.setParentRecordingId(details.recordingId);
+        recording2.setVersion(2);
+        var putRecording2 = putRecording(recording2);
+        assertResponseCode(putRecording2, 201);
+        var getRecording2 = assertRecordingExists(recording2.getId(), true);
+        assertThat(getRecording2.getBody().as(RecordingDTO.class).getTotalVersionCount()).isEqualTo(2);
+
+        // check parent recording
+        var getRecording3 = assertRecordingExists(details.recordingId, true);
+        assertThat(getRecording3.getBody().as(RecordingDTO.class).getTotalVersionCount()).isEqualTo(2);
+    }
+
     @DisplayName("Should throw 400 error when sort param is invalid")
     @Test
     void getRecordingsSortInvalidParam() {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/RecordingDTO.java
@@ -46,12 +46,19 @@ public class RecordingDTO extends BaseRecordingDTO {
     @Schema(description = "RecordingParticipants")
     private List<ParticipantDTO> participants;
 
+    @Schema(description = "RecordingTotalVersionCount")
+    private int totalVersionCount;
+
     public RecordingDTO(Recording recording) {
         id = recording.getId();
         captureSession = new CaptureSessionDTO(recording.getCaptureSession());
         parentRecordingId = recording.getParentRecording() != null
             ? recording.getParentRecording().getId()
             : null;
+        var versions = recording.getParentRecording() != null
+            ? recording.getParentRecording().getRecordings()
+            : recording.getRecordings();
+        totalVersionCount = versions != null ? versions.size() + 1 : 1;
         version = recording.getVersion();
         filename = recording.getFilename();
         duration = recording.getDuration();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Recording.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Recording.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import lombok.Getter;
@@ -22,6 +23,7 @@ import uk.gov.hmcts.reform.preapi.entities.listeners.RecordingListener;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -36,6 +38,9 @@ public class Recording extends BaseEntity implements ISoftDeletable {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "parent_recording_id")
     private Recording parentRecording;
+
+    @OneToMany(mappedBy = "parentRecording")
+    private Set<Recording> recordings;
 
     @Column(name = "version", nullable = false)
     private int version;


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3434


### Change description
- Add RecordingDTO.totalVersionCount which is the count of all versions of a recording (including all edits and the original). 


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
