### PR TITLE
S28-3958 Fix Level 4 Create Bookings Functionality

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/CaseControllerFT.java
@@ -710,6 +710,11 @@ class CaseControllerFT extends FunctionalTestBase {
             assertCaseExists(dto.getId(), true);
             assertMatchesDto(dto);
 
+            // Outstanding issue with this whole test method - fails for reason not related to the case status
+            // update OPEN -> NULL
+            // var putResponse1 = putCase(dto, role);
+            // assertResponseCode(putResponse1, 204);
+
             // update OPEN -> PENDING_CLOSURE
             dto.setState(CaseState.PENDING_CLOSURE);
             dto.setClosedAt(Timestamp.from(Instant.now()));
@@ -723,24 +728,30 @@ class CaseControllerFT extends FunctionalTestBase {
             // update PENDING_CLOSURE -> OPEN
             dto.setState(CaseState.OPEN);
             dto.setClosedAt(null);
-            var putResponse6 = putCase(dto, role);
-            assertResponseCode(putResponse6, 403);
+            var putResponse3 = putCase(dto, role);
+            assertResponseCode(putResponse3, 403);
 
             // update PENDING_CLOSURE -> CLOSED
             dto.setState(CaseState.CLOSED);
             dto.setClosedAt(Timestamp.from(Instant.now().minusSeconds(36000)));
-            var putResponse3 = putCase(dto, role);
-            assertResponseCode(putResponse3, 403);
+            var putResponse4 = putCase(dto, role);
+            assertResponseCode(putResponse4, 403);
 
-            // force the update the PENDING_CLOSURE
+            // force the update the CLOSED
             var forcedPut2 = putCase(dto);
             assertResponseCode(forcedPut2, 204);
+
+            // Outstanding issue with this whole test method - fails for reason not related to the case status
+            // update OPEN -> NULL
+            // dto.setState(null);
+            // var putResponse5 = putCase(dto, role);
+            // assertResponseCode(putResponse5, 403);
 
             // update CLOSED -> OPEN
             dto.setState(CaseState.OPEN);
             dto.setClosedAt(null);
-            var putResponse4 = putCase(dto, role);
-            assertResponseCode(putResponse4, 403);
+            var putResponse6 = putCase(dto, role);
+            assertResponseCode(putResponse6, 403);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/security/AuthorisationService.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.preapi.dto.CreateEditRequestDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateParticipantDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateShareBookingDTO;
+import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.repositories.BookingRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaptureSessionRepository;
 import uk.gov.hmcts.reform.preapi.repositories.CaseRepository;
@@ -157,8 +158,8 @@ public class AuthorisationService {
 
     public boolean canUpdateCaseState(UserAuthentication authentication, CreateCaseDTO dto) {
         return caseRepository.findById(dto.getId())
-            .map(c -> c.getState() == dto.getState())
-            .orElse(false)
+            .map(c -> (dto.getState() == null && c.getState() == CaseState.OPEN) || c.getState() == dto.getState())
+            .orElse(true)
             || authentication.isAdmin()
             || authentication.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_LEVEL_2"));
     }


### PR DESCRIPTION
PR checklist:

- [x] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] Tests have been updated / new tests has been added (if needed)
- [x] QA have been notified to perform manual testing (if needed)
- [x] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [x] Branch name should reference the Jira ticket, if not JIRA ticket has been linked

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)

- S28-3958

### Change description

- Allow Level 3&4 users to PUT /cases/<id>, as long as they are creating a case, or pushing a case state of NULL to an OPEN case.
- I've commented out the added Functional Tests, as there is an outstanding issue with how the tests are working in `updateCaseStatusAuthError()`, the current tests are getting 403 to reasons other than the case state.

As Level 3&4:
- Creating case ✅ 
- Updating case state: ❌ 
- Updating OPEN case but not supplying a case state ✅ 
- Updating a non-OPEN case but not supplying a case state ❌ 

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
