### PR TITLE
S28 3657: Blob Tagging for Deletion

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -343,6 +343,7 @@ public class MediaKind implements IMediaService {
             );
             return RecordingStatus.NO_RECORDING;
         }
+        azureIngestStorageService.markContainerAsProcessing(captureSession.getBookingId().toString());
 
         var recordingNoHyphen = getSanitisedLiveEventId(recordingId);
         var recordingTempAssetName = recordingNoHyphen + "_temp";
@@ -362,6 +363,7 @@ public class MediaKind implements IMediaService {
             log.error("Output file from {} transform not found", ENCODE_FROM_INGEST_TRANSFORM);
             return RecordingStatus.FAILURE;
         }
+        azureIngestStorageService.markContainerAsProcessing(recordingId.toString());
 
         var jobName2 = encodeFromMp4(recordingTempAssetName, recordingAssetName, filename);
         var encodeFromMp4JobState = waitEncodeComplete(jobName2, ENCODE_FROM_MP4_TRANSFORM);
@@ -373,6 +375,9 @@ public class MediaKind implements IMediaService {
                       recordingAssetName, recordingId);
             return RecordingStatus.FAILURE;
         }
+
+        azureIngestStorageService.markContainerAsSafeToDelete(captureSession.getBookingId().toString());
+        azureIngestStorageService.markContainerAsSafeToDelete(recordingId.toString());
         return RecordingStatus.RECORDING_AVAILABLE;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/storage/AzureIngestStorageService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/storage/AzureIngestStorageService.java
@@ -1,15 +1,9 @@
 package uk.gov.hmcts.reform.preapi.media.storage;
 
