### PR TITLE
S28 4043: Null Durations Cron Ignores Case State on Update

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
@@ -2,30 +2,37 @@ package uk.gov.hmcts.reform.preapi.services;
 
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.reform.preapi.controllers.params.SearchRecordings;
+import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.entities.Court;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
+import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.enums.CourtType;
 import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
+import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
+import uk.gov.hmcts.reform.preapi.exception.ResourceInWrongStateException;
 import uk.gov.hmcts.reform.preapi.security.authentication.UserAuthentication;
 import uk.gov.hmcts.reform.preapi.util.HelperFactory;
 import uk.gov.hmcts.reform.preapi.utils.IntegrationTestBase;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -135,7 +142,7 @@ public class RecordingServiceIT extends IntegrationTestBase {
         Assertions.assertEquals(recordings1.size(), 1);
         Assertions.assertEquals(recordings1.getFirst().getId(), recording1.getId());
 
-        var message = Assertions.assertThrows(
+        var message = assertThrows(
             AccessDeniedException.class,
             () -> recordingService.findAll(new SearchRecordings(), true, Pageable.unpaged()).toList()
         ).getMessage();
@@ -237,5 +244,54 @@ public class RecordingServiceIT extends IntegrationTestBase {
 
         assertThat(results).hasSize(1);
         assertThat(results.getFirst().getId()).isEqualTo(recordingWithNullDuration.getId());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Should force upsert recording even if case in uneditable state")
+    void forceUpsert() {
+        mockAdminUser();
+
+        Court court = HelperFactory.createCourt(CourtType.CROWN, "Example Court", "1234");
+        entityManager.persist(court);
+
+        Case caseEntity = HelperFactory.createCase(court, "CASE12345", true, null);
+        caseEntity.setState(CaseState.PENDING_CLOSURE);
+        entityManager.persist(caseEntity);
+
+        Booking booking = HelperFactory.createBooking(caseEntity, Timestamp.from(Instant.now()), null);
+        entityManager.persist(booking);
+
+        CaptureSession captureSession = HelperFactory.createCaptureSession(
+            booking,
+            RecordingOrigin.PRE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        entityManager.persist(captureSession);
+
+        Recording recordingWithNullDuration = HelperFactory.createRecording(
+            captureSession, null, 1, "nullDurationFile", null);
+        entityManager.persist(recordingWithNullDuration);
+        entityManager.flush();
+
+        CreateRecordingDTO updateDto = new CreateRecordingDTO();
+        updateDto.setId(recordingWithNullDuration.getId());
+        updateDto.setCaptureSessionId(captureSession.getId());
+        updateDto.setVersion(1);
+        updateDto.setFilename("updatedFilename");
+        updateDto.setDuration(Duration.ofMinutes(3));
+
+        assertThrows(
+            ResourceInWrongStateException.class,
+            () -> recordingService.upsert(updateDto)
+        );
+        assertThat(recordingService.forceUpsert(updateDto)).isEqualTo(UpsertResult.UPDATED);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/CleanupNullRecordingDuration.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/CleanupNullRecordingDuration.java
@@ -125,7 +125,7 @@ public class CleanupNullRecordingDuration extends RobotUserTask {
 
         log.info("Updating duration for recording {} to {}", dto.getId(), dto.getDuration());
         if (enableUpsert) {
-            recordingService.upsert(dto);
+            recordingService.forceUpsert(dto);
         }
         return false;
     }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/CleanupNullRecordingDurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/CleanupNullRecordingDurationTest.java
@@ -47,7 +47,7 @@ class CleanupNullRecordingDurationTest {
             cleanupNullRecordingDuration.run();
 
             ArgumentCaptor<CreateRecordingDTO> captor = ArgumentCaptor.forClass(CreateRecordingDTO.class);
-            verify(recordingService).upsert(captor.capture());
+            verify(recordingService).forceUpsert(captor.capture());
             CreateRecordingDTO capturedRecording = captor.getValue();
             assertThat(capturedRecording.getDuration()).isEqualTo(Duration.ofMinutes(10));
         }
@@ -64,7 +64,7 @@ class CleanupNullRecordingDurationTest {
             cleanupNullRecordingDuration.run();
 
             verifyNoInteractions(ffmpegService);
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
 
         @Test
@@ -92,7 +92,7 @@ class CleanupNullRecordingDurationTest {
             verify(azureFinalStorageService, times(1)).getMp4FileName(recordingId.toString());
             verify(ffmpegService, times(1)).getDurationFromMp4(recordingId.toString(), newFilename);
             ArgumentCaptor<CreateRecordingDTO> captor = ArgumentCaptor.forClass(CreateRecordingDTO.class);
-            verify(recordingService, times(1)).upsert(captor.capture());
+            verify(recordingService, times(1)).forceUpsert(captor.capture());
 
             CreateRecordingDTO capturedRecording = captor.getValue();
             assertThat(capturedRecording.getDuration()).isEqualTo(Duration.ofMinutes(10));
@@ -119,7 +119,7 @@ class CleanupNullRecordingDurationTest {
 
             verify(azureFinalStorageService, times(1)).doesContainerExist(recordingId.toString());
             verify(azureFinalStorageService).getMp4FileName(recordingId.toString());
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
 
         @Test
@@ -142,7 +142,7 @@ class CleanupNullRecordingDurationTest {
             cleanupNullRecordingDuration.run();
 
             verify(ffmpegService).getDurationFromMp4(recordingId.toString(), "test.mp4");
-            verify(recordingService).upsert(any(CreateRecordingDTO.class));
+            verify(recordingService).forceUpsert(any(CreateRecordingDTO.class));
         }
 
         @Test
@@ -166,7 +166,7 @@ class CleanupNullRecordingDurationTest {
             cleanupNullRecordingDuration.run();
 
             verify(ffmpegService).getDurationFromMp4(recordingId.toString(), "test.mp4");
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
 
         @Test
@@ -198,7 +198,7 @@ class CleanupNullRecordingDurationTest {
             verify(ffmpegService).getDurationFromMp4(recordingId.toString(), fallbackFilename);
 
             ArgumentCaptor<CreateRecordingDTO> captor = ArgumentCaptor.forClass(CreateRecordingDTO.class);
-            verify(recordingService).upsert(captor.capture());
+            verify(recordingService).forceUpsert(captor.capture());
 
             CreateRecordingDTO captured = captor.getValue();
             assertThat(captured.getFilename()).isEqualTo(fallbackFilename);
@@ -228,7 +228,7 @@ class CleanupNullRecordingDurationTest {
 
             cleanupNullRecordingDuration.run();
 
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
 
         @Test
@@ -255,7 +255,7 @@ class CleanupNullRecordingDurationTest {
             verify(azureFinalStorageService, never()).doesBlobExist(any(), any());
             verify(azureFinalStorageService, times(1)).getMp4FileName(recordingId.toString());
             verify(ffmpegService, times(1)).getDurationFromMp4(recordingId.toString(), newFilename);
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
 
         @Test
@@ -278,7 +278,7 @@ class CleanupNullRecordingDurationTest {
             cleanupNullRecordingDuration.run();
 
             verify(ffmpegService).getDurationFromMp4(recordingId.toString(), "test.mp4");
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
 
         @Test
@@ -308,7 +308,7 @@ class CleanupNullRecordingDurationTest {
 
             verify(azureFinalStorageService).getMp4FileName(recordingId.toString());
             verify(ffmpegService).getDurationFromMp4(recordingId.toString(), fallbackFilename);
-            verify(recordingService, never()).upsert(any());
+            verify(recordingService, never()).forceUpsert(any());
         }
     }
 }


### PR DESCRIPTION

<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)
- S28-4043


### Change description
- Cron job now able to update recordings where the case state is either PENDING_CLOSURE or CLOSED

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
