### PR TITLE
S28-0000 Fix flaky test

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/preapi/controllers/UserControllerFT.java
@@ -151,7 +151,7 @@ public class UserControllerFT extends FunctionalTestBase {
         assertThat(userDto2.getPortalAccess()).isNotEmpty();
         PortalAccessDTO portalAccessDto2 = userDto2.getPortalAccess().getFirst();
         assertThat(portalAccessDto2.getId()).isEqualTo(portalAccessDto1.getId());
-        assertThat(portalAccessDto2.getRegisteredAt()).isNotNull();
+        assertThat(portalAccessDto2.getRegisteredAt()).isAfterOrEqualTo(portalAccessDto1.getRegisteredAt());
         assertThat(portalAccessDto2.getStatus()).isEqualTo(AccessStatus.ACTIVE);
     }
 


### PR DESCRIPTION
### Change description
Change the test assertion to use isAfterOrEqualTo rather than isEqualTo, since when run in the pipeline the second date can sometimes be slightly after the first date due to precision loss after serialisation/deserialisation.