### PR TITLE
S28 2419: Fix Duplicate Audits on Bookings

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/AuditServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/AuditServiceIT.java
@@ -177,12 +177,10 @@ public class AuditServiceIT extends IntegrationTestBase {
 
         var auditResults = auditService.getAuditsByTableRecordId(booking.getId());
         Assertions.assertEquals(0, auditResultsEmpty.size());
-        Assertions.assertEquals(2, auditResultsCreated.size());
-        Assertions.assertEquals(4, auditResults.size());
+        Assertions.assertEquals(1, auditResultsCreated.size());
+        Assertions.assertEquals(2, auditResults.size());
         Assertions.assertEquals(AuditAction.CREATE.toString(), auditResults.get(0).getActivity());
-        Assertions.assertEquals(AuditAction.UPDATE.toString(), auditResults.get(1).getActivity());
-        Assertions.assertEquals(AuditAction.UPDATE.toString(), auditResults.get(2).getActivity());
-        Assertions.assertEquals(AuditAction.DELETE.toString(), auditResults.get(3).getActivity());
+        Assertions.assertEquals(AuditAction.DELETE.toString(), auditResults.get(1).getActivity());
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Booking.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Booking.java
@@ -84,4 +84,13 @@ public class Booking extends CreatedModifiedAtEntity implements ISoftDeletable {
     public boolean isDeleteOperation() {
         return this.isSoftDeleteOperation;
     }
+
+    @Override
+    public void prePersist() {
+        super.prePersist();
+        if (participants != null) {
+            // force hibernate to load the collection so audit is correct
+            participants.size();
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/listeners/AuditListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/listeners/AuditListener.java
@@ -129,7 +129,7 @@ public class AuditListener {
         disabledAuditClasses.get().put(entity, actions);
     }
 
-    private static boolean isAuditableEntity(Class<?> entity, AuditAction action) {
+    protected static boolean isAuditableEntity(Class<?> entity, AuditAction action) {
         return !disabledAuditClasses.get().getOrDefault(entity, Set.of()).contains(action);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
@@ -47,7 +47,6 @@ public class BookingService {
     private final CaptureSessionService captureSessionService;
     private final ShareBookingService shareBookingService;
     private final CaseService caseService;
-    private final AuditListener auditListener;
 
     @Autowired
     public BookingService(final BookingRepository bookingRepository,
@@ -55,15 +54,13 @@ public class BookingService {
                           final ParticipantRepository participantRepository,
                           final CaptureSessionService captureSessionService,
                           final ShareBookingService shareBookingService,
-                          @Lazy CaseService caseService,
-                          @Lazy AuditListener auditListener) {
+                          @Lazy CaseService caseService) {
         this.bookingRepository = bookingRepository;
         this.participantRepository = participantRepository;
         this.caseRepository = caseRepository;
         this.captureSessionService = captureSessionService;
         this.shareBookingService = shareBookingService;
         this.caseService = caseService;
-        this.auditListener = auditListener;
     }
 
     @PreAuthorize("@authorisationService.hasBookingAccess(authentication, #id)")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/entities/listeners/AuditListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/entities/listeners/AuditListenerTest.java
@@ -1,21 +1,34 @@
 package uk.gov.hmcts.reform.preapi.entities.listeners;
 
+import jakarta.persistence.Table;
 import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
+import uk.gov.hmcts.reform.preapi.entities.Audit;
 import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
+import uk.gov.hmcts.reform.preapi.entities.base.BaseEntity;
+import uk.gov.hmcts.reform.preapi.enums.AuditAction;
 import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
+import uk.gov.hmcts.reform.preapi.repositories.AuditRepository;
 import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = AuditListener.class)
@@ -27,12 +40,16 @@ public class AuditListenerTest {
     private AppAccessRepository appAccessRepository;
 
     @MockBean
+    private AuditRepository auditRepository;
+
+    @MockBean
     private HttpServletRequest request;
 
     @Autowired
     private AuditListener auditListener;
 
     @Test
+    @DisplayName("Should get user id from context when app user")
     void getUserIdFromContextAppUser() {
         var appAccess = new AppAccess();
         appAccess.setId(UUID.randomUUID());
@@ -46,6 +63,7 @@ public class AuditListenerTest {
     }
 
     @Test
+    @DisplayName("Should set userid to null when app user and app access is null")
     void getUserIdFromContextAppUserNull() {
         when(userAuthentication.isAppUser()).thenReturn(true);
         when(userAuthentication.getAppAccess()).thenReturn(null);
@@ -57,6 +75,7 @@ public class AuditListenerTest {
     }
 
     @Test
+    @DisplayName("Should get user id from context when portal user")
     void getUserIdFromContextPortalUser() {
         var portalAccess = new PortalAccess();
         portalAccess.setId(UUID.randomUUID());
@@ -70,6 +89,7 @@ public class AuditListenerTest {
     }
 
     @Test
+    @DisplayName("Should set userid to null when portal user and portal access is null")
     void getUserIdFromContextPortalUserNull() {
         when(userAuthentication.isAppUser()).thenReturn(false);
         when(userAuthentication.getPortalAccess()).thenReturn(null);
@@ -81,6 +101,7 @@ public class AuditListenerTest {
     }
 
     @Test
+    @DisplayName("Should set userid to null when context authentication is null")
     void getUserIdFromContextNullAuth() {
         SecurityContextHolder.getContext().setAuthentication(null);
 
@@ -90,6 +111,7 @@ public class AuditListenerTest {
     }
 
     @Test
+    @DisplayName("Should set userid to null when context authentication is not UserAuthentication")
     void getUserIdFromContextAnonAuth() {
         var anonAuth = mock(AnonymousAuthenticationToken.class);
         SecurityContextHolder.getContext().setAuthentication(anonAuth);
@@ -97,5 +119,93 @@ public class AuditListenerTest {
         var userId = auditListener.getUserIdFromContext();
 
         assertThat(userId).isNull();
+    }
+
+    @Test
+    @DisplayName("Should create CREATE audit on entity creation")
+    void shouldAuditOnPrePersist() {
+        auditListener.prePersist(new MockEntity());
+
+        var argumentCaptor = ArgumentCaptor.forClass(Audit.class);
+        verify(auditRepository, times(1)).save(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getActivity()).isEqualTo(AuditAction.CREATE.toString());
+    }
+
+    @Test
+    @DisplayName("Should create UPDATE audit on entity update")
+    void shouldAuditOnPreUpdate() {
+        auditListener.preUpdate(new MockEntity());
+
+        var argumentCaptor = ArgumentCaptor.forClass(Audit.class);
+        verify(auditRepository, times(1)).save(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getActivity()).isEqualTo(AuditAction.UPDATE.toString());
+    }
+
+    @Test
+    @DisplayName("Should create DELETE audit on entity deletion")
+    void shouldAuditOnPreRemove() {
+        auditListener.preRemove(new MockEntity());
+
+        var argumentCaptor = ArgumentCaptor.forClass(Audit.class);
+        verify(auditRepository, times(1)).save(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getActivity()).isEqualTo(AuditAction.DELETE.toString());
+    }
+
+    @Test
+    @DisplayName("Should not audit when disabled for class and action")
+    void shouldNotAuditWhenDisabledForClassAndAction() {
+        AuditListener.disableAuditingForClass(MockEntity.class, Set.of(AuditAction.CREATE));
+
+        auditListener.prePersist(new MockEntity());
+
+        verify(auditRepository, never()).save(any(Audit.class));
+    }
+
+    @Test
+    @DisplayName("Should audit when audit has been re-enabled for class")
+    void shouldAuditWhenEnabledForClass() {
+        AuditListener.disableAuditingForClass(MockEntity.class, Set.of(AuditAction.CREATE));
+        AuditListener.enableAuditingForClass(MockEntity.class);
+
+        auditListener.prePersist(new MockEntity());
+
+        verify(auditRepository, times(1)).save(any(Audit.class));
+    }
+
+    @Test
+    @DisplayName("Should enable/disable audits correctly when in a multi-threaded environment")
+    void shouldMaintainThreadLocalIsolation() throws InterruptedException {
+        var thread1AuditEnabled = new AtomicBoolean(false);
+        var thread2AuditEnabled = new AtomicBoolean(false);
+
+        var entityClass = MockEntity.class;
+
+        var thread1 = new Thread(() -> {
+            AuditListener.disableAuditingForClass(entityClass, Set.of(AuditAction.CREATE));
+            thread1AuditEnabled.set(AuditListener.isAuditableEntity(entityClass, AuditAction.CREATE));
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        var thread2 = new Thread(() ->
+            thread2AuditEnabled.set(AuditListener.isAuditableEntity(entityClass, AuditAction.CREATE))
+        );
+
+        thread1.start();
+        Thread.sleep(50);
+        thread2.start();
+
+        thread1.join();
+        thread2.join();
+
+        assertThat(thread1AuditEnabled.get()).isFalse();
+        assertThat(thread2AuditEnabled.get()).isTrue();
+    }
+
+    @Table(name = "mock_table")
+    private static class MockEntity extends BaseEntity {
     }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-2419


### Change description
- Fix issue causing 2 audits to be created on booking creations (1x CREATE, 1x UPDATE)
- Fix issue causing CREATE audit auditDetails on bookings contained an empty list of participants

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
