### PR TITLE
Power apps cant run APIs with a description over 80chars...

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
@@ -149,8 +149,7 @@ public class ReportController {
     @GetMapping("/user-primary-courts")
     @Operation(
         operationId = "reportUserPrimaryCourts",
-        summary = "Get report on app users: their first and last name, their role, their active status, "
-            + "their primary court and their last access time (if available)")
+        summary = "Get report on app users and their primary courts")
     public ResponseEntity<List<UserPrimaryCourtReportDTO>> reportUserPrimaryCourts() {
         return ResponseEntity.ok(reportService.reportUserPrimaryCourts());
     }


### PR DESCRIPTION
yes, really....
>Flow save failed with code 'InvalidWorkflowRunActionName' and message 'The provided workflow run action name 'Get_report_on_app_users:_their_first_and_last_name,_their_role,_their_active_status,_their_primary_court_and_their_last_access_time_(if_available)' has a length of '146' which exceeds the maximum limit of '80'.'.[Upgrade](https://make.powerautomate.com/en-US/widgets/manage/#)