### PR TITLE
S28 3770: Add `origin` to Cases

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -39,7 +39,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "93"
+  revision              = "94"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -263,6 +263,12 @@ definitions:
         description: CaseModifiedAt
         format: date-time
         type: string
+      origin:
+        description: CaseOrigin
+        enum:
+          - PRE
+          - VODAFONE
+        type: string
       participants:
         description: CaseParticipants
         items:
@@ -562,6 +568,12 @@ definitions:
       id:
         description: CreateCaseId
         format: uuid
+        type: string
+      origin:
+        description: CreateCaseOrigin
+        enum:
+          - PRE
+          - VODAFONE
         type: string
       participants:
         description: CaseParticipants
@@ -978,6 +990,12 @@ definitions:
       modified_at:
         description: CaseModifiedAt
         format: date-time
+        type: string
+      origin:
+        description: CaseOrigin
+        enum:
+          - PRE
+          - VODAFONE
         type: string
       participants:
         description: CaseParticipants

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -175,6 +175,7 @@ class TestingSupportController {
         caseEntity.setId(UUID.randomUUID());
         caseEntity.setReference("4567890123");
         caseEntity.setCourt(court);
+        caseEntity.setOrigin(RecordingOrigin.PRE);
         caseRepository.save(caseEntity);
 
         var participant1 = new Participant();
@@ -228,6 +229,7 @@ class TestingSupportController {
         caseEntity.setId(UUID.randomUUID());
         caseEntity.setReference(RandomStringUtils.randomAlphabetic(5));
         caseEntity.setCourt(court);
+        caseEntity.setOrigin(RecordingOrigin.PRE);
         caseRepository.save(caseEntity);
 
         var participant1 = new Participant();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CaseDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CaseDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.entities.Participant;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 
 import java.sql.Timestamp;
 import java.util.Comparator;
@@ -33,6 +34,9 @@ public class CaseDTO {
 
     @Schema(description = "CaseParticipants")
     private List<ParticipantDTO> participants;
+
+    @Schema(description = "CaseOrigin")
+    private RecordingOrigin origin;
 
     @Schema(description = "CaseIsTest")
     private boolean test;
@@ -64,6 +68,7 @@ public class CaseDTO {
                              .sorted(Comparator.comparing(Participant::getFirstName))
                              .map(ParticipantDTO::new))
             .collect(Collectors.toList());
+        origin = caseEntity.getOrigin();
         test = caseEntity.isTest();
         state = caseEntity.getState();
         closedAt = caseEntity.getClosedAt();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCaseDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/CreateCaseDTO.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.preapi.dto.validators.CaseStateConstraint;
 import uk.gov.hmcts.reform.preapi.dto.validators.ParticipantTypeConstraint;
 import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 
 import java.sql.Timestamp;
 import java.util.Set;
@@ -40,6 +41,9 @@ public class CreateCaseDTO {
     @ParticipantTypeConstraint
     private Set<CreateParticipantDTO> participants;
 
+    @Schema(description = "CreateCaseOrigin")
+    private RecordingOrigin origin;
+
     @Schema(description = "CreateCaseIsTest")
     private boolean test;
 
@@ -58,6 +62,7 @@ public class CreateCaseDTO {
         participants = Stream.ofNullable(caseEntity.getParticipants())
             .flatMap(participants -> participants.stream().map(CreateParticipantDTO::new))
             .collect(Collectors.toSet());
+        origin = caseEntity.getOrigin();
         test = caseEntity.isTest();
         state = caseEntity.getState();
         closedAt = caseEntity.getClosedAt();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/entities/Case.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/entities/Case.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.reform.preapi.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -15,6 +17,7 @@ import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.reform.preapi.entities.base.CreatedModifiedAtEntity;
 import uk.gov.hmcts.reform.preapi.entities.base.ISoftDeletable;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -37,6 +40,11 @@ public class Case extends CreatedModifiedAtEntity implements ISoftDeletable {
 
     @Column(name = "test")
     private boolean test;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "origin", nullable = false, columnDefinition = "recording_origin")
+    private RecordingOrigin origin;
 
     @Column(name = "deleted_at")
     private Timestamp deletedAt;
@@ -74,6 +82,7 @@ public class Case extends CreatedModifiedAtEntity implements ISoftDeletable {
                                      .filter(participant -> participant.getDeletedAt() == null)
                                      .map(Participant::getDetailsForAudit))
                     .collect(Collectors.toSet()));
+        details.put("origin", origin);
         details.put("test", test);
         details.put("state", state);
         details.put("closedAt", closedAt);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/CaseService.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.entities.Participant;
 import uk.gov.hmcts.reform.preapi.entities.base.BaseEntity;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
 import uk.gov.hmcts.reform.preapi.exception.ConflictException;
@@ -168,6 +169,12 @@ public class CaseService {
             newCase.setReference(createCaseDTO.getReference());
         }
         newCase.setTest(createCaseDTO.isTest());
+
+        if (createCaseDTO.getOrigin() != null) {
+            newCase.setOrigin(createCaseDTO.getOrigin());
+        } else if (!isUpdate) {
+            newCase.setOrigin(RecordingOrigin.PRE);
+        }
 
         // todo update once CreateCaseDTO.state is made not nullable (currently breaking)
         newCase.setState(createCaseDTO.getState() == null ? CaseState.OPEN : createCaseDTO.getState());

--- a/src/main/resources/db/migration/V029__CaseOrigin.sql
+++ b/src/main/resources/db/migration/V029__CaseOrigin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.cases ADD COLUMN origin recording_origin NOT NULL DEFAULT 'PRE';

--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/CaseDTOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/CaseDTOTest.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.preapi.entities.Court;
 import uk.gov.hmcts.reform.preapi.entities.Region;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 
 import java.sql.Timestamp;
@@ -32,14 +33,15 @@ class CaseDTOTest {
         court.setRegions(Set.of(new Region()));
         caseEntity.setCourt(court);
         caseEntity.setReference("1234567890");
-        caseEntity.setTest(false);;
+        caseEntity.setTest(false);
+        caseEntity.setOrigin(RecordingOrigin.PRE);
         caseEntity.setDeletedAt(null);
         caseEntity.setCreatedAt(Timestamp.from(Instant.now()));
         caseEntity.setModifiedAt(Timestamp.from(Instant.now()));
     }
 
-    @DisplayName("CaseDTO.participants should be sorted by participant first name")
     @Test
+    @DisplayName("CaseDTO.participants should be sorted by participant first name")
     public void testParticipantSorting() {
         var aCase = HelperFactory.createCase(
             HelperFactory.createCourt(CourtType.CROWN, "Example Court", "123"),
@@ -61,8 +63,8 @@ class CaseDTOTest {
         assertEquals("CCC", participants.get(2).getFirstName());
     }
 
-    @DisplayName("Should create a case from entity")
     @Test
+    @DisplayName("Should create a case from entity")
     void createCaseFromEntity() {
         var model = new CaseDTO(caseEntity);
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/util/HelperFactory.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/util/HelperFactory.java
@@ -110,6 +110,7 @@ public class HelperFactory {
         testCase.setCourt(court);
         testCase.setReference(reference);
         testCase.setTest(test);
+        testCase.setOrigin(RecordingOrigin.PRE);
         testCase.setDeletedAt(deletedAt);
         testCase.setState(CaseState.OPEN);
         return testCase;


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3770


### Change description
- Add `origin` to cases


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- Ensure migration works as expected (all current cases should be set to origin=PRE)
- Ensure PUT /case/{id} works when origin is `null` (to avoid breaking power apps), `PRE` and `VODAFONE`. 
- Ensure GET /cases/{id} returns a case with the field origin


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
