### PR TITLE
S28 3941: Recording synchronisation with files in storage

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
@@ -187,11 +187,12 @@ public class EditRequestService {
     @Transactional
     @PreAuthorize("@authorisationService.hasUpsertAccess(authentication, #dto)")
     public UpsertResult upsert(CreateEditRequestDTO dto) {
+        recordingService.syncRecordingMetadataWithStorage(dto.getSourceRecordingId());
+
         var sourceRecording = recordingRepository.findByIdAndDeletedAtIsNull(dto.getSourceRecordingId())
             .orElseThrow(() -> new NotFoundException("Source Recording: " + dto.getSourceRecordingId()));
 
         if (sourceRecording.getDuration() == null) {
-            // todo try get the duration (code for this not merged yet)
             throw new ResourceInWrongStateException("Source Recording ("
                                                         + dto.getSourceRecordingId()
                                                         + ") does not have a valid duration");

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/EditRequestServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/EditRequestServiceTest.java
@@ -269,6 +269,7 @@ public class EditRequestServiceTest {
         var response = editRequestService.upsert(dto);
         assertThat(response).isEqualTo(UpsertResult.CREATED);
 
+        verify(recordingService, times(1)).syncRecordingMetadataWithStorage(sourceRecording.getId());
         verify(recordingRepository, times(1)).findByIdAndDeletedAtIsNull(sourceRecording.getId());
         verify(editRequestRepository, times(1)).findById(dto.getId());
         verify(mockAuth, times(1)).getAppAccess();
@@ -320,6 +321,7 @@ public class EditRequestServiceTest {
         assertThat(editRequest.getEditInstruction())
             .contains("\"ffmpegInstructions\":[{\"start\":0,\"end\":60},{\"start\":120,\"end\":180}]");
 
+        verify(recordingService, times(1)).syncRecordingMetadataWithStorage(sourceRecording.getId());
         verify(recordingRepository, times(1)).findByIdAndDeletedAtIsNull(sourceRecording.getId());
         verify(editRequestRepository, times(1)).findById(dto.getId());
         verify(mockAuth, never()).getAppAccess();
@@ -360,6 +362,7 @@ public class EditRequestServiceTest {
         ).getMessage();
         assertThat(message).isEqualTo("Not found: Source Recording: " + dto.getSourceRecordingId());
 
+        verify(recordingService, times(1)).syncRecordingMetadataWithStorage(dto.getSourceRecordingId());
         verify(recordingRepository, times(1)).findByIdAndDeletedAtIsNull(dto.getSourceRecordingId());
         verify(editRequestRepository, never()).findById(any());
         verify(mockAuth, never()).getAppAccess();
@@ -404,6 +407,7 @@ public class EditRequestServiceTest {
         assertThat(message)
             .isEqualTo("Source Recording (" + dto.getSourceRecordingId() + ") does not have a valid duration");
 
+        verify(recordingService, times(1)).syncRecordingMetadataWithStorage(sourceRecording.getId());
         verify(recordingRepository, times(1)).findByIdAndDeletedAtIsNull(sourceRecording.getId());
         verify(editRequestRepository, never()).findById(any());
         verify(mockAuth, never()).getAppAccess();


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3941


### Change description
- On creation of edit request, check the filename and duration of the recording match the values in the storage account. If not, update the recording. 


<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
