### PR TITLE
S28 3554: Bookings Sorting Param

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "90"
+  revision              = "91"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -1998,6 +1998,11 @@ paths:
           in: query
           name: captureSessionStatusNotIn
           type: string
+        - description: Sort by
+          in: query
+          name: sort
+          type: string
+          x-example: 'createdAt,desc'
         - description: The page number of search result to return
           format: int32
           in: query

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/BookingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/BookingServiceIT.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.preapi.services;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.dto.BookingDTO;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
@@ -88,7 +90,7 @@ class BookingServiceIT extends IntegrationTestBase {
             null,
             null,
             null,
-            null
+            Pageable.unpaged(Sort.by(Sort.Order.asc("scheduledFor")))
         );
         assertEquals(1, findAllSharedWithUser.toList().size(), "Should find 1 booking");
         assertEquals(booking1.getId(), findAllSharedWithUser.toList().getFirst().getId(), "Should find booking 1");
@@ -190,7 +192,7 @@ class BookingServiceIT extends IntegrationTestBase {
             null,
             null,
             null,
-            null
+            Pageable.unpaged(Sort.by(Sort.Order.asc("scheduledFor")))
         );
         assertEquals(2, findByCaseReferenceResult.getContent().size(), "Should find 2 bookings");
         assertEquals(booking1.getId(), findByCaseReferenceResult.getContent().get(0).getId(), "Should find booking 1");
@@ -205,7 +207,7 @@ class BookingServiceIT extends IntegrationTestBase {
             null,
             null,
             null,
-            null
+            Pageable.unpaged(Sort.by(Sort.Order.asc("scheduledFor")))
         );
         assertEquals(1, findByScheduledForResult.getContent().size(), "Should find 1 bookings");
         assertEquals(
@@ -255,7 +257,7 @@ class BookingServiceIT extends IntegrationTestBase {
             false,
             null,
             null,
-            null
+            Pageable.unpaged(Sort.by(Sort.Order.asc("scheduledFor")))
         ).toList();
         assertEquals(findByHasRecordingsFalse.size(), 1);
         assertEquals(
@@ -272,7 +274,7 @@ class BookingServiceIT extends IntegrationTestBase {
             true,
             null,
             null,
-            null
+            Pageable.unpaged(Sort.by(Sort.Order.asc("scheduledFor")))
         ).toList();
         assertEquals(findByHasRecordingsTrue.size(), 1);
         assertEquals(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/BookingController.java
@@ -7,7 +7,9 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.data.web.SortDefault;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpEntity;
@@ -109,6 +111,12 @@ public class BookingController extends PreApiController {
         schema = @Schema(implementation = List.class)
     )
     @Parameter(
+        name = "sort",
+        description = "Sort by",
+        schema = @Schema(implementation = String.class),
+        example = "createdAt,desc"
+    )
+    @Parameter(
         name = "page",
         description = "The page number of search result to return",
         schema = @Schema(implementation = Integer.class),
@@ -123,7 +131,9 @@ public class BookingController extends PreApiController {
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3', 'ROLE_LEVEL_4')")
     public HttpEntity<PagedModel<EntityModel<BookingDTO>>> searchByCaseId(
         @Parameter(hidden = true) @ModelAttribute SearchBookings params,
-        @Parameter(hidden = true) Pageable pageable,
+        @SortDefault.SortDefaults(
+            @SortDefault(sort = "scheduledFor", direction = Sort.Direction.ASC)
+        ) @Parameter(hidden = true) Pageable pageable,
         @Parameter(hidden = true) PagedResourcesAssembler<BookingDTO> assembler) {
 
         final Page<BookingDTO> resultPage = bookingService.searchBy(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/BookingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/BookingRepository.java
@@ -29,7 +29,7 @@ public interface BookingRepository extends JpaRepository<Booking, UUID> {
     @Query(
         """
         SELECT b FROM Booking b
-        JOIN b.captureSessions cs
+        LEFT JOIN b.captureSessions cs
         INNER JOIN b.caseId
         WHERE
             (

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/BookingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/BookingRepository.java
@@ -29,6 +29,7 @@ public interface BookingRepository extends JpaRepository<Booking, UUID> {
     @Query(
         """
         SELECT b FROM Booking b
+        JOIN b.captureSessions cs
         INNER JOIN b.caseId
         WHERE
             (
@@ -89,7 +90,6 @@ public interface BookingRepository extends JpaRepository<Booking, UUID> {
                     AND c.status = 'RECORDING_AVAILABLE'
                 ))
             )
-        ORDER BY b.scheduledFor ASC
         """
     )
     Page<Booking> searchBookingsBy(


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3554


### Change description
- Add sort param to `GET /bookings` endpoint for sorting bookings response
    - This is for ticket sorting requirement: sort by capture session finishedAt desc

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Sort bookings by capture session finishedAt by using param sort: `cs.finishedAt,desc`
    - `GET /bookings?sort=cs.finishedAt,desc`


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
