### PR TITLE
New API endpoint to send emails to verify email addresses

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/email/GovNotifyFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/email/GovNotifyFT.java
@@ -218,4 +218,27 @@ public class GovNotifyFT {
             Kind regards,
             Pre-Recorded Evidence Team""", response);
     }
+
+    @DisplayName("Should send verify email email")
+    @Test
+    @SuppressWarnings("LineLength")
+    void verifyEmail() {
+
+        var verificationCode = "123456";
+
+        var response = client.emailVerification(toEmailAddress, userFirstName, userLastName, verificationCode);
+        assertEquals(fromEmailAddress, response.getFromEmail());
+        assertEquals(
+            "[Do Not Reply] Pre-recorded Evidence: Account Email Verification Code",
+            response.getSubject()
+        );
+        compareBody(
+            """
+            Dear John Doe,
+
+            Your code is: 123456
+
+            Kind regards,
+            Pre-Recorded Evidence Team""", response);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         new AntPathRequestMatcher("/users/by-email/**"),
         new AntPathRequestMatcher("/reports/**"),
         new AntPathRequestMatcher("/audit/**"),
+        new AntPathRequestMatcher("/b2c/**"),
         new AntPathRequestMatcher("/error"),
         new AntPathRequestMatcher("/invites", "GET"),
         new AntPathRequestMatcher("/invites/redeem", "POST"),

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/B2CController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/B2CController.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.preapi.controllers;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.hmcts.reform.preapi.dto.VerifyEmailRequestDTO;
+import uk.gov.hmcts.reform.preapi.email.EmailServiceFactory;
+import uk.gov.hmcts.reform.preapi.services.UserService;
+
+@RestController
+@RequestMapping("/b2c")
+public class B2CController {
+
+    private final UserService userService;
+    private final EmailServiceFactory emailServiceFactory;
+    private final String emailServiceName;
+
+    public B2CController(@Autowired UserService userService,
+                         @Autowired EmailServiceFactory emailServiceFactory,
+                         @Value("${email.service}") String emailServiceName) {
+        this.userService = userService;
+        this.emailServiceFactory = emailServiceFactory;
+        this.emailServiceName = emailServiceName;
+    }
+
+    @PostMapping("/email-verification")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(operationId = "postEmailVerification", summary = "Trigger an email verification email to be sent out via gov notify")
+    public void postEmailVerification(@Valid @RequestBody VerifyEmailRequestDTO request) {
+        var user = userService.findByEmail(request.getEmail()).getUser();
+        var emailService = this.emailServiceFactory.getEnabledEmailService(emailServiceName);
+        emailService.emailVerification(request.getEmail(),
+                                       user.getFirstName(),
+                                       user.getLastName(),
+                                       request.getVerificationCode());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/dto/VerifyEmailRequestDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/dto/VerifyEmailRequestDTO.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.preapi.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.preapi.entities.Case;
+import uk.gov.hmcts.reform.preapi.entities.Participant;
+import uk.gov.hmcts.reform.preapi.enums.CaseState;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
+
+import java.sql.Timestamp;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@NoArgsConstructor
+@Schema(description = "VerifyEmailRequestDTO")
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@SuppressWarnings("PMD.ShortClassName")
+public class VerifyEmailRequestDTO {
+
+    @Schema(description = "Email")
+    private String email;
+
+    @Schema(description = "VerificationCode")
+    private String verificationCode;
+}

--- a/src/main/java/uk/gov/hmcts/reform/preapi/email/IEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/email/IEmailService.java
@@ -18,4 +18,6 @@ public interface IEmailService {
     EmailResponse caseClosed(User to, Case forCase) throws EmailFailedToSendException;
 
     EmailResponse caseClosureCancelled(User to, Case forCase) throws EmailFailedToSendException;
+
+    EmailResponse emailVerification(String email, String firstName, String lastName, String verificationCode) throws EmailFailedToSendException;
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/email/govnotify/GovNotify.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/email/govnotify/GovNotify.java
@@ -117,6 +117,20 @@ public class GovNotify implements IEmailService {
         }
     }
 
+    @Override
+    public EmailResponse emailVerification(String email, String firstName, String lastName, String verificationCode) {
+        var template = new uk.gov.hmcts.reform.preapi.email.govnotify.templates.EmailVerification(
+            email, firstName, lastName, verificationCode
+        );
+        try {
+            log.info("Email verification sent to {}", email);
+            return EmailResponse.fromGovNotifyResponse(sendEmail(template));
+        } catch (NotificationClientException e) {
+            log.error("Failed to send email verification to {}", email, e);
+            throw new EmailFailedToSendException(email);
+        }
+    }
+
     private SendEmailResponse sendEmail(BaseTemplate email) throws NotificationClientException {
         return client.sendEmail(email.getTemplateId(), email.getTo(), email.getVariables(), email.getReference());
     }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/email/govnotify/templates/EmailVerification.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/email/govnotify/templates/EmailVerification.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.preapi.email.govnotify.templates;
+
+import java.util.Map;
+
+public class EmailVerification extends BaseTemplate {
+    public EmailVerification(String to, String firstName, String lastName, String verificationCode) {
+        super(
+            to,
+            Map.of(
+                "first_name", firstName,
+                "last_name", lastName,
+                "verification_code", verificationCode
+            )
+        );
+    }
+
+    public String getTemplateId() {
+        return "24de8c44-06af-4489-9e83-134b48894d36";
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/preapi/controller/B2CControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/controller/B2CControllerTest.java
@@ -1,0 +1,117 @@
+package uk.gov.hmcts.reform.preapi.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.preapi.controllers.B2CController;
+import uk.gov.hmcts.reform.preapi.dto.AccessDTO;
+import uk.gov.hmcts.reform.preapi.dto.VerifyEmailRequestDTO;
+import uk.gov.hmcts.reform.preapi.dto.base.BaseUserDTO;
+import uk.gov.hmcts.reform.preapi.email.EmailServiceFactory;
+import uk.gov.hmcts.reform.preapi.email.govnotify.GovNotify;
+import uk.gov.hmcts.reform.preapi.security.service.UserAuthenticationService;
+import uk.gov.hmcts.reform.preapi.services.ScheduledTaskRunner;
+import uk.gov.hmcts.reform.preapi.services.UserService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(B2CController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@SuppressWarnings({"PMD.LinguisticNaming"})
+class B2CControllerTest {
+
+    @Autowired
+    private transient MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private EmailServiceFactory emailServiceFactory;
+
+    @MockitoBean
+    private UserAuthenticationService userAuthenticationService;
+
+    @MockitoBean
+    private ScheduledTaskRunner taskRunner;
+
+    private static final String TEST_URL = "http://localhost";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @DisplayName("Should send email verification email")
+    @Test
+    void sendEmailVerificationEmail() throws Exception {
+
+        var email = "test@test.com";
+        var accessDTO = mock(AccessDTO.class);
+        var user = mock(BaseUserDTO.class);
+        when(accessDTO.getUser()).thenReturn(user);
+        when(user.getFirstName()).thenReturn("Foo");
+        when(user.getLastName()).thenReturn("Bar");
+
+        var emailService = mock(GovNotify.class);
+        when(emailServiceFactory.getEnabledEmailService("GovNotify")).thenReturn(emailService);
+
+        when(userService.findByEmail(email)).thenReturn(accessDTO);
+        when(emailService.emailVerification(email, "Foo", "Bar", "123456"))
+            .thenReturn(null); // no errors
+
+        var request = new VerifyEmailRequestDTO();
+        request.setEmail(email);
+        request.setVerificationCode("123456");
+
+        mockMvc.perform(post(TEST_URL + "/b2c/email-verification")
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent())
+            .andReturn();
+    }
+
+    @DisplayName("Should fail send email verification email unknown email service")
+    @Test
+    void sendEmailVerificationEmailNoSuchEmailService() throws Exception {
+
+        var email = "test@test.com";
+        var accessDTO = mock(AccessDTO.class);
+        var user = mock(BaseUserDTO.class);
+        when(accessDTO.getUser()).thenReturn(user);
+        when(user.getFirstName()).thenReturn("Foo");
+        when(user.getLastName()).thenReturn("Bar");
+
+        var emailService = mock(GovNotify.class);
+        when(emailServiceFactory.getEnabledEmailService("GovNotify"))
+            .thenThrow(new IllegalArgumentException("Unknown email service: GovNotify"));
+
+        when(userService.findByEmail(email)).thenReturn(accessDTO);
+        when(emailService.emailVerification(email, "Foo", "Bar", "123456"))
+            .thenReturn(null); // no errors
+
+        var request = new VerifyEmailRequestDTO();
+        request.setEmail(email);
+        request.setVerificationCode("123456");
+
+        var response = mockMvc.perform(post(TEST_URL + "/b2c/email-verification")
+                            .with(csrf())
+                            .content(OBJECT_MAPPER.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().is5xxServerError())
+            .andReturn();
+        assertThat(response.getResponse().getContentAsString())
+            .contains("Unknown email service: GovNotify");
+    }
+}


### PR DESCRIPTION
### JIRA ticket(s)

- S28-4064

### Change description

-
-

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

