### PR TITLE
S28 3734: Filter Recordings By Case Open/Closed

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -76,7 +76,6 @@ class CaseControllerFT extends FunctionalTestBase {
         dto.setState(CaseState.OPEN);
         dto.setClosedAt(null);
         var putCase2 = putCase(dto);
-        putCase2.prettyPrint();
         assertResponseCode(putCase2, 204);
         assertMatchesDto(dto);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
@@ -237,7 +237,6 @@ public class UserControllerFT extends FunctionalTestBase {
             TestingSupportRoles.SUPER_USER
         );
         assertResponseCode(responseActiveTrueForDeletedCourtAccess, 200);
-        responseActiveTrueForDeletedCourtAccess.prettyPrint();
         assertThat(responseActiveTrueForDeletedCourtAccess.body().jsonPath().getInt("page.totalElements"))
             .isEqualTo(0);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.controllers.params.SearchRecordings;
+import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
@@ -33,8 +34,8 @@ public class RecordingServiceIT extends IntegrationTestBase {
         SecurityContextHolder.getContext().setAuthentication(mockAuth);
     }
 
-    @Transactional
     @Test
+    @Transactional
     void searchRecordingsAsAdmin() {
         mockAdminUser();
 
@@ -83,8 +84,8 @@ public class RecordingServiceIT extends IntegrationTestBase {
         Assertions.assertTrue(recordings2.stream().anyMatch(recording -> recording.getId().equals(recording2.getId())));
     }
 
-    @Transactional
     @Test
+    @Transactional
     void searchRecordingsAsNonAdmin() {
         var court = HelperFactory.createCourt(CourtType.CROWN, "Example Court", "1234");
         entityManager.persist(court);
@@ -132,5 +133,106 @@ public class RecordingServiceIT extends IntegrationTestBase {
             () -> recordingService.findAll(new SearchRecordings(), true, Pageable.unpaged()).toList()
         ).getMessage();
         Assertions.assertEquals(message, "Access Denied");
+    }
+
+    @Test
+    @Transactional
+    void searchRecordingsByCaseOpenAsNonAdmin() {
+        var court = HelperFactory.createCourt(CourtType.CROWN, "Example Court", "1234");
+        entityManager.persist(court);
+
+        mockNonAdminUser(court.getId());
+
+        var caseEntity = HelperFactory.createCase(court, "CASE12345", true, null);
+        entityManager.persist(caseEntity);
+
+        var booking = HelperFactory.createBooking(caseEntity, Timestamp.from(Instant.now()), null);
+        entityManager.persist(booking);
+
+        var captureSession = HelperFactory.createCaptureSession(
+            booking,
+            RecordingOrigin.PRE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        entityManager.persist(captureSession);
+
+        var recording1 = HelperFactory.createRecording(captureSession, null, 1, "filename", null);
+        entityManager.persist(recording1);
+
+        var search = new SearchRecordings();
+        search.setCaseOpen(true);
+
+        var recordings = recordingService.findAll(search, false, Pageable.unpaged()).toList();
+        Assertions.assertEquals(1, recordings.size());
+        Assertions.assertEquals(recordings.getFirst().getId(), recording1.getId());
+
+        search.setCaseOpen(false);
+        var message = Assertions.assertThrows(
+            AccessDeniedException.class,
+            () -> recordingService.findAll(search, true, Pageable.unpaged()).toList()
+        ).getMessage();
+        Assertions.assertEquals(message, "Access Denied");
+    }
+
+    @Test
+    @Transactional
+    void searchRecordingsByCaseOpenAsAdmin() {
+        var court = HelperFactory.createCourt(CourtType.CROWN, "Example Court", "1234");
+        entityManager.persist(court);
+
+        mockAdminUser();
+
+        var caseEntity = HelperFactory.createCase(court, "CASE12345", true, null);
+        entityManager.persist(caseEntity);
+
+        var booking = HelperFactory.createBooking(caseEntity, Timestamp.from(Instant.now()), null);
+        entityManager.persist(booking);
+
+        var captureSession = HelperFactory.createCaptureSession(
+            booking,
+            RecordingOrigin.PRE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        entityManager.persist(captureSession);
+
+        var recording1 = HelperFactory.createRecording(captureSession, null, 1, "filename", null);
+        entityManager.persist(recording1);
+        entityManager.flush();
+
+        var searchTrue = new SearchRecordings();
+        searchTrue.setCaseOpen(true);
+        var searchFalse = new SearchRecordings();
+        searchFalse.setCaseOpen(false);
+
+        var recordings1 = recordingService.findAll(searchTrue, false, Pageable.unpaged()).toList();
+        Assertions.assertEquals(1, recordings1.size());
+        Assertions.assertEquals(recordings1.getFirst().getId(), recording1.getId());
+        var recordings2 = recordingService.findAll(searchFalse, false, Pageable.unpaged()).toList();
+        Assertions.assertTrue(recordings2.isEmpty());
+
+        // mark case as closed
+        caseEntity.setState(CaseState.CLOSED);
+        entityManager.persist(caseEntity);
+        entityManager.flush();
+
+        var recordings3 = recordingService.findAll(searchTrue, false, Pageable.unpaged()).toList();
+        Assertions.assertTrue(recordings3.isEmpty());
+        var recordings4 = recordingService.findAll(searchFalse, false, Pageable.unpaged()).toList();
+        Assertions.assertEquals(1, recordings4.size());
+        Assertions.assertEquals(recordings4.getFirst().getId(), recording1.getId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -114,6 +114,11 @@ public class RecordingController extends PreApiController {
         schema = @Schema(implementation = Boolean.class)
     )
     @Parameter(
+        name = "caseOpen",
+        description = "The case status to search by",
+        schema = @Schema(implementation = Boolean.class)
+    )
+    @Parameter(
         name = "sort",
         description = "Sort by",
         schema = @Schema(implementation = String.class),
@@ -150,7 +155,6 @@ public class RecordingController extends PreApiController {
         }
 
         return ResponseEntity.ok(assembler.toModel(resultPage));
-
     }
 
     @PutMapping("/{recordingId}")

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -219,7 +219,7 @@ class TestingSupportController {
 
         var caseEntity = new Case();
         caseEntity.setId(UUID.randomUUID());
-        caseEntity.setReference(RandomStringUtils.randomAlphabetic(5));
+        caseEntity.setReference(RandomStringUtils.randomAlphabetic(9));
         caseEntity.setCourt(court);
         caseRepository.save(caseEntity);
 
@@ -418,7 +418,7 @@ class TestingSupportController {
 
         return ResponseEntity.ok(assembler.toModel(resultPage));
     }
-  
+
     @PostMapping(value = "/booking-scheduled-for-past/{bookingId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<BookingDTO> bookingScheduledForPast(@PathVariable UUID bookingId) {
         var booking = bookingRepository.findByIdAndDeletedAtIsNull(bookingId)

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
@@ -29,6 +29,7 @@ public class SearchRecordings {
     private Timestamp startedAtUntil;
     private List<UUID> authorisedBookings;
     private UUID authorisedCourt;
+    private Boolean caseOpen;
 
     public String getCaseReference() {
         return caseReference != null && !caseReference.isEmpty() ? caseReference : null;
@@ -44,5 +45,10 @@ public class SearchRecordings {
 
     public String getId() {
         return id != null && !id.isEmpty() ? id : null;
+    }
+
+    // used in recordingRepository.searchAllBy()
+    public boolean isCaseOpen() {
+        return caseOpen == null || caseOpen;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/params/SearchRecordings.java
@@ -46,9 +46,4 @@ public class SearchRecordings {
     public String getId() {
         return id != null && !id.isEmpty() ? id : null;
     }
-
-    // used in recordingRepository.searchAllBy()
-    public boolean isCaseOpen() {
-        return caseOpen == null || caseOpen;
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.preapi.repositories;
 
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -77,6 +76,9 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
                 AND p.deletedAt IS NULL
             )
         )
+        AND (
+            (:#{#searchParams.isCaseOpen()} = TRUE AND r.captureSession.booking.caseId.state IN ('OPEN', 'PENDING_CLOSURE'))
+            OR (:#{#searchParams.isCaseOpen()} = FALSE AND r.captureSession.booking.caseId.state = 'CLOSED'))
         """
     )
     Page<Recording> searchAllBy(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -77,8 +77,11 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
             )
         )
         AND (
-            (:#{#searchParams.isCaseOpen()} = TRUE AND r.captureSession.booking.caseId.state IN ('OPEN', 'PENDING_CLOSURE'))
-            OR (:#{#searchParams.isCaseOpen()} = FALSE AND r.captureSession.booking.caseId.state = 'CLOSED'))
+            :#{#searchParams.caseOpen} IS NULL
+            OR (:#{#searchParams.caseOpen} = TRUE
+                AND r.captureSession.booking.caseId.state IN ('OPEN', 'PENDING_CLOSURE'))
+            OR (:#{#searchParams.caseOpen} = FALSE
+                AND r.captureSession.booking.caseId.state = 'CLOSED'))
         """
     )
     Page<Recording> searchAllBy(

--- a/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
@@ -141,4 +141,10 @@ public class AuthorisationService {
             || authentication.isAdmin()
             || authentication.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_LEVEL_2"));
     }
+
+    public boolean canSearchByCaseClosed(UserAuthentication authentication, boolean caseOpen) {
+        return caseOpen
+            || authentication.isAdmin()
+            || authentication.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_LEVEL_2"));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
@@ -142,8 +142,9 @@ public class AuthorisationService {
             || authentication.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_LEVEL_2"));
     }
 
-    public boolean canSearchByCaseClosed(UserAuthentication authentication, boolean caseOpen) {
-        return caseOpen
+    public boolean canSearchByCaseClosed(UserAuthentication authentication, Boolean caseOpen) {
+        return caseOpen == null
+            || caseOpen
             || authentication.isAdmin()
             || authentication.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_LEVEL_2"));
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -60,7 +60,12 @@ public class RecordingService {
     }
 
     @Transactional
-    @PreAuthorize("!#includeDeleted or @authorisationService.canViewDeleted(authentication)")
+    @PreAuthorize(
+        """
+        (!#includeDeleted or @authorisationService.canViewDeleted(authentication))
+        and @authorisationService.canSearchByCaseClosed(authentication, #params.isCaseOpen())
+        """
+    )
     public Page<RecordingDTO> findAll(
         SearchRecordings params,
         boolean includeDeleted,

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -63,7 +63,7 @@ public class RecordingService {
     @PreAuthorize(
         """
         (!#includeDeleted or @authorisationService.canViewDeleted(authentication))
-        and @authorisationService.canSearchByCaseClosed(authentication, #params.isCaseOpen())
+        and @authorisationService.canSearchByCaseClosed(authentication, #params.getCaseOpen())
         """
     )
     public Page<RecordingDTO> findAll(

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/RecordingControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -513,6 +514,66 @@ class RecordingControllerTest {
             .andReturn();
 
         verify(recordingService, times(1)).findAll(any(), eq(true), any());
+    }
+
+    @Test
+    @DisplayName("Should search by case open status = true")
+    void getRecordingsCaseOpenTrue() throws Exception {
+        var mockRecordingDTO = new RecordingDTO();
+        mockRecordingDTO.setId(UUID.randomUUID());
+        when(recordingService.findAll(any(), anyBoolean(), any()))
+            .thenReturn(new PageImpl<>(List.of(mockRecordingDTO)));
+
+        mockMvc.perform(get("/recordings?caseOpen=true")
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.recordingDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.recordingDTOList[0].id").value(mockRecordingDTO.getId().toString()));
+
+        var argCaptor = ArgumentCaptor.forClass(SearchRecordings.class);
+        verify(recordingService, times(1)).findAll(argCaptor.capture(), eq(false), any());
+
+        assertThat(argCaptor.getValue().getCaseOpen()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Should search by case open status = false")
+    void getRecordingsCaseOpenFalse() throws Exception {
+        var mockRecordingDTO = new RecordingDTO();
+        mockRecordingDTO.setId(UUID.randomUUID());
+        when(recordingService.findAll(any(), anyBoolean(), any()))
+            .thenReturn(new PageImpl<>(List.of(mockRecordingDTO)));
+
+        mockMvc.perform(get("/recordings?caseOpen=false")
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.recordingDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.recordingDTOList[0].id").value(mockRecordingDTO.getId().toString()));
+
+        var argCaptor = ArgumentCaptor.forClass(SearchRecordings.class);
+        verify(recordingService, times(1)).findAll(argCaptor.capture(), eq(false), any());
+
+        assertThat(argCaptor.getValue().getCaseOpen()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Should search by case open status = null")
+    void getRecordingsCaseOpenNull() throws Exception {
+        var mockRecordingDTO = new RecordingDTO();
+        mockRecordingDTO.setId(UUID.randomUUID());
+        when(recordingService.findAll(any(), anyBoolean(), any()))
+            .thenReturn(new PageImpl<>(List.of(mockRecordingDTO)));
+
+        mockMvc.perform(get("/recordings")
+                            .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.recordingDTOList").isNotEmpty())
+            .andExpect(jsonPath("$._embedded.recordingDTOList[0].id").value(mockRecordingDTO.getId().toString()));
+
+        var argCaptor = ArgumentCaptor.forClass(SearchRecordings.class);
+        verify(recordingService, times(1)).findAll(argCaptor.capture(), eq(false), any());
+
+        assertThat(argCaptor.getValue().getCaseOpen()).isNull();
     }
 
     @DisplayName("Should undelete a recording by id and return a 200 response")

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchRecordingsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/params/SearchRecordingsTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SearchRecordingsTest {
-
     @Test
     public void getCaseReference() {
         var searchRecordings = new SearchRecordings();
@@ -46,7 +45,8 @@ public class SearchRecordingsTest {
         searchRecordings.setDefendantName(null);
         assertNull(searchRecordings.getDefendantName());
     }
-  
+
+    @Test
     public void getId() {
         var searchRecordings = new SearchRecordings();
         searchRecordings.setId("abc");

--- a/src/test/java/uk/gov/hmcts/reform/preapi/security/AuthorisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/security/AuthorisationServiceTest.java
@@ -750,4 +750,38 @@ public class AuthorisationServiceTest {
         assertFalse(authorisationService.hasUpsertAccess(authenticationUser, dto));
     }
 
+    @Test
+    @DisplayName("Should grant access when caseOpen param is null")
+    void canSearchByCaseClosedCaseOpenNull() {
+        assertTrue(authorisationService.canSearchByCaseClosed(authenticationUser, null));
+    }
+
+    @Test
+    @DisplayName("Should grant access when caseOpen param is true")
+    void canSearchByCaseClosedCaseOpenTrue() {
+        assertTrue(authorisationService.canSearchByCaseClosed(authenticationUser, true));
+    }
+
+    @Test
+    @DisplayName("Should grant access when caseOpen param is false and user is admin")
+    void canSearchByCaseClosedCaseOpenFalseIsAdmin() {
+        when(authenticationUser.isAdmin()).thenReturn(true);
+        assertTrue(authorisationService.canSearchByCaseClosed(authenticationUser, false));
+    }
+
+    @Test
+    @DisplayName("Should grant access when caseOpen param is false and user is level 2")
+    void canSearchByCaseClosedCaseOpenFalseIsLevel2() {
+        when(authenticationUser.isAdmin()).thenReturn(false);
+        when(authenticationUser.getAuthorities()).thenReturn(List.of(new SimpleGrantedAuthority("ROLE_LEVEL_2")));
+        assertTrue(authorisationService.canSearchByCaseClosed(authenticationUser, false));
+    }
+
+    @Test
+    @DisplayName("Should not grant access when caseOpen param is false and user is not admin or level 2")
+    void canSearchByCaseClosedCaseOpenFalseIsNotAdminOrLevel2() {
+        when(authenticationUser.isAdmin()).thenReturn(false);
+        when(authenticationUser.getAuthorities()).thenReturn(List.of(new SimpleGrantedAuthority("ROLE_LEVEL_3")));
+        assertFalse(authorisationService.canSearchByCaseClosed(authenticationUser, false));
+    }
 }


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3734


### Change description
- Add `caseOpen` search param to `GET /recordings`
    - `true`: Returns recordings where case is `OPEN` or `PENDING_CLOSURE`
    - `false`: Returns recordings where case is `CLOSED`
    - `null`: Existing functionality

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Test `caseOpen` param on `GET /recordings` endpoint 


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
