### PR TITLE
S28 2059: Search Audits

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/AuditController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/AuditController.java
@@ -17,18 +17,23 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.preapi.controllers.params.SearchAudits;
 import uk.gov.hmcts.reform.preapi.dto.AuditDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateAuditDTO;
+import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 import uk.gov.hmcts.reform.preapi.exception.PathPayloadMismatchException;
 import uk.gov.hmcts.reform.preapi.exception.RequestedPageOutOfRangeException;
 import uk.gov.hmcts.reform.preapi.services.AuditService;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static uk.gov.hmcts.reform.preapi.config.OpenAPIConfiguration.X_USER_ID_HEADER;
@@ -64,6 +69,46 @@ public class AuditController {
     @GetMapping
     @Operation(operationId = "getAuditLogs", summary = "Search all Audits")
     @Parameter(
+        name = "after",
+        description = "The date time to search after",
+        schema = @Schema(implementation = LocalDateTime.class, format = "iso-date-time"),
+        example = "2021-01-01T00:00:00"
+    )
+    @Parameter(
+        name = "before",
+        description = "The date time to search before",
+        schema = @Schema(implementation = LocalDateTime.class, format = "iso-date-time"),
+        example = "2021-01-01T00:00:00"
+    )
+    @Parameter(
+        name = "functionalArea",
+        description = "The functional area to search by",
+        schema = @Schema(implementation = String.class),
+        example = "API"
+    )
+    @Parameter(
+        name = "source",
+        description = "The source to search by",
+        schema = @Schema(implementation = AuditLogSource.class)
+    )
+    @Parameter(
+        name = "userName",
+        description = "Partial user's name to search by",
+        schema = @Schema(implementation = String.class)
+    )
+    @Parameter(
+        name = "courtId",
+        description = "The court id of the audit to search by",
+        schema = @Schema(implementation = UUID.class),
+        example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    @Parameter(
+        name = "caseReference",
+        description = "The case reference of the audit to search by",
+        schema = @Schema(implementation = String.class),
+        example = "CASE12345"
+    )
+    @Parameter(
         name = "page",
         description = "The page number of search result to return",
         schema = @Schema(implementation = Integer.class),
@@ -77,6 +122,7 @@ public class AuditController {
     )
     @PreAuthorize("hasAnyRole('ROLE_SUPER_USER')")
     public HttpEntity<PagedModel<EntityModel<AuditDTO>>> searchAuditLogs(
+        @Parameter(hidden = true) @ModelAttribute SearchAudits params,
         @SortDefault.SortDefaults(
             @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
         )
@@ -84,6 +130,13 @@ public class AuditController {
         @Parameter(hidden = true) PagedResourcesAssembler<AuditDTO> assembler
     ) {
         var resultPage = auditService.findAll(
+            params.getAfter() != null ? Timestamp.valueOf(params.getAfter()) : null,
+            params.getBefore() != null ? Timestamp.valueOf(params.getBefore()) : null,
+            params.getFunctionalArea(),
+            params.getSource(),
+            params.getUserName(),
+            params.getCourtId(),
+            params.getCaseReference(),
             pageable
         );
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -410,7 +410,7 @@ class TestingSupportController {
         @Parameter(hidden = true) Pageable pageable,
         @Parameter(hidden = true) PagedResourcesAssembler<Audit> assembler
     ) {
-        var resultPage = auditRepository.searchAll(pageable);
+        var resultPage = auditRepository.searchAll(null, null, null, null, null, null, null, pageable);
 
         if (pageable.getPageNumber() > resultPage.getTotalPages()) {
             throw new RequestedPageOutOfRangeException(pageable.getPageNumber(), resultPage.getTotalPages());

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchAudits.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchAudits.java
@@ -25,4 +25,16 @@ public class SearchAudits {
     private UUID courtId;
 
     private String caseReference;
+
+    public String getFunctionalArea() {
+        return functionalArea != null && !functionalArea.isEmpty() ? functionalArea : null;
+    }
+
+    public String getUserName() {
+        return userName != null && !userName.isEmpty() ? userName : null;
+    }
+
+    public String getCaseReference() {
+        return caseReference != null && !caseReference.isEmpty() ? caseReference : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchAudits.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchAudits.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.preapi.controllers.params;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+public class SearchAudits {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime after;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime before;
+
+    private String functionalArea;
+
+    private AuditLogSource source;
+
+    private String userName;
+
+    private UUID courtId;
+
+    private String caseReference;
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/AuditDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/AuditDTO.java
@@ -7,37 +7,55 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.dto.base.BaseUserDTO;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.entities.User;
 
 import java.sql.Timestamp;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
 @Schema(description = "AuditDTO")
+@EqualsAndHashCode(callSuper = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AuditDTO extends CreateAuditDTO {
 
-    @Schema(description = "AuditCreatedAt")
     @NotNull
+    @Schema(description = "AuditCreatedAt")
     private Timestamp createdAt;
 
-    @Schema(description = "AuditCreatedBy")
     @NotNull
-    private UUID createdBy;
+    @Schema(description = "AuditCreatedBy")
+    private BaseUserDTO createdBy;
 
     public AuditDTO(Audit auditEntity) {
         super();
-        this.id = auditEntity.getId();
-        this.tableName = auditEntity.getTableName();
-        this.tableRecordId = auditEntity.getTableRecordId();
-        this.source = auditEntity.getSource();
-        this.category = auditEntity.getCategory();
-        this.activity = auditEntity.getActivity();
-        this.functionalArea = auditEntity.getFunctionalArea();
-        this.auditDetails = auditEntity.getAuditDetails();
-        this.createdAt = auditEntity.getCreatedAt();
-        this.createdBy = auditEntity.getCreatedBy();
+        id = auditEntity.getId();
+        tableName = auditEntity.getTableName();
+        tableRecordId = auditEntity.getTableRecordId();
+        source = auditEntity.getSource();
+        category = auditEntity.getCategory();
+        activity = auditEntity.getActivity();
+        functionalArea = auditEntity.getFunctionalArea();
+        auditDetails = auditEntity.getAuditDetails();
+        createdAt = auditEntity.getCreatedAt();
+        if (auditEntity.getCreatedBy() != null) {
+            createdBy = new BaseUserDTO();
+            createdBy.setId(auditEntity.getCreatedBy());
+        }
+    }
+
+    public AuditDTO(Audit auditEntity, User user) {
+        super();
+        id = auditEntity.getId();
+        tableName = auditEntity.getTableName();
+        tableRecordId = auditEntity.getTableRecordId();
+        source = auditEntity.getSource();
+        category = auditEntity.getCategory();
+        activity = auditEntity.getActivity();
+        functionalArea = auditEntity.getFunctionalArea();
+        auditDetails = auditEntity.getAuditDetails();
+        createdAt = auditEntity.getCreatedAt();
+        createdBy = new BaseUserDTO(user);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/AuditDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/AuditDTO.java
@@ -46,16 +46,7 @@ public class AuditDTO extends CreateAuditDTO {
     }
 
     public AuditDTO(Audit auditEntity, User user) {
-        super();
-        id = auditEntity.getId();
-        tableName = auditEntity.getTableName();
-        tableRecordId = auditEntity.getTableRecordId();
-        source = auditEntity.getSource();
-        category = auditEntity.getCategory();
-        activity = auditEntity.getActivity();
-        functionalArea = auditEntity.getFunctionalArea();
-        auditDetails = auditEntity.getAuditDetails();
-        createdAt = auditEntity.getCreatedAt();
+        this(auditEntity);
         createdBy = new BaseUserDTO(user);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/AuditRepository.java
@@ -4,10 +4,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
 import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,8 +31,63 @@ public interface AuditRepository extends JpaRepository<Audit, UUID> {
     @Query(
         """
         SELECT a FROM Audit a
+        WHERE (CAST(:after as Timestamp) IS NULL
+            OR CAST(FUNCTION('TIMEZONE', 'Europe/London', a.createdAt) as Timestamp) >= :after)
+        AND (CAST(:before as Timestamp) IS NULL
+            OR CAST(FUNCTION('TIMEZONE', 'Europe/London', a.createdAt) as Timestamp) <= :before)
+        AND (:functionalArea IS NULL OR a.functionalArea ILIKE %:functionalArea%)
+        AND (CAST(:source as text) IS NULL OR a.source = :source)
+        AND (:userName IS NULL
+            OR EXISTS (
+                SELECT 1 FROM AppAccess aa
+                WHERE aa.id = a.createdBy
+                AND CONCAT(aa.user.firstName, ' ', aa.user.lastName) ILIKE %:userName%)
+            OR EXISTS (
+                SELECT 1 FROM PortalAccess pa
+                WHERE pa.id = a.createdBy
+                AND CONCAT(pa.user.firstName, ' ', pa.user.lastName) ILIKE %:userName%))
+        AND ((CAST(:courtId as uuid) IS NULL AND :caseReference IS NULL)
+            OR EXISTS (
+                SELECT 1 FROM Court court
+                WHERE :caseReference IS NULL
+                AND court.id = a.tableRecordId
+                AND (CAST(:courtId as uuid) IS NULL OR court.id = :courtId))
+            OR EXISTS (
+                SELECT 1 FROM Case c
+                WHERE c.id = a.tableRecordId
+                AND (CAST(:courtId as uuid) IS NULL OR c.court.id = :courtId)
+                AND (:caseReference IS NULL OR c.reference ILIKE %:caseReference%))
+            OR EXISTS (
+                SELECT 1 FROM Booking b
+                WHERE b.id = a.tableRecordId
+                AND (CAST(:courtId as uuid) IS NULL OR b.caseId.court.id = :courtId)
+                AND (:caseReference IS NULL OR b.caseId.reference ILIKE %:caseReference%))
+            OR EXISTS (
+                SELECT 1 FROM CaptureSession cs
+                WHERE cs.id = a.tableRecordId
+                AND (CAST(:courtId as uuid) IS NULL OR cs.booking.caseId.court.id = :courtId)
+                AND (:caseReference IS NULL OR cs.booking.caseId.reference ILIKE %:caseReference%))
+            OR EXISTS (
+                SELECT 1 FROM Recording r
+                WHERE r.id = a.tableRecordId
+                AND (CAST(:courtId as uuid) IS NULL OR r.captureSession.booking.caseId.court.id = :courtId)
+                AND (:caseReference IS NULL OR r.captureSession.booking.caseId.reference ILIKE %:caseReference%))
+            OR EXISTS (
+                SELECT 1 FROM Participant p
+                WHERE p.id = a.tableRecordId
+                AND (CAST(:courtId as uuid) IS NULL OR p.caseId.court.id = :courtId)
+                AND (:caseReference IS NULL OR p.caseId.reference ILIKE %:caseReference%)))
         ORDER BY a.createdAt DESC
         """
     )
-    Page<Audit> searchAll(Pageable pageable);
+    Page<Audit> searchAll(
+        @Param("after") Timestamp after,
+        @Param("before") Timestamp before,
+        @Param("functionalArea") String functionalArea,
+        @Param("source") AuditLogSource source,
+        @Param("userName") String userName,
+        @Param("courtId") UUID courtId,
+        @Param("caseReference") String caseReference,
+        Pageable pageable
+    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/AuditService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/AuditService.java
@@ -8,10 +8,15 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.AuditDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateAuditDTO;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.ImmutableDataException;
+import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
 import uk.gov.hmcts.reform.preapi.repositories.AuditRepository;
+import uk.gov.hmcts.reform.preapi.repositories.PortalAccessRepository;
+import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -20,10 +25,17 @@ import javax.annotation.Nullable;
 public class AuditService {
 
     private final AuditRepository auditRepository;
+    private final UserRepository userRepository;
+    private final AppAccessRepository appAccessRepository;
+    private final PortalAccessRepository portalAccessRepository;
 
     @Autowired
-    public AuditService(AuditRepository auditRepository) {
+    public AuditService(AuditRepository auditRepository, UserRepository userRepository,
+                        AppAccessRepository appAccessRepository, PortalAccessRepository portalAccessRepository) {
         this.auditRepository = auditRepository;
+        this.userRepository = userRepository;
+        this.appAccessRepository = appAccessRepository;
+        this.portalAccessRepository = portalAccessRepository;
     }
 
     public UpsertResult upsert(CreateAuditDTO createAuditDTO, @Nullable UUID createdBy) {
@@ -48,10 +60,29 @@ public class AuditService {
     }
 
     @Transactional
-    public Page<AuditDTO> findAll(Pageable pageable) {
+    public Page<AuditDTO> findAll(
+        Timestamp after,
+        Timestamp before,
+        String functionalArea,
+        AuditLogSource source,
+        String userName,
+        UUID courtId,
+        String caseReference,
+        Pageable pageable
+    ) {
         return auditRepository
-            .searchAll(pageable)
-            .map(AuditDTO::new);
+            .searchAll(after, before, functionalArea, source, userName, courtId, caseReference, pageable)
+            .map(audit -> {
+                var createdById = audit.getCreatedBy();
+                if (createdById == null) {
+                    return new AuditDTO(audit);
+                }
+                return appAccessRepository.findById(createdById)
+                    .map(aa -> new AuditDTO(audit, aa.getUser()))
+                    .orElseGet(() -> portalAccessRepository.findById(createdById)
+                        .map(pa -> new AuditDTO(audit, pa.getUser()))
+                        .orElseGet(() -> new AuditDTO(audit)));
+            });
     }
 
     public List<Audit> getAuditsByTableRecordId(UUID tableRecordId) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/AuditService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/AuditService.java
@@ -14,7 +14,6 @@ import uk.gov.hmcts.reform.preapi.exception.ImmutableDataException;
 import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
 import uk.gov.hmcts.reform.preapi.repositories.AuditRepository;
 import uk.gov.hmcts.reform.preapi.repositories.PortalAccessRepository;
-import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -25,15 +24,14 @@ import javax.annotation.Nullable;
 public class AuditService {
 
     private final AuditRepository auditRepository;
-    private final UserRepository userRepository;
     private final AppAccessRepository appAccessRepository;
     private final PortalAccessRepository portalAccessRepository;
 
     @Autowired
-    public AuditService(AuditRepository auditRepository, UserRepository userRepository,
-                        AppAccessRepository appAccessRepository, PortalAccessRepository portalAccessRepository) {
+    public AuditService(AuditRepository auditRepository,
+                        AppAccessRepository appAccessRepository,
+                        PortalAccessRepository portalAccessRepository) {
         this.auditRepository = auditRepository;
-        this.userRepository = userRepository;
         this.appAccessRepository = appAccessRepository;
         this.portalAccessRepository = portalAccessRepository;
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/AuditControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/AuditControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,7 +12,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.reform.preapi.controllers.AuditController;
 import uk.gov.hmcts.reform.preapi.dto.AuditDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateAuditDTO;
@@ -22,12 +22,14 @@ import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 import uk.gov.hmcts.reform.preapi.services.AuditService;
 import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
 
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,7 +39,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.preapi.config.OpenAPIConfiguration.X_USER_ID_HEADER;
-
 
 @WebMvcTest(AuditController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -58,15 +59,18 @@ class AuditControllerTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    private String getPath(UUID auditId) {
+        return "/audit/" + auditId;
+    }
+
     @BeforeAll
-    static void setUp() {
+    public static void setUp() {
         OBJECT_MAPPER.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SS'Z'"));
     }
 
-    @DisplayName("Should create an audit record with 201 response code")
     @Test
-    void createAuditEndpointCreated() throws Exception {
-
+    @DisplayName("Should create an audit record with 201 response code")
+    public void createAuditEndpointCreated() throws Exception {
         var audit = new CreateAuditDTO();
         audit.setId(UUID.randomUUID());
         audit.setAuditDetails(OBJECT_MAPPER.readTree("{\"test\": \"test\"}"));
@@ -75,9 +79,7 @@ class AuditControllerTest {
         var xUserId = UUID.randomUUID();
         when(auditService.upsert(audit, xUserId)).thenReturn(UpsertResult.CREATED);
 
-        System.out.println(OBJECT_MAPPER.writeValueAsString(audit));
-
-        MvcResult response = mockMvc.perform(put(getPath(audit.getId()))
+        var response = mockMvc.perform(put(getPath(audit.getId()))
                                                  .with(csrf())
                                                  .header(X_USER_ID_HEADER, xUserId)
                                                  .content(OBJECT_MAPPER.writeValueAsString(audit))
@@ -89,10 +91,9 @@ class AuditControllerTest {
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
     }
 
-    @DisplayName("Should create an audit record with 201 response code without x-user-id header")
     @Test
-    void createAuditEndpointWithoutXUserIdCreated() throws Exception {
-
+    @DisplayName("Should create an audit record with 201 response code without x-user-id header")
+    public void createAuditEndpointWithoutXUserIdCreated() throws Exception {
         var audit = new CreateAuditDTO();
         audit.setId(UUID.randomUUID());
         audit.setAuditDetails(OBJECT_MAPPER.readTree("{\"test\": \"test\"}"));
@@ -101,9 +102,7 @@ class AuditControllerTest {
         var xUserId = UUID.randomUUID();
         when(auditService.upsert(audit, xUserId)).thenReturn(UpsertResult.CREATED);
 
-        System.out.println(OBJECT_MAPPER.writeValueAsString(audit));
-
-        MvcResult response = mockMvc.perform(put(getPath(audit.getId()))
+        var response = mockMvc.perform(put(getPath(audit.getId()))
                                                  .with(csrf())
                                                  .content(OBJECT_MAPPER.writeValueAsString(audit))
                                                  .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -114,10 +113,9 @@ class AuditControllerTest {
         assertThat(response.getResponse().getContentAsString()).isEqualTo("");
     }
 
-    @DisplayName("Should fail to update an audit record as they are immutable")
     @Test
-    void updateAuditFailure() throws Exception {
-
+    @DisplayName("Should fail to update an audit record as they are immutable")
+    public void updateAuditFailure() throws Exception {
         var audit = new CreateAuditDTO();
         audit.setId(UUID.randomUUID());
         audit.setAuditDetails(OBJECT_MAPPER.readTree("{\"test\": \"test\"}"));
@@ -137,10 +135,9 @@ class AuditControllerTest {
                            .value("Data is immutable and cannot be changed. Id: " + audit.getId()));
     }
 
-    @DisplayName("Should fail to create an audit record with 400 response code auditId mismatch")
     @Test
-    void createAuditEndpointAuditIdMismatch() throws Exception {
-
+    @DisplayName("Should fail to create an audit record with 400 response code auditId mismatch")
+    public void createAuditEndpointAuditIdMismatch() throws Exception {
         var audit = new CreateAuditDTO();
         audit.setId(UUID.randomUUID());
         audit.setAuditDetails(OBJECT_MAPPER.readTree("{\"test\": \"test\"}"));
@@ -148,7 +145,7 @@ class AuditControllerTest {
 
         var xUserId = UUID.randomUUID();
 
-        MvcResult response = mockMvc.perform(put(getPath(UUID.randomUUID()))
+        var response = mockMvc.perform(put(getPath(UUID.randomUUID()))
                                                  .with(csrf())
                                                  .header(X_USER_ID_HEADER, xUserId)
                                                  .content(OBJECT_MAPPER.writeValueAsString(audit))
@@ -161,26 +158,21 @@ class AuditControllerTest {
             .isEqualTo("{\"message\":\"Path id does not match payload property createAuditDTO.id\"}");
     }
 
-    @DisplayName("Should fail to create an audit record with 400 response code")
     @Test
-    void createAuditEndpointNotAcceptable() throws Exception {
-
+    @DisplayName("Should fail to create an audit record with 400 response code")
+    public void createAuditEndpointNotAcceptable() throws Exception {
         mockMvc.perform(put(getPath(UUID.randomUUID())))
             .andExpect(status().is4xxClientError());
     }
 
-    private String getPath(UUID auditId) {
-        return "/audit/" + auditId;
-    }
-
-    @DisplayName("Should get a list of audit logs with 200 response code")
     @Test
-    void testSearchAuditLogsSuccess() throws Exception {
-        UUID auditLogId = UUID.randomUUID();
+    @DisplayName("Should get a list of audit logs with 200 response code")
+    public void testSearchAuditLogsSuccess() throws Exception {
+        var auditLogId = UUID.randomUUID();
         var mockAuditDTO = new AuditDTO();
         mockAuditDTO.setId(auditLogId);
         var auditDTOList = List.of(mockAuditDTO);
-        when(auditService.findAll(any()))
+        when(auditService.findAll(any(), any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(auditDTOList));
 
         mockMvc.perform(get("/audit")
@@ -190,22 +182,176 @@ class AuditControllerTest {
             .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
             .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
 
-        verify(auditService, times(1)).findAll(any());
+        verify(auditService, times(1)).findAll(any(), any(), any(), any(), any(), any(), any(), any());
     }
 
-    @DisplayName("Requested page out of range")
     @Test
-    void getAuditLogsRequestedPageOutOfRange() throws Exception {
+    @DisplayName("Search audits by created after")
+    public void searchLogsByCreatedAfter() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var searchTimestampAfterStr = "2021-01-01T00:00:00";
+        when(auditService.findAll(any(Timestamp.class), any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?after=" + searchTimestampAfterStr)
+                                              .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        var argumentCaptor = ArgumentCaptor.forClass(Timestamp.class);
+
+        verify(auditService, times(1))
+            .findAll(argumentCaptor.capture(), any(), any(), any(), any(), any(), any(), any());
+
+        assertThat(argumentCaptor.getValue().toString()).isEqualTo("2021-01-01 00:00:00.0");
+    }
+
+    @Test
+    @DisplayName("Search audits by created before")
+    public void searchLogsByCreatedBefore() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var searchTimestampBeforeStr = "2021-01-01T00:00:00";
+        when(auditService.findAll(any(), any(Timestamp.class), any(), any(), any(), any(), any(), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?before=" + searchTimestampBeforeStr)
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        var argumentCaptor = ArgumentCaptor.forClass(Timestamp.class);
+
+        verify(auditService, times(1))
+            .findAll(any(), argumentCaptor.capture(), any(), any(), any(), any(), any(), any());
+
+        assertThat(argumentCaptor.getValue().toString()).isEqualTo("2021-01-01 00:00:00.0");
+    }
+
+    @Test
+    @DisplayName("Search audits by functional area")
+    public void searchLogsByFunctionalArea() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var functionalArea = "API";
+        when(auditService.findAll(any(), any(), eq(functionalArea), any(), any(), any(), any(), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?functionalArea=" + functionalArea)
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        verify(auditService, times(1))
+            .findAll(any(), any(), eq(functionalArea), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Search audits by source")
+    public void searchLogsBySource() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var source = AuditLogSource.AUTO;
+        when(auditService.findAll(any(), any(), any(), eq(source), any(), any(), any(), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?source=" + source)
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        verify(auditService, times(1))
+            .findAll(any(), any(), any(), eq(source), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Search audits by user's name")
+    public void searchLogsByUserName() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var name = "someone";
+        when(auditService.findAll(any(), any(), any(), any(), eq(name), any(), any(), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?userName=" + name)
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        verify(auditService, times(1))
+            .findAll(any(), any(), any(), any(), eq(name), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Search audits by court id")
+    public void searchLogsByCourtId() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var courtId = UUID.randomUUID();
+        when(auditService.findAll(any(), any(), any(), any(), any(), eq(courtId), any(), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?courtId=" + courtId)
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        verify(auditService, times(1))
+            .findAll(any(), any(), any(), any(), any(), eq(courtId), any(), any());
+    }
+
+    @Test
+    @DisplayName("Search audits by case reference")
+    public void searchLogsByCaseReference() throws Exception {
+        var auditLogId = UUID.randomUUID();
+        var mockAudit = new AuditDTO();
+        mockAudit.setId(auditLogId);
+        var auditDTOList = List.of(mockAudit);
+        var caseReference = "CASE123";
+        when(auditService.findAll(any(), any(), any(), any(), any(), any(), eq(caseReference), any()))
+            .thenReturn(new PageImpl<>(auditDTOList));
+
+        mockMvc.perform(get("/audit?caseReference=" + caseReference)
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.auditDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.auditDTOList[0].id").value(auditLogId.toString()));
+
+        verify(auditService, times(1))
+            .findAll(any(), any(), any(), any(), any(), any(), eq(caseReference), any());
+    }
+
+    @Test
+    @DisplayName("Requested page out of range")
+    public void getAuditLogsRequestedPageOutOfRange() throws Exception {
         UUID auditLogId = UUID.randomUUID();
         var mockAuditDTO = new AuditDTO();
         mockAuditDTO.setId(auditLogId);
         var auditDTOList = List.of(mockAuditDTO);
-        when(auditService.findAll(any()))
+        when(auditService.findAll(any(), any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(new PageImpl<>(auditDTOList));
 
         mockMvc.perform(get("/audit?page=5"))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message").value("Requested page {5} is out of range. Max page is {1}"));
-
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchAuditsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchAuditsTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.preapi.controllers.params;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SearchAuditsTest {
+
+    private SearchAudits search;
+
+    @BeforeEach
+    void setUp() {
+        search = new SearchAudits();
+    }
+
+    @Test
+    void testGetFunctionalArea_WhenNotNullOrEmpty() {
+        search.setFunctionalArea("FunctionalArea");
+        assertEquals("FunctionalArea", search.getFunctionalArea());
+    }
+
+    @Test
+    void testGetFunctionalArea_WhenNull() {
+        search.setFunctionalArea(null);
+        assertNull(search.getFunctionalArea());
+    }
+
+    @Test
+    void testGetFunctionalArea_WhenEmpty() {
+        search.setFunctionalArea("");
+        assertNull(search.getFunctionalArea());
+    }
+
+    @Test
+    void testGetUserName_WhenNotNullOrEmpty() {
+        search.setUserName("Example Person");
+        assertEquals("Example Person", search.getUserName());
+    }
+
+    @Test
+    void testGetUserName_WhenNull() {
+        search.setUserName(null);
+        assertNull(search.getUserName());
+    }
+
+    @Test
+    void testGetUserName_WhenEmpty() {
+        search.setUserName("");
+        assertNull(search.getUserName());
+    }
+
+    @Test
+    void testGetCaseReference_WhenNotNullOrEmpty() {
+        search.setCaseReference("CASE12345");
+        assertEquals("CASE12345", search.getCaseReference());
+    }
+
+    @Test
+    void testGetCaseReference_WhenNull() {
+        search.setCaseReference(null);
+        assertNull(search.getCaseReference());
+    }
+
+    @Test
+    void testGetCaseReference_WhenEmpty() {
+        search.setCaseReference("");
+        assertNull(search.getCaseReference());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/AuditDTOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/AuditDTOTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.entities.User;
 import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 
 import java.sql.Timestamp;
@@ -33,14 +34,38 @@ class AuditDTOTest {
         auditEntity.setCreatedAt(new Timestamp(System.currentTimeMillis()));
     }
 
-    @DisplayName("Should create an Audit model from an Audit entity")
     @Test
+    @DisplayName("Should create an Audit model from an Audit entity")
     void createCaseFromEntity() {
+        assertAuditDtoValid(new AuditDTO(auditEntity));
+    }
 
-        var model = new AuditDTO(auditEntity);
+    @Test
+    @DisplayName("Should create an Audit model from an Audit and User entity")
+    public void createCaseFromAuditAndUser() {
+        var user = new User();
+        user.setId(auditEntity.getCreatedBy());
+        user.setFirstName("Example");
+        user.setLastName("Person");
+        user.setEmail("example@example.com");
+        user.setPhone("1234567890");
+        user.setOrganisation("Example Organisation");
+
+        var model = new AuditDTO(auditEntity, user);
+        assertAuditDtoValid(model);
+
+        var userDto = model.getCreatedBy();
+        assertThat(userDto.getFirstName()).isEqualTo(user.getFirstName());
+        assertThat(userDto.getLastName()).isEqualTo(user.getLastName());
+        assertThat(userDto.getEmail()).isEqualTo(user.getEmail());
+        assertThat(userDto.getPhoneNumber()).isEqualTo(user.getPhone());
+        assertThat(userDto.getOrganisation()).isEqualTo(user.getOrganisation());
+    }
+
+    private void assertAuditDtoValid(AuditDTO model) {
         assertThat(model.getId()).isEqualTo(auditEntity.getId());
         assertThat(model.getCreatedAt()).isEqualTo(auditEntity.getCreatedAt());
-        assertThat(model.getCreatedBy()).isEqualTo(auditEntity.getCreatedBy());
+        assertThat(model.getCreatedBy().getId()).isEqualTo(auditEntity.getCreatedBy());
         assertThat(model.getAuditDetails().get("foo").asText()).isEqualTo("bar");
         assertThat(model.getActivity()).isEqualTo(auditEntity.getActivity());
         assertThat(model.getCategory()).isEqualTo(auditEntity.getCategory());

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/AuditServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/AuditServiceTest.java
@@ -1,20 +1,25 @@
 package uk.gov.hmcts.reform.preapi.services;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.dto.CreateAuditDTO;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.entities.PortalAccess;
 import uk.gov.hmcts.reform.preapi.entities.User;
+import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.ImmutableDataException;
 import uk.gov.hmcts.reform.preapi.repositories.AppAccessRepository;
 import uk.gov.hmcts.reform.preapi.repositories.AuditRepository;
+import uk.gov.hmcts.reform.preapi.repositories.PortalAccessRepository;
 import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 
 import java.sql.Timestamp;
@@ -27,6 +32,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = AuditService.class)
@@ -40,11 +48,38 @@ class AuditServiceTest {
     @MockBean
     private AppAccessRepository appAccessRepository;
 
+    @MockBean
+    private PortalAccessRepository portalAccessRepository;
+
     @Autowired
     private AuditService auditService;
 
-    @DisplayName("Create an audit entry")
+    private Timestamp after;
+    private Timestamp before;
+    private String functionalArea;
+    private AuditLogSource source;
+    private String userName;
+    private UUID courtId;
+    private String caseReference;
+    private Pageable pageable;
+    private Audit audit;
+
+    @BeforeEach
+    void setUp() {
+        after = Timestamp.valueOf("2024-01-01 00:00:00");
+        before = Timestamp.valueOf("2024-12-31 23:59:59");
+        functionalArea = "API";
+        source = AuditLogSource.AUTO;
+        userName = "testUser";
+        courtId = UUID.randomUUID();
+        caseReference = "CASE123";
+        pageable = mock(Pageable.class);
+        audit = new Audit();
+        audit.setCreatedBy(UUID.randomUUID());
+    }
+
     @Test
+    @DisplayName("Create an audit entry")
     void upsertAuditSuccessCreated() {
         var auditModel = new CreateAuditDTO();
         auditModel.setId(UUID.randomUUID());
@@ -63,8 +98,8 @@ class AuditServiceTest {
         assertThat(auditService.upsert(auditModel, appAccess.getId())).isEqualTo(UpsertResult.CREATED);
     }
 
-    @DisplayName("Create an audit entry")
     @Test
+    @DisplayName("Create an audit entry")
     void upsertAuditSuccessWhenIdCannotBeFoundCreated() {
         var auditModel = new CreateAuditDTO();
         auditModel.setId(UUID.randomUUID());
@@ -80,8 +115,8 @@ class AuditServiceTest {
         assertThat(auditService.upsert(auditModel, id)).isEqualTo(UpsertResult.CREATED);
     }
 
-    @DisplayName("Create a booking when case not found")
     @Test
+    @DisplayName("Create a booking when case not found")
     void upsertUpdateAuditAttempt() {
         var auditModel = new CreateAuditDTO();
         auditModel.setId(UUID.randomUUID());
@@ -94,22 +129,171 @@ class AuditServiceTest {
         );
     }
 
-    @DisplayName("Find a list of audit logs and return a list of models")
     @Test
+    @DisplayName("Find a list of audit logs and return a list of models")
     void findAllAuditsSuccess() {
         auditEntity = new Audit();
         auditEntity.setId(UUID.randomUUID());
         auditEntity.setCreatedAt(Timestamp.from(Instant.now()));
 
         when(
-            auditRepository.searchAll(any())
+            auditRepository.searchAll(any(), any(), any(), any(), any(), any(), any(), any())
         ).thenReturn(new PageImpl<>(List.of(auditEntity)));
         var mockAuth = mock(UserAuthentication.class);
         when(mockAuth.isAdmin()).thenReturn(true);
         SecurityContextHolder.getContext().setAuthentication(mockAuth);
 
-        var modelList = auditService.findAll(null).get().toList();
+        var modelList = auditService.findAll(null, null, null, null, null, null, null, null).get().toList();
         assertThat(modelList).hasSize(1);
         assertThat(modelList.getFirst().getId()).isEqualTo(auditEntity.getId());
+    }
+
+    @Test
+    @DisplayName("Search audits and return a list of models with created by from app access")
+    void findAllAuditsFindUserAppAccess() {
+        when(auditRepository.searchAll(
+            after,
+            before,
+            functionalArea,
+            source,
+            userName,
+            courtId,
+            caseReference,
+            pageable
+        ))
+            .thenReturn(new PageImpl<>(List.of(audit)));
+
+        var user = new User();
+        user.setId(UUID.randomUUID());
+        user.setFirstName("test");
+        user.setLastName("user");
+        user.setEmail("example@example.com");
+        user.setPhone("1234567890");
+        user.setOrganisation("org");
+
+        var appAccess = new AppAccess();
+        appAccess.setId(audit.getCreatedBy());
+        appAccess.setUser(user);
+
+        when(appAccessRepository.findById(audit.getCreatedBy()))
+            .thenReturn(Optional.of(appAccess));
+
+        var results = auditService.findAll(
+            after,
+            before,
+            functionalArea,
+            source,
+            userName,
+            courtId,
+            caseReference,
+            pageable
+        );
+
+        assertThat(results).isNotNull();
+        assertThat(results.getContent()).hasSize(1);
+        var userDto = results.getContent().getFirst().getCreatedBy();
+        assertThat(userDto).isNotNull();
+        assertThat(userDto.getId()).isEqualTo(user.getId());
+        assertThat(userDto.getFirstName()).isEqualTo(user.getFirstName());
+
+        verify(appAccessRepository, times(1)).findById(audit.getCreatedBy());
+        verify(portalAccessRepository, never()).findById(audit.getCreatedBy());
+    }
+
+    @Test
+    @DisplayName("Search audits and return a list of models with created by from portal access")
+    void findAllAuditsFindUserPortalAccess() {
+        when(auditRepository.searchAll(
+            after,
+            before,
+            functionalArea,
+            source,
+            userName,
+            courtId,
+            caseReference,
+            pageable
+        )).thenReturn(new PageImpl<>(List.of(audit)));
+
+        var user = new User();
+        user.setId(UUID.randomUUID());
+        user.setFirstName("test");
+        user.setLastName("user");
+        user.setEmail("example@example.com");
+        user.setPhone("1234567890");
+        user.setOrganisation("org");
+
+        var portalAccess = new PortalAccess();
+        portalAccess.setId(audit.getCreatedBy());
+        portalAccess.setUser(user);
+
+        when(appAccessRepository.findById(audit.getCreatedBy()))
+            .thenReturn(Optional.empty());
+
+        when(portalAccessRepository.findById(audit.getCreatedBy()))
+            .thenReturn(Optional.of(portalAccess));
+
+        var results = auditService.findAll(
+            after,
+            before,
+            functionalArea,
+            source,
+            userName,
+            courtId,
+            caseReference,
+            pageable
+        );
+
+        assertThat(results).isNotNull();
+        assertThat(results.getContent()).hasSize(1);
+        var userDto = results.getContent().getFirst().getCreatedBy();
+        assertThat(userDto).isNotNull();
+        assertThat(userDto.getId()).isEqualTo(user.getId());
+        assertThat(userDto.getFirstName()).isEqualTo(user.getFirstName());
+
+        verify(appAccessRepository, times(1)).findById(audit.getCreatedBy());
+        verify(portalAccessRepository, times(1)).findById(audit.getCreatedBy());
+    }
+
+    @Test
+    @DisplayName("Search audits and return a list of models with created by not found")
+    void findAllAuditsFindUserNotFound() {
+        when(auditRepository.searchAll(
+            after,
+            before,
+            functionalArea,
+            source,
+            userName,
+            courtId,
+            caseReference,
+            pageable
+        ))
+            .thenReturn(new PageImpl<>(List.of(audit)));
+
+        when(appAccessRepository.findById(audit.getCreatedBy()))
+            .thenReturn(Optional.empty());
+
+        when(portalAccessRepository.findById(audit.getCreatedBy()))
+            .thenReturn(Optional.empty());
+
+        var results = auditService.findAll(
+            after,
+            before,
+            functionalArea,
+            source,
+            userName,
+            courtId,
+            caseReference,
+            pageable
+        );
+
+        assertThat(results).isNotNull();
+        assertThat(results.getContent()).hasSize(1);
+        var userDto = results.getContent().getFirst().getCreatedBy();
+        assertThat(userDto).isNotNull();
+        assertThat(userDto.getId()).isEqualTo(audit.getCreatedBy());
+        assertThat(userDto.getFirstName()).isNull();
+
+        verify(appAccessRepository, times(1)).findById(audit.getCreatedBy());
+        verify(portalAccessRepository, times(1)).findById(audit.getCreatedBy());
     }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-2058
- S28-2059


### Change description
- Search audits via GET /audits endpoint by:
    - `after`- Search by created_at after timestamp provided
    - `before`- Search by created_at before timestamp provided
    - `functionalArea`
    - `source`
    - `userName`- Search by associated user's name (first/last/full) via `created_by`
    - `courtId`- Search by association to a court
    - `caseReference`- Search by association to a case

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
