### PR TITLE
S28-4084 - Removes null check for live output url

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/CheckForMissingRecordings.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/CheckForMissingRecordings.java
@@ -150,11 +150,6 @@ public class CheckForMissingRecordings extends RobotUserTask {
                     "Recording for capture session %s has zero duration in database",
                     captureSessionId
                 ));
-            } else if (recording.getCaptureSession().getLiveOutputUrl() == null) {
-                unhappyRecordings.add(format(
-                    "Capture session %s missing live output url",
-                    captureSessionId
-                ));
             } else {
                 var recordingFromFinalSA = azureFinalStorageService.getRecordingDuration(recording.getId());
                 if (recordingFromFinalSA == null) {

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/CheckForMissingRecordingsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/CheckForMissingRecordingsTest.java
@@ -181,10 +181,6 @@ public class CheckForMissingRecordingsTest {
                           + ": not in database\\n");
 
         assertThat(slackCaptor.getValue())
-            .contains("\\nCapture session " + captureSessionNoLiveOutputUrl.getId()
-                          + " missing live output url\\n");
-
-        assertThat(slackCaptor.getValue())
             .contains("Missing recording for capture session " + captureSessionRecNotInSA.getId()
                           + ": not in final SA\\n");
     }


### PR DESCRIPTION
<!--

### JIRA ticket(s)

https://tools.hmcts.net/jira/browse/S28-4084

### Change description

Removes checking for the live output url for a recording from the task that sends alerts about recordings.