### PR TITLE
S28 3976: Restrict LEVEL 4 Access to VOD and Recordings

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceControllerFT.java
@@ -14,8 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MediaServiceControllerFT extends FunctionalTestBase {
 
-    @DisplayName("Should return links to play back a vod on demand")
+    private static final String VOD_ENDPOINT = "/media-service/vod";
+
     @Test
+    @DisplayName("Should return links to play back a vod")
     void vodLinks() throws JsonProcessingException {
         var captureSession = createCaptureSession();
         var putCaptureSession = putCaptureSession(captureSession);
@@ -37,8 +39,16 @@ public class MediaServiceControllerFT extends FunctionalTestBase {
         assertResponseCode(links.peek(), 404);
     }
 
+    @Test
+    @DisplayName("Should return 403 when level 4 user attempts to access a vod")
+    void getVodLevel4() {
+        Response getVodResponse = doGetRequest(VOD_ENDPOINT + "?recordingId=" + UUID.randomUUID(),
+                                               TestingSupportRoles.LEVEL_4);
+        assertResponseCode(getVodResponse, 403);
+    }
+
     private ResponseBody<Response> getVodLinks(UUID recordingId) {
-        return doGetRequest("/media-service/vod?recordingId=" + recordingId + "&mediaService=MediaKind",
+        return doGetRequest(VOD_ENDPOINT + "?recordingId=" + recordingId + "&mediaService=MediaKind",
                             TestingSupportRoles.SUPER_USER);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/RecordingControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/RecordingControllerFT.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.preapi.controllers.params.TestingSupportRoles;
@@ -281,6 +282,21 @@ public class RecordingControllerFT extends FunctionalTestBase {
 
         assertThat(getRecordings.body().jsonPath().getString("message"))
             .isEqualTo("Invalid sort parameter 'invalidParam' for 'uk.gov.hmcts.reform.preapi.entities.Recording'");
+    }
+
+    @Test
+    @DisplayName("Should throw 403 when LEVEL 4 user attempts to search recordings")
+    void getRecordingsLevel4() {
+        Response getRecordings = doGetRequest(RECORDINGS_ENDPOINT, TestingSupportRoles.LEVEL_4);
+        assertResponseCode(getRecordings, 403);
+    }
+
+    @Test
+    @DisplayName("Should throw 403 when LEVEL 4 user attempts to get recording by id")
+    void getRecordingByIdLevel4() {
+        Response getRecordings = doGetRequest(RECORDINGS_ENDPOINT + "/" + UUID.randomUUID(),
+                                              TestingSupportRoles.LEVEL_4);
+        assertResponseCode(getRecordings, 403);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/MediaServiceController.java
@@ -137,7 +137,7 @@ public class MediaServiceController extends PreApiController {
     }
 
     @GetMapping("/vod")
-    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3', 'ROLE_LEVEL_4')")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3')")
     public ResponseEntity<PlaybackDTO> getVod(
         @RequestParam UUID recordingId,
         @RequestParam(required = false) String mediaService

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/RecordingController.java
@@ -47,7 +47,7 @@ public class RecordingController extends PreApiController {
 
     @GetMapping("/{recordingId}")
     @Operation(operationId = "getRecordingById", summary = "Get a Recording by Id")
-    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3', 'ROLE_LEVEL_4')")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3')")
     public ResponseEntity<RecordingDTO> getRecordingById(
         @PathVariable UUID recordingId
     ) {
@@ -131,7 +131,7 @@ public class RecordingController extends PreApiController {
         schema = @Schema(implementation = Integer.class),
         example = "10"
     )
-    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3', 'ROLE_LEVEL_4')")
+    @PreAuthorize("hasAnyRole('ROLE_SUPER_USER', 'ROLE_LEVEL_1', 'ROLE_LEVEL_2', 'ROLE_LEVEL_3')")
     public HttpEntity<PagedModel<EntityModel<RecordingDTO>>> searchRecordings(
         @Parameter(hidden = true) @ModelAttribute SearchRecordings params,
         @SortDefault.SortDefaults(


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->


### JIRA ticket(s)
- S28-3976


### Change description
- Remove level 4 access from the following endpoints
    - GET /recordings
    - GET /recordings/{id}
    - GET /media-service/vod

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