-import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.models.BlobItem;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-
-@Slf4j
 @Service
 public class AzureIngestStorageService extends AzureStorageService {
     @Autowired
@@ -27,22 +21,5 @@ public class AzureIngestStorageService extends AzureStorageService {
 
     public void markContainerAsSafeToDelete(String containerName) {
         tagAllBlobsInContainer(containerName, "status", "safe_to_delete");
-    }
-
-    protected void tagAllBlobsInContainer(String containerName, String tagKey, String tagValue) {
-        log.info("Setting all blob's tags in container '{}': '{}' to '{}'", containerName, tagKey, tagValue);
-        var containerClient = client.getBlobContainerClient(containerName);
-        containerClient.listBlobs()
-            .stream()
-            .map(BlobItem::getName)
-            .map(containerClient::getBlobClient)
-            .forEach(blob -> setBlobTag(blob, tagKey, tagValue));
-    }
-
-    protected void setBlobTag(BlobClient blob, String tagKey, String tagValue) {
-        var currentTags = blob.getTags();
-        var newTags = new HashMap<>(currentTags);
-        newTags.put(tagKey, tagValue);
-        blob.setTags(newTags);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/storage/AzureIngestStorageService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/storage/AzureIngestStorageService.java
@@ -1,9 +1,15 @@
 package uk.gov.hmcts.reform.preapi.media.storage;
 
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobItem;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+
+@Slf4j
 @Service
 public class AzureIngestStorageService extends AzureStorageService {
     @Autowired
@@ -13,5 +19,30 @@ public class AzureIngestStorageService extends AzureStorageService {
 
     public boolean doesValidAssetExist(String containerName) {
         return doesIsmFileExist(containerName) || doesBlobExist(containerName, "gc_state");
+    }
+
+    public void markContainerAsProcessing(String containerName) {
+        tagAllBlobsInContainer(containerName, "status", "processing");
+    }
+
+    public void markContainerAsSafeToDelete(String containerName) {
+        tagAllBlobsInContainer(containerName, "status", "safe_to_delete");
+    }
+
+    protected void tagAllBlobsInContainer(String containerName, String tagKey, String tagValue) {
+        log.info("Setting all blob's tags in container '{}': '{}' to '{}'", containerName, tagKey, tagValue);
+        var containerClient = client.getBlobContainerClient(containerName);
+        containerClient.listBlobs()
+            .stream()
+            .map(BlobItem::getName)
+            .map(containerClient::getBlobClient)
+            .forEach(blob -> setBlobTag(blob, tagKey, tagValue));
+    }
+
+    protected void setBlobTag(BlobClient blob, String tagKey, String tagValue) {
+        var currentTags = blob.getTags();
+        var newTags = new HashMap<>(currentTags);
+        newTags.put(tagKey, tagValue);
+        blob.setTags(newTags);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/storage/AzureStorageService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/storage/AzureStorageService.java
@@ -1,8 +1,14 @@
 package uk.gov.hmcts.reform.preapi.media.storage;
 
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobItem;
+import lombok.extern.slf4j.Slf4j;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 
+import java.util.HashMap;
+
+@Slf4j
 public abstract class AzureStorageService {
 
     protected final BlobServiceClient client;
@@ -51,5 +57,22 @@ public abstract class AzureStorageService {
                 .listBlobs()
                 .stream()
                 .anyMatch(blobItem -> blobItem.getName().equalsIgnoreCase(blobName));
+    }
+
+    public void tagAllBlobsInContainer(String containerName, String tagKey, String tagValue) {
+        log.info("Setting all blob's tags in container '{}': '{}' to '{}'", containerName, tagKey, tagValue);
+        var containerClient = client.getBlobContainerClient(containerName);
+        containerClient.listBlobs()
+            .stream()
+            .map(BlobItem::getName)
+            .map(containerClient::getBlobClient)
+            .forEach(blob -> setBlobTag(blob, tagKey, tagValue));
+    }
+
+    protected void setBlobTag(BlobClient blob, String tagKey, String tagValue) {
+        var currentTags = blob.getTags();
+        var newTags = new HashMap<>(currentTags);
+        newTags.put(tagKey, tagValue);
+        blob.setTags(newTags);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -477,7 +477,6 @@ public class MediaKindTest {
         verify(mockClient, times(1)).deleteLiveOutput(liveEventName, liveEventName);
         verify(azureIngestStorageService, times(1)).doesValidAssetExist(captureSession.getBookingId().toString());
         verify(mockClient, never()).putAsset(any(), any());
-
     }
 
     @Test
@@ -526,6 +525,11 @@ public class MediaKindTest {
         verify(mockClient, times(2)).getJob(eq(ENCODE_FROM_MP4_TRANSFORM), jobArgument4.capture());
         assertThat(jobArgument3.getValue()).startsWith(tempName);
         assertThat(jobArgument4.getValue()).startsWith(tempName);
+        verify(azureIngestStorageService, times(1)).markContainerAsProcessing(captureSession.getBookingId().toString());
+        verify(azureIngestStorageService, times(1)).markContainerAsProcessing(recordingId.toString());
+        verify(azureIngestStorageService, times(1))
+            .markContainerAsSafeToDelete(captureSession.getBookingId().toString());
+        verify(azureIngestStorageService, times(1)).markContainerAsSafeToDelete(recordingId.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/storage/AzureIngestStorageServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/storage/AzureIngestStorageServiceTest.java
@@ -1,21 +1,28 @@
 package uk.gov.hmcts.reform.preapi.media.storage;
 
 import com.azure.core.http.rest.PagedIterable;
+import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.models.BlobItem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = AzureIngestStorageService.class)
@@ -66,5 +73,58 @@ public class AzureIngestStorageServiceTest {
         when(pagedIterable.stream()).thenAnswer(inv -> Stream.of(blobItem));
 
         assertFalse(azureIngestStorageService.doesValidAssetExist("test-container"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void markContainerAsProcessing() {
+        var blobItem = mock(BlobItem.class);
+        var blobClient = mock(BlobClient.class);
+        when(blobContainerClient.exists()).thenReturn(true);
+        when(blobItem.getName()).thenReturn("video.ism");
+        when(pagedIterable.stream()).thenReturn(Stream.of(blobItem));
+        when(blobContainerClient.getBlobClient("video.ism")).thenReturn(blobClient);
+
+        azureIngestStorageService.markContainerAsProcessing("test-container");
+
+        verify(blobClient, times(1)).getTags();
+
+        var tagsCaptor = ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+        verify(blobClient, times(1)).setTags(tagsCaptor.capture());
+        assertThat(tagsCaptor.getValue()).containsEntry("status", "processing");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void markContainerAsSafeToDelete() {
+        var blobItem = mock(BlobItem.class);
+        var blobClient = mock(BlobClient.class);
+        when(blobContainerClient.exists()).thenReturn(true);
+        when(blobItem.getName()).thenReturn("video.ism");
+        when(pagedIterable.stream()).thenReturn(Stream.of(blobItem));
+        when(blobContainerClient.getBlobClient("video.ism")).thenReturn(blobClient);
+
+        azureIngestStorageService.markContainerAsSafeToDelete("test-container");
+
+        verify(blobClient, times(1)).getTags();
+        var tagsCaptor = ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+        verify(blobClient, times(1)).setTags(tagsCaptor.capture());
+        assertThat(tagsCaptor.getValue()).containsEntry("status", "safe_to_delete");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testSetBlobTag() {
+        var blobClient = mock(BlobClient.class);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("existing_key", "existing_value");
+        when(blobClient.getTags()).thenReturn(tags);
+
+        azureIngestStorageService.setBlobTag(blobClient, "status", "processing");
+
+        var tagsCaptor = ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+        verify(blobClient, times(1)).setTags(tagsCaptor.capture());
+        assertThat(tagsCaptor.getValue()).containsEntry("existing_key", "existing_value");
+        assertThat(tagsCaptor.getValue()).containsEntry("status", "processing");
     }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)
- S28-3657


### Change description
- On stopLiveEvent:
  - Before running MK transform jobs for assets stored in ingest account, mark blobs for ingest asset as `state`: `processing`
  - After running MK transform jobs, mark blobs for ingest account assets as `state`: `safe_to_delete`

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Start live event, start recording, stop live event.
  - Locate ingest asset (named after booking id) in storage + see blob index tag `state` set to `processing`
  - After processing has completed, refresh page, sett blob index tag `state` set to `safe_to_delete`


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
