### PR TITLE
S28 3488: On Closed Case Delete Bookings w/ Capture Session No Recording or Failure

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/BookingControllerFT.java
@@ -592,7 +592,7 @@ class BookingControllerFT extends FunctionalTestBase {
         assertCaseExists(caseEntity.getId(), true);
 
         var captureSession = createCaptureSession(booking.getId());
-        captureSession.setStatus(RecordingStatus.NO_RECORDING);
+        captureSession.setStatus(RecordingStatus.RECORDING_AVAILABLE);
         var putCaptureSession = putCaptureSession(captureSession);
         assertResponseCode(putCaptureSession, 201);
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaptureSessionControllerFT.java
@@ -127,7 +127,7 @@ public class CaptureSessionControllerFT extends FunctionalTestBase {
 
         // create capture session
         var dto = createCaptureSession(bookingId);
-        dto.setStatus(RecordingStatus.NO_RECORDING);
+        dto.setStatus(RecordingStatus.RECORDING_AVAILABLE);
         var putResponse = putCaptureSession(dto);
         assertResponseCode(putResponse, 201);
         assertCaptureSessionExists(dto.getId(), true);
@@ -144,7 +144,7 @@ public class CaptureSessionControllerFT extends FunctionalTestBase {
         assertResponseCode(putCase, 204);
 
         // attempt update capture session
-        dto.setStatus(RecordingStatus.FAILURE);
+        dto.setStatus(RecordingStatus.RECORDING);
         var putCaptureSession1 = putCaptureSession(dto);
         assertResponseCode(putCaptureSession1, 400);
         assertThat(putCaptureSession1.getBody().jsonPath().getString("message"))

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -605,7 +605,7 @@ class CaseControllerFT extends FunctionalTestBase {
         assertBookingExists(booking.getId(), true);
 
         var captureSession = createCaptureSession(booking.getId());
-        captureSession.setStatus(RecordingStatus.NO_RECORDING);
+        captureSession.setStatus(RecordingStatus.RECORDING_AVAILABLE);
         var putCaptureSession = putCaptureSession(captureSession);
         assertResponseCode(putCaptureSession, 201);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.preapi.dto.ParticipantDTO;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
+import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.ConflictException;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
@@ -26,6 +27,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CaseServiceIT extends IntegrationTestBase {
     @Autowired
@@ -293,5 +296,78 @@ public class CaseServiceIT extends IntegrationTestBase {
             () -> caseService.upsert(dto)
         ).getMessage();
         Assertions.assertEquals("Conflict: Case reference is already in use for this court", message);
+    }
+
+    @Test
+    @Transactional
+    void closeCaseWithEmptyCaptureSessions() {
+        mockAdminUser();
+
+        var court = HelperFactory.createCourt(CourtType.CROWN, "Example Court", "1234");
+        entityManager.persist(court);
+
+        var caseEntity = HelperFactory.createCase(court, "CASE12345", true, null);
+        entityManager.persist(caseEntity);
+
+        var booking1 = HelperFactory.createBooking(caseEntity, Timestamp.from(Instant.now()), null);
+        entityManager.persist(booking1);
+        var booking2 = HelperFactory.createBooking(caseEntity, Timestamp.from(Instant.now()), null);
+        entityManager.persist(booking2);
+        var booking3 = HelperFactory.createBooking(caseEntity, Timestamp.from(Instant.now()), null);
+        entityManager.persist(booking3);
+
+        var captureSessionNoRecording = HelperFactory.createCaptureSession(
+            booking1,
+            RecordingOrigin.PRE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            RecordingStatus.NO_RECORDING,
+            null
+        );
+        entityManager.persist(captureSessionNoRecording);
+        var captureSessionFailure = HelperFactory.createCaptureSession(
+            booking2,
+            RecordingOrigin.PRE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            RecordingStatus.FAILURE,
+            null
+        );
+        entityManager.persist(captureSessionFailure);
+        var captureSessionRecordingAvailable = HelperFactory.createCaptureSession(
+            booking3,
+            RecordingOrigin.PRE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            RecordingStatus.RECORDING_AVAILABLE,
+            null
+        );
+        entityManager.persist(captureSessionRecordingAvailable);
+        entityManager.flush();
+
+        entityManager.refresh(booking1);
+        entityManager.refresh(booking2);
+        entityManager.refresh(booking3);
+
+        caseService.onCaseClosed(caseEntity);
+
+        assertThat(booking1.getDeletedAt()).isNotNull();
+        assertThat(captureSessionNoRecording.getDeletedAt()).isNotNull();
+        assertThat(booking2.getDeletedAt()).isNotNull();
+        assertThat(captureSessionFailure.getDeletedAt()).isNotNull();
+        assertThat(booking3.getDeletedAt()).isNull();
+        assertThat(captureSessionRecordingAvailable.getDeletedAt()).isNull();
     }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3488


### Change description
- On case closure: 
    - Delete bookings with a capture session in the state `NO_RECORDING` (cascades to delete capture session as well)
    - Delete bookings with a capture session in the state `FAILURE` (cascades to delete capture session as well)

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Create a case with three bookings and setup capture sessions using `PUT /capture-sessions/{id}`: 
    - One booking/capture session with the status `NO_RECORDING`
    - One booking/capture session with the status `FAILURE`
    - One booking/capture session with the status `RECORDING_AVAILABLE`
- Mark the case as closed via `PUT /cases/{id}`
- Test 1: 
    - `GET /bookings/{id}` for the first booking, see 404 (because booking has been deleted) 
    - `GET /capture-sessions/{id}` for the first capture session (status `NO_RECORDING`), see 404 (because capture session has been deleted) 
- Test 2: 
    - `GET /bookings/{id}` for the second booking, see 404 (because booking has been deleted) 
    - `GET /capture-sessions/{id}` for the second capture session (status `FAILURE`), see 404 (because capture session has been deleted) 
- Test 3: 
    - `GET /bookings/{id}` for the third booking, see 200 (booking has not been deleted)
    - `GET /capture-sessions/{id}` for the third capture session (status `RECORDING_AVAILABLE`), see 200 (because capture session has not been deleted) 


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
