### PR TITLE
S28-3959 AntPathMatcher deprecated, remove and replace

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.preapi.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -10,7 +11,6 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import uk.gov.hmcts.reform.preapi.security.filter.XUserIdFilter;
 import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
 
@@ -21,23 +21,23 @@ public class SecurityConfig {
 
     private final UserAuthenticationService userAuthenticationService;
 
-    public static final AntPathRequestMatcher[] NOT_AUTHORIZED_URIS = new AntPathRequestMatcher[] {
-        new AntPathRequestMatcher("/testing-support/**"),
-        new AntPathRequestMatcher("/swagger-ui/**"),
-        new AntPathRequestMatcher("/v3/api-docs/**"),
-        new AntPathRequestMatcher("/v3/api-docs"),
-        new AntPathRequestMatcher("/health/**"),
-        new AntPathRequestMatcher("/health"),
-        new AntPathRequestMatcher("/info"),
-        new AntPathRequestMatcher("/prometheus"),
-        new AntPathRequestMatcher("/users/by-email/**"),
-        new AntPathRequestMatcher("/reports/**"),
-        new AntPathRequestMatcher("/audit/**"),
-        new AntPathRequestMatcher("/error"),
-        new AntPathRequestMatcher("/invites", "GET"),
-        new AntPathRequestMatcher("/invites/redeem", "POST"),
-        new AntPathRequestMatcher("/app-terms-and-conditions/latest"),
-        new AntPathRequestMatcher("/portal-terms-and-conditions/latest"),
+    public static final String[] NOT_AUTHORIZED_URIS = new String[] {
+        "/testing-support/**",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/v3/api-docs",
+        "/health/**",
+        "/health",
+        "/info",
+        "/prometheus",
+        "/users/by-email/**",
+        "/reports/**",
+        "/audit/**",
+        "/error",
+        "/invites",
+        "/invites/redeem",
+        "/app-terms-and-conditions/latest",
+        "/portal-terms-and-conditions/latest"
     };
 
     @Autowired
@@ -49,10 +49,12 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                                       authorizationManagerRequestMatcherRegistry
+            .authorizeHttpRequests(authorize ->
+                                       authorize
+                                           .requestMatchers(HttpMethod.GET, "/invites").permitAll()
+                                           .requestMatchers(HttpMethod.POST, "/invites/redeem").permitAll()
                                            .requestMatchers(NOT_AUTHORIZED_URIS).permitAll()
-                                           .requestMatchers("/**").fullyAuthenticated()
+                                           .anyRequest().authenticated()
             )
             .authenticationManager(authentication -> authentication)
             .httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-3959
-->

### Change description

Fixed deprecation message by removing AntPathRequestMatcher. Replaced with Array of Strings.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
