### PR TITLE
S28 3584: Deletion of Only Complete Capture Sessions

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/AuditServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/AuditServiceIT.java
@@ -196,7 +196,7 @@ public class AuditServiceIT extends IntegrationTestBase {
                                                                 null,
                                                                 null,
                                                                 null,
-                                                                RecordingStatus.STANDBY,
+                                                                RecordingStatus.NO_RECORDING,
                                                                 null);
 
         captureSession.setId(UUID.randomUUID());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/CaseServiceIT.java
@@ -183,7 +183,7 @@ public class CaseServiceIT extends IntegrationTestBase {
             null,
             null,
             null,
-            null,
+            RecordingStatus.RECORDING_AVAILABLE,
             null
         );
         entityManager.persist(captureSession);


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3584


### Change description
- Capture sessions can only be deleted if one of these states: `FAILURE`, `RECORDING_AVAILABLE`, `NO_RECORDING`

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Attempt to delete a capture session in each state. See 400 when not allowed.
- Attempt to delete a booking with a capture session in each state- see cascade fails resulting in 400 and deletion not happening.
- (Optional) Do same as above with a case


<!-- If this PR contains a breaking change uncomment the following: -->


> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**
- Potentially breaking if not covered in UI error handling

