### PR TITLE
Fix: Start Live Event Asset Conflict

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -417,7 +417,14 @@ public class MediaKind implements IMediaService {
         var liveEventName = getSanitisedLiveEventId(captureSession.getId());
         createLiveEvent(captureSession);
         getLiveEventMk(liveEventName);
-        createAsset(liveEventName, captureSession, captureSession.getBookingId().toString(), false);
+
+        try {
+            createAsset(liveEventName, captureSession, captureSession.getBookingId().toString(), false);
+        } catch (ConflictException e) {
+            mediaKindClient.deleteLiveEvent(liveEventName);
+            throw e;
+        }
+
         createLiveOutput(liveEventName, liveEventName);
         startLiveEvent(liveEventName);
         if (enableStreamingLocatorOnStart) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -320,7 +320,7 @@ public class MediaKind implements IMediaService {
         try {
             return mediaKindClient.getLiveEvent(liveEventName);
         } catch (NotFoundException e) {
-            throw new NotFoundException("Live Event: " + liveEventName);
+            throw new NotFoundException(getLiveEventNotFoundExceptionMessage(liveEventName));
         }
     }
 
@@ -436,7 +436,7 @@ public class MediaKind implements IMediaService {
         try {
             mediaKindClient.startLiveEvent(liveEventName);
         } catch (NotFoundException e) {
-            throw new NotFoundException("Live Event: " + liveEventName);
+            throw new NotFoundException(getLiveEventNotFoundExceptionMessage(liveEventName));
         }
     }
 
@@ -444,7 +444,7 @@ public class MediaKind implements IMediaService {
         try {
             mediaKindClient.stopLiveEvent(liveEventName);
         } catch (NotFoundException e) {
-            throw new NotFoundException("Live Event: " + liveEventName);
+            throw new NotFoundException(getLiveEventNotFoundExceptionMessage(liveEventName));
         } catch (FeignException.BadRequest e) {
             // live output still exists (only occurs on manually created live events)
             log.info("Skipped stopping live event. The live event will be cleaned up by deletion.");
@@ -577,7 +577,7 @@ public class MediaKind implements IMediaService {
         } catch (ConflictException e) {
             throw new ConflictException("Live Output: " + liveOutputName);
         } catch (NotFoundException e) {
-            throw new NotFoundException("Live Event: " + liveEventName);
+            throw new NotFoundException(getLiveEventNotFoundExceptionMessage(liveEventName));
         }
     }
 
@@ -784,5 +784,9 @@ public class MediaKind implements IMediaService {
                + "."
                + LOCATION
                + ".streaming.mediakind.com";
+    }
+
+    private String getLiveEventNotFoundExceptionMessage(String liveEventName) {
+        return "Live Event: " + liveEventName;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -419,6 +419,7 @@ public class MediaKindTest {
         verify(mockClient, times(1)).putLiveEvent(any(), any());
         verify(mockClient, times(1)).getLiveEvent(any());
         verify(mockClient, times(1)).putAsset(any(), any());
+        verify(mockClient, times(1)).deleteLiveEvent(any());
         verify(mockClient, never()).createStreamingLocator(any(), any());
     }
 


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3773


### Change description
- Graceful shutdown live event when startLiveEvent's asset creation encounters 409 Conflict. 

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
