### PR TITLE
Fix: Check Streaming Locator Exists Before Attempting Create

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/media/MediaKind.java
@@ -735,22 +735,32 @@ public class MediaKind implements IMediaService {
     }
 
     private void assertStreamingLocatorExists(UUID liveEventId) {
+        var sanitisedLiveEventId = getSanitisedLiveEventId(liveEventId);
 
         try {
-            log.info("Creating Streaming locator");
-            var sanitisedLiveEventId = getSanitisedLiveEventId(liveEventId);
+            mediaKindClient.getStreamingLocator(sanitisedLiveEventId);
+        } catch (NotFoundException e) {
+            createStreamingLocator(sanitisedLiveEventId);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw e;
+        }
+    }
 
+    private void createStreamingLocator(String sanitisedLiveEventId) {
+        log.info("Creating Streaming locator");
+        try {
             // Streaming Locator for a live event
             mediaKindClient.createStreamingLocator(
                 sanitisedLiveEventId,
                 MkStreamingLocator.builder()
-                                  .properties(MkStreamingLocatorProperties
-                                                  .builder()
-                                                  .assetName(sanitisedLiveEventId)
-                                                  .streamingLocatorId(sanitisedLiveEventId)
-                                                  .streamingPolicyName(STREAMING_POLICY_CLEAR_STREAMING_ONLY)
-                                                  .build()
-                                  ).build()
+                    .properties(MkStreamingLocatorProperties
+                                    .builder()
+                                    .assetName(sanitisedLiveEventId)
+                                    .streamingLocatorId(sanitisedLiveEventId)
+                                    .streamingPolicyName(STREAMING_POLICY_CLEAR_STREAMING_ONLY)
+                                    .build())
+                    .build()
             );
         } catch (ConflictException e) {
             log.info("Streaming locator already exists");

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -326,6 +326,8 @@ public class MediaKindTest {
         var mockLiveEvent = mock(MkLiveEvent.class);
 
         when(mockClient.getLiveEvent(liveEventName)).thenReturn(mockLiveEvent);
+        when(mockClient.getStreamingLocator(any()))
+            .thenThrow(mock(NotFoundException.class));
 
         mediaKind.startLiveEvent(captureSession);
 
@@ -334,6 +336,7 @@ public class MediaKindTest {
         verify(mockClient, times(1)).putAsset(any(), any());
         verify(mockClient, times(1)).putLiveOutput(any(), any(), any());
         verify(mockClient, times(1)).startLiveEvent(any());
+        verify(mockClient, times(1)).getStreamingLocator(any());
         verify(mockClient, times(1)).createStreamingLocator(any(), any());
     }
 
@@ -345,6 +348,8 @@ public class MediaKindTest {
 
         when(mockClient.putLiveEvent(any(), any()))
             .thenThrow(mock(ConflictException.class));
+        when(mockClient.getStreamingLocator(any()))
+            .thenThrow(mock(NotFoundException.class));
         when(mockClient.getLiveEvent(liveEventName)).thenReturn(mockLiveEvent);
 
         mediaKind.startLiveEvent(captureSession);
@@ -354,6 +359,7 @@ public class MediaKindTest {
         verify(mockClient, times(1)).putAsset(any(), any());
         verify(mockClient, times(1)).putLiveOutput(any(), any(), any());
         verify(mockClient, times(1)).startLiveEvent(any());
+        verify(mockClient, times(1)).getStreamingLocator(any());
         verify(mockClient, times(1)).createStreamingLocator(any(), any());
     }
 
@@ -923,6 +929,9 @@ public class MediaKindTest {
                                      .build()
             );
 
+        when(mockClient.getStreamingLocator(any()))
+            .thenThrow(mock(NotFoundException.class));
+
         when(mockClient.listStreamingLocatorPaths(liveEventName))
             .thenReturn(getGoodStreamingLocatorPaths(liveEventName));
 
@@ -934,6 +943,44 @@ public class MediaKindTest {
             + "-pre-mediakind-stg.uksouth.streaming.mediakind.com/"
             + liveEventName
             + "/index.qfm/manifest(format=m3u8-cmaf)");
+    }
+
+    @Test
+    @DisplayName("Should play a live event successfully when streaming locator already exists")
+    void playLiveEventStreamingLocatorAlreadyExistsSuccess() throws JsonProcessingException, InterruptedException {
+        var liveEventName = captureSession.getId().toString().replace("-", "");
+        var mockLiveEvent = mock(MkLiveEvent.class);
+
+        when(mockClient.getStreamingEndpointByName(DEFAULT_LIVE_STREAMING_ENDPOINT))
+            .thenReturn(MkStreamingEndpoint.builder()
+                            .properties(MkStreamingEndpointProperties.builder()
+                                            .resourceState(MkStreamingEndpointProperties.ResourceState.Running)
+                                            .build())
+                            .build());
+        when(mockClient.getLiveEvent(liveEventName)).thenReturn(mockLiveEvent);
+        when(mockLiveEvent.getProperties())
+            .thenReturn(
+                MkLiveEventProperties.builder()
+                    .resourceState(LiveEventResourceState.RUNNING.toString())
+                    .build()
+            );
+
+        when(mockClient.getStreamingLocator(any()))
+            .thenReturn(MkStreamingLocator.builder().build());
+
+        when(mockClient.listStreamingLocatorPaths(liveEventName))
+            .thenReturn(getGoodStreamingLocatorPaths(liveEventName));
+
+        var result = mediaKind.playLiveEvent(captureSession.getId());
+
+        assertThat(result).isEqualTo(
+            "https://ep-"
+                + DEFAULT_LIVE_STREAMING_ENDPOINT
+                + "-pre-mediakind-stg.uksouth.streaming.mediakind.com/"
+                + liveEventName
+                + "/index.qfm/manifest(format=m3u8-cmaf)");
+
+        verify(mockClient, never()).createStreamingLocator(any(), any());
     }
 
     @SuppressWarnings("checkstyle:Indentation")


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-0000
-->

### Change description
- Fix issue causing `PUT /media-service/streaming-locator/live-event/{id}` endpoint to receive 400 from MK on attempting to create a streaming locator that already exists


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->


> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**
- `POST /testing-support/create-well-formed-booking` to create the booking
- Create a capture session for the booking via `PUT /capture-session/{id}`
- Call `PUT /media-service/live-event/start/{captureSessionId}` to start the MediaKind live event
- Call `GET /media-service/live-events/{liveEventName}` until status is Running
- Use the live event (CVP or OBS)
- Call `POST /media-service/live-event/check/{id}` until not erroring
- Call `PUT /media-service/streaming-locator/live-event/{id}`
- See you don't get 400 error - should be 200


<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
