### PR TITLE
SQL to update existing court names and add Birmingham court

### DIFF
--- a/src/main/resources/db/migration/V027__UpdateNewCourtsNRO.sql
+++ b/src/main/resources/db/migration/V027__UpdateNewCourtsNRO.sql
@@ -1,0 +1,99 @@
+-- Update the court names in the courts table by replacing the old names with new ones.
+UPDATE public.courts
+SET name = CASE
+    WHEN name = 'Exeter Crown Court' THEN 'Exeter Combined Court Centre'
+    WHEN name = 'Liverpool Crown Court' THEN 'Liverpool QEII Law Courts: Liverpool Crown Court'
+    WHEN name = 'Mold Crown Court' THEN 'Mold Justice Centre (Mold Law Courts)'
+    WHEN name = 'Nottingham Crown Court' THEN 'Nottingham County Court & Family Court Crown Court'
+    WHEN name = 'Kingston upon Thames Crown Court' THEN 'Kingston-upon-Thames Crown Court'
+    ELSE name  
+END
+WHERE name IN (
+    'Exeter Crown Court',
+    'Liverpool Crown Court',
+    'Mold Crown Court',
+    'Kingston upon Thames Crown Court',
+    'Nottingham Crown Court'
+);
+
+-- Generate audit entries for court name update.
+INSERT INTO public.audits (
+    id, 
+    table_name, 
+    table_record_id, 
+    source, 
+    category, 
+    activity, 
+    functional_area, 
+    created_by, 
+    created_at, 
+    audit_details
+)
+SELECT
+    gen_random_uuid() AS id,
+    'courts' AS table_name,
+    c.id AS table_record_id,
+    'AUTO' AS source,
+    'Court' AS category,
+    'Update' AS activity,
+    'Update a court' AS functional_area,
+    (SELECT id FROM public.users WHERE last_name = 'Admin' LIMIT 1) AS created_by,
+    NOW() AS created_at,
+    jsonb_build_object(
+        'description', 'Court name has been updated.',
+        'courtName', c.name,
+        'locationCode', c.location_code
+    ) AS audit_details
+FROM public.courts c
+WHERE c.name IN (
+    'Exeter Combined Court Centre',
+    'Liverpool QEII Law Courts: Liverpool Crown Court',
+    'Mold Justice Centre (Mold Law Courts)',
+    'Kingston-upon-Thames Crown Court',
+    'Nottingham County Court & Family Court Crown Court'
+);
+
+-- Insert new court into the 'courts' table
+INSERT INTO public.courts (id, court_type, name, location_code)
+VALUES
+(gen_random_uuid(), 'CROWN', 'Birmingham Crown Court & Annex', '404');
+
+-- Insert court-region association into 'court_region'
+INSERT INTO PUBLIC.court_region (court_id, region_id)
+SELECT c.id AS court_id, r.id AS region_id
+FROM PUBLIC.courts c
+JOIN PUBLIC.regions r
+ON CASE
+    WHEN c.name = 'Birmingham Crown Court & Annex' THEN r.NAME = 'West Midlands (England)'
+END; 
+
+-- Generate audit entry for new court.
+INSERT INTO public.audits (
+    id, 
+    table_name, 
+    table_record_id, 
+    source, 
+    category, 
+    activity, 
+    functional_area, 
+    created_by, 
+    created_at, 
+    audit_details
+)
+SELECT
+    gen_random_uuid() AS id,
+    'courts' AS table_name,
+    c.id AS table_record_id,
+    'AUTO' AS source,
+    'Court' AS category,
+    'Add' AS activity,
+    'Add a court' AS functional_area,
+    (SELECT id FROM public.users WHERE last_name = 'Admin' LIMIT 1) AS created_by,
+    NOW() AS created_at,
+    jsonb_build_object(
+        'description', 'A new court has been added.',
+        'courtName', c.name,
+        'locationCode', c.location_code
+    ) AS audit_details
+FROM public.courts c
+WHERE (c.name = 'Birmingham Crown Court & Annex');


### PR DESCRIPTION
### JIRA ticket(s)

- S28-3615   ( refer to ticket for court info added in this PR + Colin's comments)

### Change Description

#### Updated Pre-existing court names
- Updated name for **'Exeter Crown Court'** to `Exeter Combined Court Centre`.
- Updated name for **'Liverpool Crown Court'** to `Liverpool QEII Law Courts: Liverpool Crown Court`.
- Updated name for **'Mold Crown Court'** to `Mold Justice Centre (Mold Law Courts)`.
- Updated name for **'Nottingham Crown Court'** to `Nottingham County Court & Family Court Crown Court`.
- Updated name for **'Kingston upon Thames Crown Court'** to `Kingston-upon-Thames Crown Court`.

#### Inserted New Court:
- Added 1 new courts to the `courts` table using generated UUIDs.  This is for **'Birmingham Crown Court & Annex'**

#### Established Court-Region Associations:
- Mapped new court to region dynamically

#### Added Audit Logging:
- Implemented audit entry for new court addition.
- Implemented audit entries for all court name updates 
