### PR TITLE
 Mk Assets - to include Vodafone recordings with null duration (not just NO_RECORDING sessions)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -140,4 +140,13 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
         """
     )
     List<Recording> findAllOriginVodafone();
+
+    @Query("""
+        SELECT r FROM Recording r
+        WHERE r.captureSession.origin = 'VODAFONE'
+        AND r.duration IS NULL
+        AND r.deletedAt IS NULL
+        """
+    )
+    List<Recording> findAllOriginVodafoneNoDuration();
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -252,15 +252,10 @@ public class RecordingService {
 
     @Transactional
     public List<RecordingDTO> findAllVodafoneRecordings() {
-        return recordingRepository.findAllOriginVodafone().stream()
-            .map(RecordingDTO::new)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public List<RecordingDTO> findAllVodafoneRecordingsNoDuration() {
+        // return recordingRepository.findAllOriginVodafone().stream()
         return recordingRepository.findAllOriginVodafoneNoDuration().stream()
             .map(RecordingDTO::new)
             .collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/RecordingService.java
@@ -256,4 +256,11 @@ public class RecordingService {
             .map(RecordingDTO::new)
             .collect(Collectors.toList());
     }
+
+    @Transactional
+    public List<RecordingDTO> findAllVodafoneRecordingsNoDuration() {
+        return recordingRepository.findAllOriginVodafoneNoDuration().stream()
+            .map(RecordingDTO::new)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssets.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssets.java
@@ -89,8 +89,7 @@ public class BatchImportMissingMkAssets extends RobotUserTask {
         IMediaService mediaService = mediaServiceBroker.getEnabledMediaService();
 
         // Step 1: Find all VF recordings missing final asset
-        // List<RecordingDTO> recordings = recordingService.findAllVodafoneRecordings().stream()
-        List<RecordingDTO> recordings = recordingService.findAllVodafoneRecordingsNoDuration().stream()
+        List<RecordingDTO> recordings = recordingService.findAllVodafoneRecordings().stream()
             // Step 2: Copy blob from Vodafone to Ingest
             .filter(this::copyBlobBetweenContainers)
             // Step 3: Create Temp Asset

--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssets.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssets.java
@@ -89,7 +89,8 @@ public class BatchImportMissingMkAssets extends RobotUserTask {
         IMediaService mediaService = mediaServiceBroker.getEnabledMediaService();
 
         // Step 1: Find all VF recordings missing final asset
-        List<RecordingDTO> recordings = recordingService.findAllVodafoneRecordings().stream()
+        // List<RecordingDTO> recordings = recordingService.findAllVodafoneRecordings().stream()
+        List<RecordingDTO> recordings = recordingService.findAllVodafoneRecordingsNoDuration().stream()
             // Step 2: Copy blob from Vodafone to Ingest
             .filter(this::copyBlobBetweenContainers)
             // Step 3: Create Temp Asset

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceTest.java
@@ -701,4 +701,17 @@ class RecordingServiceTest {
         assertThrows(NotFoundException.class, () -> recordingService.forceUpsert(recordingModel));
         verify(recordingRepository, never()).save(any(Recording.class));
     }
+
+    @Test
+    @DisplayName("Find all Vodafone recordings with null duration")
+    void findAllVodafoneRecordingsSuccess() {
+        when(recordingRepository.findAllOriginVodafoneNoDuration())
+            .thenReturn(List.of(recordingEntity));
+
+        List<RecordingDTO> results = recordingService.findAllVodafoneRecordings();
+
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getId()).isEqualTo(recordingEntity.getId());
+        verify(recordingRepository, times(1)).findAllOriginVodafoneNoDuration();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssetsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssetsTest.java
@@ -113,10 +113,10 @@ public class BatchImportMissingMkAssetsTest {
 
     @Test
     void runVodafoneRecordingsEmpty() throws IOException {
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of());
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of());
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
         verify(mediaService, never()).getAsset(any());
         ArgumentCaptor<String> filenameCaptor =  ArgumentCaptor.forClass(String.class);
         verify(azureFinalStorageService, never()).uploadBlob(filenameCaptor.capture(), any(), any());
@@ -131,7 +131,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         doThrow(NotFoundException.class).when(azureVodafoneStorageService).getBlobUrlForCopy(any(), any());
         when(azureVodafoneStorageService.getStorageAccountName()).thenReturn("voda-sa");
@@ -139,7 +139,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
         verify(mediaService, times(0)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureVodafoneStorageService, never()).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -174,14 +174,14 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(false);
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
         verify(mediaService, times(1)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -216,7 +216,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -224,7 +224,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
         verify(mediaService, times(2)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -260,7 +260,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -273,7 +273,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
         verify(mediaService, times(2)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -315,7 +315,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -330,7 +330,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
         verify(mediaService, times(2)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -420,7 +420,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -448,7 +448,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -469,7 +469,7 @@ public class BatchImportMissingMkAssetsTest {
 
     @Test
     @DisplayName("Should return Vodafone recordings with null duration")
-    void findAllVodafoneRecordingsNoDuration_ShouldReturnVodafoneRecordingsWithNullDuration() {
+    void findAllVodafoneRecordings_ShouldReturnVodafoneRecordingsWithNullDuration() {
         RecordingDTO recording1 = new RecordingDTO();
         recording1.setId(UUID.randomUUID());
         recording1.setDuration(null);
@@ -488,13 +488,13 @@ public class BatchImportMissingMkAssetsTest {
         captureSession2.setOrigin(RecordingOrigin.VODAFONE);
         recording2.setCaptureSession(captureSession2);
         
-        when(recordingService.findAllVodafoneRecordingsNoDuration())
+        when(recordingService.findAllVodafoneRecordings())
             .thenReturn(List.of(recording1));
         
-        List<RecordingDTO> result = recordingService.findAllVodafoneRecordingsNoDuration();
+        List<RecordingDTO> result = recordingService.findAllVodafoneRecordings();
         
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(recording1.getId());
-        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+        verify(recordingService, times(1)).findAllVodafoneRecordings();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssetsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssetsTest.java
@@ -112,10 +112,10 @@ public class BatchImportMissingMkAssetsTest {
 
     @Test
     void runVodafoneRecordingsEmpty() throws IOException {
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of());
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of());
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordings();
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
         verify(mediaService, never()).getAsset(any());
         ArgumentCaptor<String> filenameCaptor =  ArgumentCaptor.forClass(String.class);
         verify(azureFinalStorageService, never()).uploadBlob(filenameCaptor.capture(), any(), any());
@@ -130,7 +130,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         doThrow(NotFoundException.class).when(azureVodafoneStorageService).getBlobUrlForCopy(any(), any());
         when(azureVodafoneStorageService.getStorageAccountName()).thenReturn("voda-sa");
@@ -138,7 +138,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordings();
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
         verify(mediaService, times(0)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureVodafoneStorageService, never()).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -173,14 +173,14 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(false);
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordings();
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
         verify(mediaService, times(1)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -215,7 +215,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -223,7 +223,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordings();
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
         verify(mediaService, times(2)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -259,7 +259,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
 
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -272,7 +272,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordings();
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
         verify(mediaService, times(2)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -314,7 +314,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -329,7 +329,7 @@ public class BatchImportMissingMkAssetsTest {
 
         batchImportMissingMkAssets.run();
 
-        verify(recordingService, times(1)).findAllVodafoneRecordings();
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
         verify(mediaService, times(2)).getAsset(any());
         verify(azureVodafoneStorageService, times(1)).getBlobUrlForCopy(any(), any());
         verify(azureIngestStorageService, times(1)).copyBlobOverwritable(any(), any(), any(), eq(false));
@@ -419,7 +419,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);
@@ -447,7 +447,7 @@ public class BatchImportMissingMkAssetsTest {
         captureSession.setId(UUID.randomUUID());
         recording.setCaptureSession(captureSession);
         recording.setVersion(1);
-        when(recordingService.findAllVodafoneRecordings()).thenReturn(List.of(recording));
+        when(recordingService.findAllVodafoneRecordingsNoDuration()).thenReturn(List.of(recording));
         when(mediaService.getAsset(any())).thenReturn(null);
         when(azureVodafoneStorageService.getBlobUrlForCopy(any(), any())).thenReturn("example-url.com");
         when(mediaService.importAsset(recording, false)).thenReturn(true);

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssetsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/migration/BatchImportMissingMkAssetsTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.preapi.dto.CreateCaptureSessionDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.base.BaseAppAccessDTO;
+import uk.gov.hmcts.reform.preapi.enums.RecordingOrigin;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.media.IMediaService;
@@ -466,4 +467,34 @@ public class BatchImportMissingMkAssetsTest {
         assertThat(output.getOut()).contains("Unknown job processing state: " + jobName);
     }
 
+    @Test
+    @DisplayName("Should return Vodafone recordings with null duration")
+    void findAllVodafoneRecordingsNoDuration_ShouldReturnVodafoneRecordingsWithNullDuration() {
+        RecordingDTO recording1 = new RecordingDTO();
+        recording1.setId(UUID.randomUUID());
+        recording1.setDuration(null);
+        recording1.setDeletedAt(null);
+        
+        CaptureSessionDTO captureSession1 = new CaptureSessionDTO();
+        captureSession1.setOrigin(RecordingOrigin.VODAFONE);
+        recording1.setCaptureSession(captureSession1);
+        
+        RecordingDTO recording2 = new RecordingDTO();
+        recording2.setId(UUID.randomUUID());
+        recording2.setDuration(Duration.ofMinutes(5)); 
+        recording2.setDeletedAt(null);
+        
+        CaptureSessionDTO captureSession2 = new CaptureSessionDTO();
+        captureSession2.setOrigin(RecordingOrigin.VODAFONE);
+        recording2.setCaptureSession(captureSession2);
+        
+        when(recordingService.findAllVodafoneRecordingsNoDuration())
+            .thenReturn(List.of(recording1));
+        
+        List<RecordingDTO> result = recordingService.findAllVodafoneRecordingsNoDuration();
+        
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(recording1.getId());
+        verify(recordingService, times(1)).findAllVodafoneRecordingsNoDuration();
+    }
 }


### PR DESCRIPTION
Previously, the method for fetching Vodafone recordings (findAllOriginVodafone) only selected recordings where the associated capture session had a status of NO_RECORDING.

This caused an issue where subsequent versions of recordings (eg. version 2s or COPYs) were not being picked up once an earlier version (version 1) succeeded - because the capture session status had already been updated to RECORDING_AVAILABLE.

Changes:
- Added a new repository query method findAllOriginVodafoneNoDuration() to fetch all Vodafone recordings where recording duration and deleted_at are null 
- updated service layer to use this new method 
- updated tests