### PR TITLE
S28 4188 - User stuck on Terms and Conditions page loop

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedServiceIT.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.preapi.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.entities.TermsAndConditions;
 import uk.gov.hmcts.reform.preapi.entities.User;
@@ -14,6 +16,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 public class UserTermsAcceptedServiceIT extends IntegrationTestBase {
@@ -21,12 +24,19 @@ public class UserTermsAcceptedServiceIT extends IntegrationTestBase {
     @Autowired
     private UserTermsAcceptedService userTermsAcceptedService;
 
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
     private User user;
     private TermsAndConditions termsAndConditions;
 
     @BeforeEach
     void setUp() {
-        user = HelperFactory.createDefaultTestUser();
+        user = HelperFactory.createUser("firstName",
+                                        "lastName", "example@example.com", null, null, null);
         user.setId(UUID.randomUUID());
         entityManager.persist(user);
 
@@ -55,5 +65,67 @@ public class UserTermsAcceptedServiceIT extends IntegrationTestBase {
         assertThat(termsAccepted.getTermsAndConditions().getId()).isEqualTo(termsAndConditions.getId());
         // very recently created
         assertThat(termsAccepted.getAcceptedAt()).isAfter(Instant.now().minusSeconds(5));
+    }
+
+    @Test
+    @Transactional
+    public void acceptTermsAndConditionsMultipleTimes() {
+        var mockedUser = mockAdminUser();
+        when(mockedUser.getUserId()).thenReturn(user.getId());
+        userTermsAcceptedService.acceptTermsAndConditions(termsAndConditions.getId());
+        userTermsAcceptedService.acceptTermsAndConditions(termsAndConditions.getId());
+        userTermsAcceptedService.acceptTermsAndConditions(termsAndConditions.getId());
+
+        entityManager.flush();
+        entityManager.refresh(user);
+
+        assertThat(user.getUserTermsAccepted()).isNotNull();
+        assertThat(user.getUserTermsAccepted()).hasSize(3);
+
+        var termsAccepted = user.getUserTermsAccepted();
+        assertThat(termsAccepted).isNotNull();
+        assertThat(termsAccepted.stream()
+                       .allMatch(t -> t.getTermsAndConditions().getId()
+                           .equals(termsAndConditions.getId()))).isTrue();
+    }
+
+    @Test
+    @Transactional
+    public void evictCacheAfterAcceptingTerms() {
+        var mockedUser = mockAdminUser();
+        when(mockedUser.getUserId()).thenReturn(user.getId());
+
+        // Populate the cache before accepting terms
+        userService.findByEmail(user.getEmail());
+
+        var cache = cacheManager.getCache("users");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(user.getEmail())).isNotNull();
+
+        userTermsAcceptedService.acceptTermsAndConditions(termsAndConditions.getId());
+        entityManager.flush();
+        entityManager.refresh(user);
+        // After accepting terms, the cache should be evicted
+        assertThat(cache.get(user.getEmail())).isNull();
+    }
+
+    @Test
+    @Transactional
+    public void cacheWontBeEvictedIfAcceptanceFails() throws Exception {
+        var mockedUser = mockAdminUser();
+        when(mockedUser.getUserId()).thenReturn(user.getId());
+
+        // Populate the cache before accepting terms
+        userService.findByEmail(user.getEmail());
+
+        var cache = cacheManager.getCache("users");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(user.getEmail())).isNotNull();
+
+        assertThatThrownBy(() -> userTermsAcceptedService.acceptTermsAndConditions(null))
+            .isInstanceOf(InvalidDataAccessApiUsageException.class)
+            .hasMessageContaining("The given id must not be null");;
+
+        assertThat(cache.get(user.getEmail())).isNotNull();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.preapi.services;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,22 +21,38 @@ public class UserTermsAcceptedService {
     private final UserRepository userRepository;
     private final TermsAndConditionsRepository termsAndConditionsRepository;
     private final UserTermsAcceptedRepository userTermsAcceptedRepository;
+    private final CacheManager cacheManager;
 
     @Autowired
     public UserTermsAcceptedService(UserRepository userRepository,
                                     TermsAndConditionsRepository termsAndConditionsRepository,
-                                    UserTermsAcceptedRepository userTermsAcceptedRepository) {
+                                    UserTermsAcceptedRepository userTermsAcceptedRepository,
+                                    CacheManager cacheManager) {
         this.userRepository = userRepository;
         this.termsAndConditionsRepository = termsAndConditionsRepository;
         this.userTermsAcceptedRepository = userTermsAcceptedRepository;
+        this.cacheManager = cacheManager;
     }
 
+    /**
+     * Accepts the specified terms and conditions for a user.
+     * <p>Retrieves the user from the database via security context. Gets the specified terms
+     * and conditions then creates and persists a record of the user's acceptance of those terms.</p>
+     * <p>
+     * After persisting the acceptance, this method manually evicts the the cache populated by {@link uk.gov.hmcts.reform.preapi.services.UserService#findByEmail(String)}.
+     * This ensures that the user's updated terms acceptance is reflected in the cache on subsequent calls to
+     * {@link uk.gov.hmcts.reform.preapi.services.UserService#findByEmail(String)}.
+     * <p>
+     * @param termsId the UUID of the terms and conditions to accept
+     * @throws uk.gov.hmcts.reform.preapi.exception.NotFoundException if the user or terms and conditions are not found
+     */
     @Transactional
     public void acceptTermsAndConditions(UUID termsId) {
         var userId = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication()).getUserId();
         var user = userRepository.findById(userId)
             // this will not happen
             .orElseThrow(() -> new NotFoundException("User: " + userId));
+        var userEmail = user.getEmail(); // for cache eviction
         var termsAndConditions = termsAndConditionsRepository.findById(termsId)
             .orElseThrow(() -> new NotFoundException("TermsAndConditions: " + termsId));
 
@@ -45,5 +62,10 @@ public class UserTermsAcceptedService {
         accepted.setTermsAndConditions(termsAndConditions);
         accepted.setAcceptedAt(Timestamp.from(Instant.now()));
         userTermsAcceptedRepository.save(accepted);
+
+        var cache = cacheManager.getCache("users");
+        if (cache != null) {
+            cache.evict(userEmail.toLowerCase());
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedService.java
@@ -36,13 +36,18 @@ public class UserTermsAcceptedService {
 
     /**
      * Accepts the specified terms and conditions for a user.
-     * <p>Retrieves the user from the database via security context. Gets the specified terms
-     * and conditions then creates and persists a record of the user's acceptance of those terms.</p>
+     *
      * <p>
-     * After persisting the acceptance, this method manually evicts the the cache populated by {@link uk.gov.hmcts.reform.preapi.services.UserService#findByEmail(String)}.
+     * Retrieves the user from the database via security context. Gets the specified terms
+     * and conditions then creates and persists a record of the user's acceptance of those terms.
+     * </p>
+     *
+     * <p>
+     * After persisting the acceptance, this method manually evicts the the cache populated by
+     * {@link uk.gov.hmcts.reform.preapi.services.UserService#findByEmail(String)}.
      * This ensures that the user's updated terms acceptance is reflected in the cache on subsequent calls to
      * {@link uk.gov.hmcts.reform.preapi.services.UserService#findByEmail(String)}.
-     * <p>
+     * </p>
      * @param termsId the UUID of the terms and conditions to accept
      * @throws uk.gov.hmcts.reform.preapi.exception.NotFoundException if the user or terms and conditions are not found
      */
@@ -52,7 +57,6 @@ public class UserTermsAcceptedService {
         var user = userRepository.findById(userId)
             // this will not happen
             .orElseThrow(() -> new NotFoundException("User: " + userId));
-        var userEmail = user.getEmail(); // for cache eviction
         var termsAndConditions = termsAndConditionsRepository.findById(termsId)
             .orElseThrow(() -> new NotFoundException("TermsAndConditions: " + termsId));
 
@@ -63,6 +67,7 @@ public class UserTermsAcceptedService {
         accepted.setAcceptedAt(Timestamp.from(Instant.now()));
         userTermsAcceptedRepository.save(accepted);
 
+        var userEmail = user.getEmail(); // needed for cache eviction
         var cache = cacheManager.getCache("users");
         if (cache != null) {
             cache.evict(userEmail.toLowerCase());

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/UserTermsAcceptedServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.reform.preapi.entities.TermsAndConditions;
@@ -38,6 +39,9 @@ public class UserTermsAcceptedServiceTest {
     @MockitoBean
     private UserTermsAcceptedRepository userTermsAcceptedRepository;
 
+    @MockitoBean
+    CacheManager cacheManager;
+
     @Autowired
     private UserTermsAcceptedService userTermsAcceptedService;
 
@@ -58,6 +62,7 @@ public class UserTermsAcceptedServiceTest {
         verify(userRepository, times(1)).findById(user.getId());
         verify(termsAndConditionsRepository, times(1)).findById(terms.getId());
         verify(userTermsAcceptedRepository, times(1)).save(any(UserTermsAccepted.class));
+        verify(cacheManager, times(1)).getCache("users");
     }
 
     @Test
@@ -80,6 +85,7 @@ public class UserTermsAcceptedServiceTest {
         verify(userRepository, times(1)).findById(user.getId());
         verify(termsAndConditionsRepository, never()).findById(any());
         verify(userTermsAcceptedRepository, never()).save(any());
+        verify(cacheManager, never()).getCache("users");
     }
 
     @Test
@@ -103,6 +109,7 @@ public class UserTermsAcceptedServiceTest {
         verify(userRepository, times(1)).findById(user.getId());
         verify(termsAndConditionsRepository, times(1)).findById(terms.getId());
         verify(userTermsAcceptedRepository, never()).save(any());
+        verify(cacheManager, never()).getCache("users");
     }
 
     private void mockUser(User user) {


### PR DESCRIPTION
### JIRA ticket(s)

- [S28-4188](https://tools.hmcts.net/jira/browse/S28-4188)

### Change description

- Adds evicting the users cache when a user accepts the terms and conditions. This is meant to prevent the API returning stale info to the portal that the user hasn't accepted the terms and conditions

**QA instructions**

- Regression test of seeing a recording in Portal
- Create a new user that has not accepted the terms and conditions for the portal
- Login as that user and assert that user is asked just once to accept the terms and conditions