### PR TITLE
Skip listpaths for getting live event manifest path

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/media/MediaKindTest.java
@@ -921,9 +921,6 @@ public class MediaKindTest {
         when(mockClient.getStreamingLocator(any()))
             .thenThrow(mock(NotFoundException.class));
 
-        when(mockClient.listStreamingLocatorPaths(liveEventName))
-            .thenReturn(getGoodStreamingLocatorPaths(liveEventName));
-
         var result = mediaKind.playLiveEvent(captureSession.getId());
 
         assertThat(result).isEqualTo(
@@ -956,9 +953,6 @@ public class MediaKindTest {
 
         when(mockClient.getStreamingLocator(any()))
             .thenReturn(MkStreamingLocator.builder().build());
-
-        when(mockClient.listStreamingLocatorPaths(liveEventName))
-            .thenReturn(getGoodStreamingLocatorPaths(liveEventName));
 
         var result = mediaKind.playLiveEvent(captureSession.getId());
 
@@ -994,9 +988,6 @@ public class MediaKindTest {
 
         when(mockClient.getStreamingLocator(any()))
             .thenThrow(mock(ConflictException.class));
-
-        when(mockClient.listStreamingLocatorPaths(liveEventName))
-            .thenReturn(getGoodStreamingLocatorPaths(liveEventName));
 
         assertThrows(
             ConflictException.class,


### PR DESCRIPTION
### JIRA ticket(s)

- S28-4434

### Change description

Skip using the [MK API /listpaths endpoint](https://docs.mk.io/reference/post_apiv1projectsproject_namemediastreaminglocatorslocator_namelistpaths) to get the streaming paths.

Instead generate the manifest path using the liveEventId as it is always in a predictable format. MK themselves have confirmed that this is an ok approach.

This is a workaround for an ongoing livestream issue until MK fix the issue: https://support.mk.io/portal/en/ticket/866814000041435007