### PR TITLE
Makes db pool size configurable per env

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
       charSet: UTF-8
     hikari:
       minimumIdle: 2
-      maximumPoolSize: 10
+      maximumPoolSize: ${HIKARI_POOL_SIZE:10}
       idleTimeout: 10000
       poolName: PreHikariCP
       maxLifetime: 7200000


### PR DESCRIPTION
Adding this configuration so that we can tweak the Hikari CP settings per env and avoid errors like : `PreHikariCP - Connection is not available, request timed out after 30000ms (total=10, active=10, idle=0, waiting=0)`