### PR TITLE
Fix bug in APIM revision number increment

### DIFF
--- a/.github/workflows/publish-swagger-v2-and-bump-apim-revision.yaml
+++ b/.github/workflows/publish-swagger-v2-and-bump-apim-revision.yaml
@@ -75,7 +75,7 @@ jobs:
             echo "No changes to pre-api-stg.yaml"
             if [[ $master_revision -gt $branch_revision ]]; then
               echo "Master revision is greater than branch revision"
-              awk -v new_revision="$master_revision" 'BEGIN{FS=OFS="\""} /api_revision/{$2=new_revision}1' infrastructure/main.tf > temp && mv temp infrastructure/main.tf
+              awk -v new_revision="$master_revision" 'BEGIN{FS=OFS="\""} /api_revision=/{$2=new_revision}1' infrastructure/main.tf > temp && mv temp infrastructure/main.tf
               git add infrastructure/main.tf
               commit_message="${commit_message} Bump APIm revision to $master_revision"
             fi
@@ -83,7 +83,7 @@ jobs:
             echo "API Spec has changed compared to master, ensure revision is incremented"
             if [[ $master_revision -ge $branch_revision ]]; then
               new_revision=$((master_revision + 1))
-              awk -v new_revision="$new_revision" 'BEGIN{FS=OFS="\""} /api_revision/{$2=new_revision}1' infrastructure/main.tf > temp && mv temp infrastructure/main.tf
+              awk -v new_revision="$new_revision" 'BEGIN{FS=OFS="\""} /api_revision=/{$2=new_revision}1' infrastructure/main.tf > temp && mv temp infrastructure/main.tf
               git add infrastructure/main.tf
               commit_message="${commit_message} Bump APIm revision to $new_revision"
             fi


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-0000
-->

### Change description

- Fixes bug in awk script that updates APIM revision number
- Follows from main.tf change where revision number was replaced by variable https://github.com/hmcts/pre-api/commit/f06875faed0699cc88e264f63b5c8b9ce1141d18
- Don't know why this hasn't been a problem for the last few increments??

Incorrect: 
<img width="601" height="625" alt="image" src="https://github.com/user-attachments/assets/f6b6477a-dbc0-4655-bc6a-8f9cfbe2f6b4" />




<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
