### PR TITLE
Separate out View Per Media Held Report and rename

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -41,7 +41,7 @@ module "pre_api" {
   api_mgmt_rg           = "ss-${var.env}-network-rg"
   api_mgmt_name         = "sds-api-mgmt-${var.env}"
   display_name          = "Pre Recorded Evidence API"
-  revision              = "109"
+  revision              = "110"
   product_id            = module.pre_product[0].product_id
   path                  = "pre-api"
   service_url           = local.apim_service_url

--- a/pre-api-stg.yaml
+++ b/pre-api-stg.yaml
@@ -2213,6 +2213,50 @@ definitions:
         description: UserPrimaryCourtReportRoleName
         type: string
     type: object
+  UserRecordingPlaybackReportDTOV2:
+    description: PlaybackReportDTOV2
+    properties:
+      case_reference:
+        description: ReportCaseReference
+        type: string
+      county:
+        description: ReportCounty
+        type: string
+      court:
+        description: ReportCourt
+        type: string
+      defendants:
+        description: PlaybackReportDefendants
+        type: string
+      playback_date:
+        description: PlaybackReportPlaybackDate
+        type: string
+      playback_time:
+        description: PlaybackReportPlaybackTime
+        type: string
+      postcode:
+        description: ReportPostcode
+        type: string
+      recording_version:
+        description: PlaybackReportRecordingVersion
+        format: int32
+        type: integer
+      region:
+        description: ReportRegion
+        type: string
+      user_email:
+        description: PlaybackReportUserEmail
+        type: string
+      user_full_name:
+        description: PlaybackReportUserFullName
+        type: string
+      user_organisation:
+        description: PlaybackReportUserOrganisation
+        type: string
+      witness:
+        description: PlaybackReportWitness
+        type: string
+    type: object
 externalDocs:
   description: README
   url: 'https://github.com/hmcts/pre-api'
@@ -3971,6 +4015,29 @@ paths:
               $ref: '#/definitions/UserPrimaryCourtReportDTO'
             type: array
       summary: Get report on app users and their primary courts
+      tags:
+        - report-controller
+  /reports-v2/user-recording-playback:
+    get:
+      operationId: userRecordingPlaybackReport
+      parameters:
+        - description: The User Id of the User making the request
+          format: uuid
+          in: header
+          name: X-User-Id
+          required: false
+          type: string
+          x-example: 123e4567-e89b-12d3-a456-426614174000
+      produces:
+        - application/octet-stream
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/UserRecordingPlaybackReportDTOV2'
+            type: array
+      summary: Get report on playback by playback for all sources
       tags:
         - report-controller
   /reports/capture-sessions-concurrent:

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/ReportController.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.ScheduleReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.SharedReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.UserPrimaryCourtReportDTO;
+import uk.gov.hmcts.reform.preapi.dto.reports.UserRecordingPlaybackReportDTOV2;
 import uk.gov.hmcts.reform.preapi.enums.AuditLogSource;
 import uk.gov.hmcts.reform.preapi.services.ReportService;
 
@@ -109,7 +110,6 @@ public class ReportController {
         return ResponseEntity.ok(reportService.reportScheduled());
     }
 
-
     @GetMapping("/playback")
     @Operation(
         operationId = "reportPlayback",
@@ -124,6 +124,15 @@ public class ReportController {
         @RequestParam(required = false) AuditLogSource source
     ) {
         return ResponseEntity.ok(reportService.reportPlayback(source));
+    }
+
+    @GetMapping("/user-recording-playback")
+    @Operation(
+        operationId = "userRecordingPlaybackReport",
+        summary = "Get report on playback by playback for all sources"
+    )
+    public ResponseEntity<List<UserRecordingPlaybackReportDTOV2>> userRecordingPlaybackReport() {
+        return ResponseEntity.ok(reportService.userRecordingPlaybackReport());
     }
 
     @GetMapping("/completed-capture-sessions")

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/PlaybackReportArgsRecord.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/PlaybackReportArgsRecord.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.preapi.dto.reports;
+
+import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.entities.Recording;
+import uk.gov.hmcts.reform.preapi.entities.User;
+
+public record PlaybackReportArgsRecord(Audit audit, User user, Recording recording) { }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/PlaybackReportDTOV2.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/PlaybackReportDTOV2.java
@@ -8,14 +8,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
-import uk.gov.hmcts.reform.preapi.entities.Booking;
-import uk.gov.hmcts.reform.preapi.entities.Participant;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
 import uk.gov.hmcts.reform.preapi.entities.User;
-import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
 import uk.gov.hmcts.reform.preapi.utils.DateTimeUtils;
 
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 @Data
@@ -24,62 +20,13 @@ import javax.annotation.Nullable;
 @EqualsAndHashCode(callSuper = true)
 @Schema(description = "PlaybackReportDTOV2")
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class PlaybackReportDTOV2 extends BaseReportDTO {
-
-    @Schema(description = "PlaybackReportPlaybackDate")
-    private String playbackDate;
-
-    @Schema(description = "PlaybackReportPlaybackTime")
-    private String playbackTime;
+public class PlaybackReportDTOV2 extends UserRecordingPlaybackReportDTOV2 {
 
     @Schema(description = "PlaybackReportTimeZone")
     private String playbackTimeZone;
 
-    @Schema(description = "PlaybackReportRecordingVersion")
-    private Integer recordingVersion;
-
-    @Schema(description = "PlaybackReportDefendants")
-    private String defendants;
-
-    @Schema(description = "PlaybackReportWitness")
-    private String witness;
-
-    @Schema(description = "PlaybackReportUserFullName")
-    private String userFullName;
-
-    @Schema(description = "PlaybackReportUserEmail")
-    private String userEmail;
-
-    @Schema(description = "PlaybackReportUserOrganisation")
-    private String userOrganisation;
-
     public PlaybackReportDTOV2(Audit audit, User user, @Nullable Recording recording) {
-        super(recording != null ? recording.getCaptureSession().getBooking().getCaseId() : null);
-
-        playbackDate = DateTimeUtils.formatDate(audit.getCreatedAt());
-        playbackTime = DateTimeUtils.formatTime(audit.getCreatedAt());
+        super(audit, user, recording);
         playbackTimeZone = DateTimeUtils.getTimezoneAbbreviation(audit.getCreatedAt());
-        if (user != null) {
-            userFullName = user.getFullName();
-            userEmail = user.getEmail();
-            userOrganisation = user.getOrganisation();
-        }
-
-        if (recording != null) {
-            Booking booking = recording.getCaptureSession().getBooking();
-            recordingVersion = recording.getVersion();
-            witness = booking.getParticipants()
-                             .stream()
-                             .filter(p -> p.getParticipantType() == ParticipantType.WITNESS)
-                             .findFirst()
-                             .map(Participant::getFullName)
-                             .orElse(null);
-            defendants = booking.getParticipants().stream()
-                                .filter(p -> p.getParticipantType() == ParticipantType.DEFENDANT)
-                                .map(Participant::getFullName)
-                                .collect(Collectors.collectingAndThen(
-                                    Collectors.joining(", "),
-                                    result -> result.isEmpty() ? null : result));
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/UserRecordingPlaybackReportDTOV2.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/reports/UserRecordingPlaybackReportDTOV2.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.reform.preapi.dto.reports;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.entities.Audit;
+import uk.gov.hmcts.reform.preapi.entities.Booking;
+import uk.gov.hmcts.reform.preapi.entities.Participant;
+import uk.gov.hmcts.reform.preapi.entities.Recording;
+import uk.gov.hmcts.reform.preapi.entities.User;
+import uk.gov.hmcts.reform.preapi.enums.ParticipantType;
+import uk.gov.hmcts.reform.preapi.utils.DateTimeUtils;
+
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Schema(description = "PlaybackReportDTOV2")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserRecordingPlaybackReportDTOV2 extends BaseReportDTO {
+
+    @Schema(description = "PlaybackReportPlaybackDate")
+    protected String playbackDate;
+
+    @Schema(description = "PlaybackReportPlaybackTime")
+    protected String playbackTime;
+
+    @Schema(description = "PlaybackReportRecordingVersion")
+    protected Integer recordingVersion;
+
+    @Schema(description = "PlaybackReportDefendants")
+    protected String defendants;
+
+    @Schema(description = "PlaybackReportWitness")
+    protected String witness;
+
+    @Schema(description = "PlaybackReportUserFullName")
+    protected String userFullName;
+
+    @Schema(description = "PlaybackReportUserEmail")
+    protected String userEmail;
+
+    @Schema(description = "PlaybackReportUserOrganisation")
+    protected String userOrganisation;
+
+    public UserRecordingPlaybackReportDTOV2(Audit audit, User user, @Nullable Recording recording) {
+        super(recording != null ? recording.getCaptureSession().getBooking().getCaseId() : null);
+
+        playbackDate = DateTimeUtils.formatDate(audit.getCreatedAt());
+        playbackTime = DateTimeUtils.formatTime(audit.getCreatedAt());
+        if (user != null) {
+            userFullName = user.getFullName();
+            userEmail = user.getEmail();
+            userOrganisation = user.getOrganisation();
+        }
+
+        if (recording != null) {
+            Booking booking = recording.getCaptureSession().getBooking();
+            recordingVersion = recording.getVersion();
+            witness = booking.getParticipants()
+                             .stream()
+                             .filter(p -> p.getParticipantType() == ParticipantType.WITNESS)
+                             .findFirst()
+                             .map(Participant::getFullName)
+                             .orElse(null);
+            defendants = booking.getParticipants().stream()
+                                .filter(p -> p.getParticipantType() == ParticipantType.DEFENDANT)
+                                .map(Participant::getFullName)
+                                .collect(Collectors.collectingAndThen(
+                                    Collectors.joining(", "),
+                                    result -> result.isEmpty() ? null : result));
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ReportService.java
@@ -7,12 +7,14 @@ import uk.gov.hmcts.reform.preapi.dto.reports.AccessRemovedReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.CompletedCaptureSessionReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.ConcurrentCaptureSessionReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.EditReportDTOV2;
+import uk.gov.hmcts.reform.preapi.dto.reports.PlaybackReportArgsRecord;
 import uk.gov.hmcts.reform.preapi.dto.reports.PlaybackReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingParticipantsReportDTO;
 import uk.gov.hmcts.reform.preapi.dto.reports.RecordingsPerCaseReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.ScheduleReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.SharedReportDTOV2;
 import uk.gov.hmcts.reform.preapi.dto.reports.UserPrimaryCourtReportDTO;
+import uk.gov.hmcts.reform.preapi.dto.reports.UserRecordingPlaybackReportDTOV2;
 import uk.gov.hmcts.reform.preapi.entities.AppAccess;
 import uk.gov.hmcts.reform.preapi.entities.Audit;
 import uk.gov.hmcts.reform.preapi.entities.Case;
@@ -117,15 +119,20 @@ public class ReportService {
             .collect(Collectors.toList());
     }
 
+    public List<UserRecordingPlaybackReportDTOV2> userRecordingPlaybackReport() {
+        return auditRepository
+            .findAllAccessAttempts()
+            .stream()
+            .map(a -> {
+                var args = toPlaybackReport(a);
+                return new UserRecordingPlaybackReportDTOV2(args.audit(), args.user(), args.recording());
+            })
+            .toList();
+    }
+
     @Transactional
     public List<PlaybackReportDTOV2> reportPlayback(AuditLogSource source) {
-        if (source == null) {
-            return auditRepository
-                .findAllAccessAttempts()
-                .stream()
-                .map(this::toPlaybackReport)
-                .toList();
-        } else if (source == AuditLogSource.PORTAL || source == AuditLogSource.APPLICATION) {
+        if (source == AuditLogSource.PORTAL || source == AuditLogSource.APPLICATION) {
             final var activityPlay = "Play";
             final var functionalAreaVideoPlayer = "Video Player";
             final var functionalAreaViewRecordings = "View Recordings";
@@ -139,7 +146,10 @@ public class ReportService {
                     activityPlay
                 )
                 .stream()
-                .map(this::toPlaybackReport)
+                .map(a -> {
+                    var args = toPlaybackReport(a);
+                    return new PlaybackReportDTOV2(args.audit(), args.user(), args.recording());
+                })
                 .toList();
         } else {
             throw new NotFoundException("Report for playback source: " + source);
@@ -186,8 +196,7 @@ public class ReportService {
             .toList();
     }
 
-    private PlaybackReportDTOV2 toPlaybackReport(Audit audit) {
-        // S28-3604 discovered audit details records Recording Id as recordingId _and_ recordinguid
+    private PlaybackReportArgsRecord toPlaybackReport(Audit audit) {
         var auditDetails = audit.getAuditDetails() != null && !audit.getAuditDetails().isNull();
         UUID recordingId = null;
         if (auditDetails) {
@@ -198,21 +207,20 @@ public class ReportService {
             }
         }
 
-        return new PlaybackReportDTOV2(
-            audit,
-            audit.getCreatedBy() != null
-                ? userRepository
-                .findById(audit.getCreatedBy())
-                .orElse(appAccessRepository.findById(audit.getCreatedBy())
-                            .map(AppAccess::getUser)
-                            .orElse(portalAccessRepository.findById(audit.getCreatedBy())
-                                        .map(PortalAccess::getUser)
-                                        .orElse(null)))
-                : null,
-            recordingId != null
-                ? recordingRepository.findById(recordingId).orElse(null)
-                : null
-        );
+        var user = audit.getCreatedBy() != null
+            ? userRepository.findById(audit.getCreatedBy())
+                            .orElse(appAccessRepository.findById(audit.getCreatedBy())
+                                                       .map(AppAccess::getUser)
+                                                       .orElse(portalAccessRepository.findById(audit.getCreatedBy())
+                                                                                     .map(PortalAccess::getUser)
+                                                                                     .orElse(null)))
+            : null;
+
+        var recording = recordingId != null
+            ? recordingRepository.findById(recordingId).orElse(null)
+            : null;
+
+        return new PlaybackReportArgsRecord(audit, user, recording);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ReportServiceTest.java
@@ -520,7 +520,7 @@ public class ReportServiceTest {
 
     @DisplayName("Find audits relating to all playback attempts and return a report")
     @Test
-    void reportPlaybackAllSuccess() {
+    void userRecordingPlaybackReportAllSuccess() {
         var user = new User();
         user.setId(UUID.randomUUID());
         user.setEmail("example@example.com");
@@ -537,12 +537,10 @@ public class ReportServiceTest {
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(recordingRepository.findById(recordingEntity.getId())).thenReturn(Optional.of(recordingEntity));
 
-        var report = reportService.reportPlayback(null);
+        var report = reportService.userRecordingPlaybackReport();
 
         assertThat(report.getFirst().getPlaybackDate()).isEqualTo(DateTimeUtils.formatDate(auditEntity.getCreatedAt()));
         assertThat(report.getFirst().getPlaybackTime()).isEqualTo(DateTimeUtils.formatTime(auditEntity.getCreatedAt()));
-        assertThat(report.getFirst().getPlaybackTimeZone())
-            .isEqualTo(DateTimeUtils.getTimezoneAbbreviation(auditEntity.getCreatedAt()));
 
 
         assertThat(report.getFirst().getUserFullName()).isEqualTo(user.getFullName());
@@ -561,7 +559,7 @@ public class ReportServiceTest {
 
     @DisplayName("Find audits relating to all playback attempts and return a report when null auditdetails")
     @Test
-    void reportPlaybackAllSuccessNullAuditDetails() {
+    void userRecordingPlaybackReportAllSuccessNullAuditDetails() {
         var user = new User();
         user.setId(UUID.randomUUID());
         user.setEmail("example@example.com");
@@ -574,13 +572,11 @@ public class ReportServiceTest {
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(recordingRepository.findById(recordingEntity.getId())).thenReturn(Optional.of(recordingEntity));
 
-        var report = reportService.reportPlayback(null);
+        var report = reportService.userRecordingPlaybackReport();
 
         assertThat(report.size()).isEqualTo(1);
         assertThat(report.getFirst().getPlaybackDate()).isEqualTo(DateTimeUtils.formatDate(auditEntity.getCreatedAt()));
         assertThat(report.getFirst().getPlaybackTime()).isEqualTo(DateTimeUtils.formatTime(auditEntity.getCreatedAt()));
-        assertThat(report.getFirst().getPlaybackTimeZone())
-            .isEqualTo(DateTimeUtils.getTimezoneAbbreviation(auditEntity.getCreatedAt()));
         assertThat(report.getFirst().getUserFullName()).isEqualTo(user.getFullName());
         assertThat(report.getFirst().getUserEmail()).isEqualTo(user.getEmail());
         assertThat(report.getFirst().getUserOrganisation()).isEqualTo(user.getOrganisation());
@@ -596,7 +592,7 @@ public class ReportServiceTest {
 
     @Test
     @DisplayName("Returns audits for all playback attempts a report when createdBy is portalAccess id not of user id")
-    void reportPlaybackAllSuccessAuditDetailsWhenPortalAccessId() {
+    void userRecordingPlaybackReportAllSuccessAuditDetailsWhenPortalAccessId() {
         var user = new User();
         user.setId(UUID.randomUUID());
         user.setEmail("example@example.com");
@@ -614,7 +610,7 @@ public class ReportServiceTest {
         when(portalAccessRepository.findById(portalAccess.getId())).thenReturn(Optional.of(portalAccess));
         when(recordingRepository.findById(recordingEntity.getId())).thenReturn(Optional.of(recordingEntity));
 
-        var report = reportService.reportPlayback(null);
+        var report = reportService.userRecordingPlaybackReport();
 
         assertThat(report.size()).isEqualTo(1);
         assertThat(report.getFirst().getPlaybackDate()).isEqualTo(DateTimeUtils.formatDate(auditEntity.getCreatedAt()));


### PR DESCRIPTION
### JIRA ticket(s)

- S28-3167

### Change description

- Split out View Per Media Held Report into separate endpoint and rename to User Recording Playback Report
- New report is the same as the Application and Portal playback reports but without the timezone column...
