### PR TITLE
S28-3377 Functional test changes

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/OpenAPISpecFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/OpenAPISpecFunctionalTest.java
@@ -3,23 +3,23 @@ package uk.gov.hmcts.reform.preapi.controllers;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.OK;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class OpenAPISpecFunctionalTest {
     private static final String SPEC_ENDPOINT = "/v3/api-docs";
 
-    @Value("${TEST_URL:http://localhost:4550}")
-    private String testUrl;
+    @LocalServerPort
+    private int port;
 
     @BeforeEach
     public void setUp() {
-        RestAssured.baseURI = testUrl;
+        RestAssured.baseURI = String.format("http://localhost:%s", port);
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/util/FunctionalTestBase.java
@@ -6,8 +6,8 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.util.CollectionUtils;
 import uk.gov.hmcts.reform.preapi.Application;
 import uk.gov.hmcts.reform.preapi.controllers.params.TestingSupportRoles;
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static uk.gov.hmcts.reform.preapi.config.OpenAPIConfiguration.X_USER_ID_HEADER;
 
-@SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @SuppressWarnings("PMD.JUnit5TestShouldBePackagePrivate")
 public class FunctionalTestBase {
     protected static final String CONTENT_TYPE_VALUE = "application/json";
@@ -64,8 +64,10 @@ public class FunctionalTestBase {
 
     protected static Map<TestingSupportRoles, AuthUserDetails> authenticatedUserIds;
 
-    @Value("${TEST_URL:http://localhost:4550}")
-    protected String testUrl;
+    @LocalServerPort
+    private int port;
+
+    public String testUrl = "";
 
     @BeforeAll
     static void beforeAll() {
@@ -96,6 +98,7 @@ public class FunctionalTestBase {
 
     @BeforeEach
     void setUp() {
+        testUrl = String.format("http://localhost:%s", port);
         RestAssured.baseURI = testUrl;
 
         if (authenticatedUserIds == null) {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/S28-3377

### Change description

- Changed functional tests so they always use the app spun up by spring
