### PR TITLE
S28 3316: Trigger Re-Invitation Email for User

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/InviteService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/InviteService.java
@@ -63,11 +63,9 @@ public class InviteService {
     public UpsertResult upsert(CreateInviteDTO createInviteDTO) {
         var result = userService.upsert(createInviteDTO);
 
-        if (result == UpsertResult.CREATED) {
-            var user = userRepository.findById(createInviteDTO.getUserId())
-                .orElseThrow(() -> new NotFoundException("User: " + createInviteDTO.getUserId()));
-            onUserInvitedToPortal(user);
-        }
+        var user = userRepository.findById(createInviteDTO.getUserId())
+            .orElseThrow(() -> new NotFoundException("User: " + createInviteDTO.getUserId()));
+        onUserInvitedToPortal(user);
 
         return result;
     }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3316


### Change description
- Remove check for only sending email on creation of invite service. Now sends email on successful call to user upsert from invite method (`userService.upsert(CreateInviteDTO createInviteDTO)`). 

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Call `PUT /invite/{userid}` to create user/invite and get 201 response
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
