### PR TITLE
S28-4112 UserDTOTest update to fix failing test

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/preapi/dto/UserDTOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/dto/UserDTOTest.java
@@ -126,6 +126,8 @@ public class UserDTOTest {
     private User createUserEntity() {
         var user = HelperFactory.createUser("Example", "Person", "example@example.com", null, null, null);
 
+        var now = Instant.now();
+
         var court = HelperFactory.createCourt(CourtType.CROWN, "Example", "123");
         var access2 = HelperFactory.createAppAccess(
             user,
@@ -133,7 +135,7 @@ public class UserDTOTest {
             HelperFactory.createRole("Example Role 1"),
             true,
             null,
-            Timestamp.from(Instant.now()),
+            Timestamp.from(now),
             true
         );
         var access3 = HelperFactory.createAppAccess(
@@ -142,7 +144,7 @@ public class UserDTOTest {
             HelperFactory.createRole("Example Role 2"),
             true,
             null,
-            Timestamp.from(Instant.now()),
+            Timestamp.from(now.plusSeconds(10)),
             false
         );
         var access1 = HelperFactory.createAppAccess(
@@ -151,7 +153,7 @@ public class UserDTOTest {
             HelperFactory.createRole("Example Role 3"),
             true,
             null,
-            Timestamp.from(Instant.now()),
+            Timestamp.from(now.plusSeconds(20)),
             false
         );
         var access4 = HelperFactory.createAppAccess(


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-4122
-->

### Change description

Test originally used multiple Instant.now() calls. This caused intermittent failures as the timestamp could be identical.

Replaced multiple calls to Instant.now() with a single 'now' variable.
Timestamps are generated calling now.plusSeconds() to add time and simulate the expected sorting order.

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
