### PR TITLE
Fix: Decrease time taken running MediaKind unit tests

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -87,6 +87,8 @@ mediakind:
   issuer: ${ISSUER:https://sts.windows.net/531ff96d-0ae9-462a-8d2d-bec7c0b42082/}
   symmetricKey: ${SYMMETRIC_KEY:}
   streaming-locator-on-start: ${ENABLE_STREAMING_LOCATOR_ON_START:false}
+  job-poll-interval: 10000
+  streaming-endpoint-polling-interval: 2000
 
 media-service: ${MEDIA_SERVICE:MediaKind}
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -70,6 +70,8 @@ import static uk.gov.hmcts.reform.preapi.media.MediaKind.ENCODE_FROM_MP4_TRANSFO
     "mediakind.issuer=testIssuer",
     "mediakind.symmetricKey=testSymmetricKey",
     "mediakind.streaming-locator-on-start=true",
+    "mediakind.job-poll-interval=10",
+    "mediakind.streaming-endpoint-polling-interval=10"
 })
 public class MediaKindTest {
     @MockitoBean


### PR DESCRIPTION

<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-0000
-->

### Change description
- Add way to change the sleep time in for polling (utilised by tests)
- Running all tests (unit, integration, functional) should now be 6x quicker from ~3 mins to ~30seconds
- Reformatted `MediaKind.java` so its slightly more readable


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
