### PR TITLE
fix: extend timeout for processing capture sessions to 2 hours

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/ProcessCaptureSessions.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/ProcessCaptureSessions.java
@@ -46,7 +46,7 @@ public class ProcessCaptureSessions extends RobotUserTask {
 
         encodeJobService.findAllProcessing()
             .stream()
-            .filter(job -> job.getCreatedAt().before(Timestamp.from(Instant.now().minusSeconds(120))))
+            .filter(job -> job.getCreatedAt().before(Timestamp.from(Instant.now().minusSeconds(7200)))) // 2hrs
             .forEach(job -> {
                 log.error(
                     "Processing job {} for capture session {} has timed out",


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)

- S28-3748


### Change description
- increase processing job timeout to 2hrs

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
