### PR TITLE
S28-3541: Create a daily counter in AppInsights for capture session statuses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,6 +263,7 @@ ext.libraries = [
 ext['snakeyaml.version'] = '2.0'
 
 dependencies {
+  implementation 'com.microsoft.azure:applicationinsights-core:3.7.1'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -43,7 +43,9 @@ import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 import uk.gov.hmcts.reform.preapi.services.CaptureSessionService;
 import uk.gov.hmcts.reform.preapi.services.RecordingService;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -246,7 +248,10 @@ public class MediaServiceController extends PreApiController {
         // update captureSession
         captureSession.setLiveOutputUrl(liveOutputUrl);
         captureSession.setStatus(RecordingStatus.RECORDING);
-        telemetry.trackEvent(captureSession.getStatus().name());
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("captureSession_ID", captureSession.getId().toString());
+        properties.put("captureSession_STATUS", captureSession.getStatus().name());
+        telemetry.trackEvent(properties.toString());
 
         captureSessionService.upsert(captureSession);
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.controllers;
 
 import com.azure.resourcemanager.mediaservices.models.JobState;
+import com.microsoft.applicationinsights.TelemetryClient;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -56,6 +57,8 @@ public class MediaServiceController extends PreApiController {
     private final AzureFinalStorageService azureFinalStorageService;
     private final AzureIngestStorageService azureIngestStorageService;
     private final RecordingService recordingService;
+
+    private final TelemetryClient telemetry = new TelemetryClient();
 
     @Autowired
     public MediaServiceController(MediaServiceBroker mediaServiceBroker,
@@ -243,6 +246,8 @@ public class MediaServiceController extends PreApiController {
         // update captureSession
         captureSession.setLiveOutputUrl(liveOutputUrl);
         captureSession.setStatus(RecordingStatus.RECORDING);
+        telemetry.trackEvent(captureSession.getStatus().name());
+
         captureSessionService.upsert(captureSession);
 
         return ResponseEntity.ok(captureSession);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -31,6 +31,8 @@ import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -207,7 +209,10 @@ public class CaptureSessionService {
         captureSession.setFinishedAt(createCaptureSessionDTO.getFinishedAt());
         captureSession.setFinishedByUser(finishedByUser);
         captureSession.setStatus(createCaptureSessionDTO.getStatus());
-        telemetry.trackEvent(captureSession.getStatus().name());
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("captureSession_ID", captureSession.getId().toString());
+        properties.put("captureSession_STATUS", captureSession.getStatus().name());
+        telemetry.trackEvent(properties.toString());
 
         captureSessionRepository.save(captureSession);
 
@@ -241,7 +246,10 @@ public class CaptureSessionService {
         captureSession.setStartedAt(Timestamp.from(Instant.now()));
 
         captureSession.setStatus(status);
-        telemetry.trackEvent(captureSession.getStatus().name());
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("captureSession_ID", captureSession.getId().toString());
+        properties.put("captureSession_STATUS", captureSession.getStatus().name());
+        telemetry.trackEvent(properties.toString());
 
         captureSession.setIngestAddress(ingestAddress);
 
@@ -259,8 +267,10 @@ public class CaptureSessionService {
 
         log.info("Stopping capture session {} with status {}", captureSessionId, status);
         captureSession.setStatus(status);
-        telemetry.trackEvent(captureSession.getStatus().name());
-
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("captureSession_ID", captureSession.getId().toString());
+        properties.put("captureSession_STATUS", captureSession.getStatus().name());
+        telemetry.trackEvent(properties.toString());
 
         switch (status) {
             case PROCESSING -> {
@@ -291,7 +301,10 @@ public class CaptureSessionService {
             .findByIdAndDeletedAtIsNull(captureSessionId)
             .orElseThrow(() -> new NotFoundException("Capture Session: " + captureSessionId));
         captureSession.setStatus(status);
-        telemetry.trackEvent(captureSession.getStatus().name());
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("captureSession_ID", captureSession.getId().toString());
+        properties.put("captureSession_STATUS", captureSession.getStatus().name());
+        telemetry.trackEvent(properties.toString());
 
         captureSessionRepository.save(captureSession);
         return new CaptureSessionDTO(captureSession);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaptureSessionService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.preapi.services;
 
+import com.microsoft.applicationinsights.TelemetryClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -42,6 +43,8 @@ public class CaptureSessionService {
     private final BookingRepository bookingRepository;
     private final UserRepository userRepository;
     private final BookingService bookingService;
+
+    private final TelemetryClient telemetry = new TelemetryClient();
 
     @Autowired
     public CaptureSessionService(RecordingService recordingService,
@@ -204,6 +207,7 @@ public class CaptureSessionService {
         captureSession.setFinishedAt(createCaptureSessionDTO.getFinishedAt());
         captureSession.setFinishedByUser(finishedByUser);
         captureSession.setStatus(createCaptureSessionDTO.getStatus());
+        telemetry.trackEvent(captureSession.getStatus().name());
 
         captureSessionRepository.save(captureSession);
 
@@ -237,6 +241,8 @@ public class CaptureSessionService {
         captureSession.setStartedAt(Timestamp.from(Instant.now()));
 
         captureSession.setStatus(status);
+        telemetry.trackEvent(captureSession.getStatus().name());
+
         captureSession.setIngestAddress(ingestAddress);
 
         captureSessionRepository.save(captureSession);
@@ -253,6 +259,8 @@ public class CaptureSessionService {
 
         log.info("Stopping capture session {} with status {}", captureSessionId, status);
         captureSession.setStatus(status);
+        telemetry.trackEvent(captureSession.getStatus().name());
+
 
         switch (status) {
             case PROCESSING -> {
@@ -283,6 +291,8 @@ public class CaptureSessionService {
             .findByIdAndDeletedAtIsNull(captureSessionId)
             .orElseThrow(() -> new NotFoundException("Capture Session: " + captureSessionId));
         captureSession.setStatus(status);
+        telemetry.trackEvent(captureSession.getStatus().name());
+
         captureSessionRepository.save(captureSession);
         return new CaptureSessionDTO(captureSession);
     }


### PR DESCRIPTION
### JIRA ticket(s)

- [S28-3541](https://tools.hmcts.net/jira/browse/S28-3541)

### Change description

- Adds AppInsights dependency to import telemetry
- Adds log for all changes in capture session status
- TrackEvent used to count each status a capture session goes into