### PR TITLE
Extend court_reference column length in vf_migration_records

### DIFF
--- a/src/main/resources/db/migration/V047__UpdateTempTableFieldLength.sql
+++ b/src/main/resources/db/migration/V047__UpdateTempTableFieldLength.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.vf_migration_records
+ALTER COLUMN court_reference TYPE VARCHAR(255);


### PR DESCRIPTION
The FE allows users to select the full official court name (e.g. Manchester Minshull Street Crown Court), which in cases exceeds 25 characters. These values are being stored in the temp migration table under court_reference.

The simplest fix is to extend the field length.