### PR TITLE
S28 4625 - LazyInitializationException fix

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/tasks/CaptureSessionStatusCorrectionTaskIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/tasks/CaptureSessionStatusCorrectionTaskIT.java
@@ -197,7 +197,7 @@ public class CaptureSessionStatusCorrectionTaskIT extends IntegrationTestBase {
         entityManager.persist(captureSession2);
 
         //Add the robot user that signs in to the database
-        User robotUser = HelperFactory.createUser("robot", "user", "test@test.com", null, null, null);
+        User robotUser = HelperFactory.createUser("robot", "user", cronUserEmail, null, null, null);
         entityManager.persist(robotUser);
 
         Role role = HelperFactory.createRole("Super User");

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -427,6 +427,7 @@ class TestingSupportController {
         return ResponseEntity.ok(new BookingDTO(booking));
     }
 
+    //TODO: Needs some tweaking to fix as the source recording is not being set to the edit request and causes error
     @SneakyThrows
     @PostMapping(value = "/trigger-edit-request-processing/{editId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> triggerEditRequestProcessing(@PathVariable UUID editId) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -84,7 +84,7 @@ import static java.lang.Character.toLowerCase;
 @RestController
 @RequestMapping("/testing-support")
 @SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveImports",
-    "PMD.TestClassWithoutTestCases", "PMD.TooManyMethods"})
+    "PMD.TestClassWithoutTestCases"})
 @ConditionalOnExpression("${testing-support-endpoints.enabled:false}")
 class TestingSupportController {
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -451,6 +451,28 @@ class TestingSupportController {
         ));
     }
 
+    @SneakyThrows
+    @PostMapping(value = "/trigger-processing-next-pending-edit-request", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> triggerProcessingNextEditRequest() {
+        Role role = roleRepository.findFirstByName("Super User")
+            .orElse(createRole("Super User"));
+        AppAccess appAccess = createAppAccess(role);
+        SecurityContextHolder.getContext()
+            .setAuthentication(new UserAuthentication(
+                appAccess,
+                List.of(new SimpleGrantedAuthority("ROLE_SUPER_USER"))));
+
+        EditRequest editRequest = editRequestService.getNextPendingEditRequest()
+            .orElseThrow(() -> new NotFoundException("No pending edit requests"));
+
+        RecordingDTO recording = editRequestService.performEdit(editRequest);
+
+        return ResponseEntity.ok(Map.of(
+            "request", editRequest,
+            "recording", recording
+        ));
+    }
+
     @PostMapping(value = "/trigger-task/{taskName}")
     public ResponseEntity<Void> triggerTask(@PathVariable String taskName) {
         final String beanName = toLowerCase(taskName.charAt(0)) + taskName.substring(1);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -452,28 +452,6 @@ class TestingSupportController {
         ));
     }
 
-    @SneakyThrows
-    @PostMapping(value = "/trigger-processing-next-pending-edit-request", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> triggerProcessingNextEditRequest() {
-        Role role = roleRepository.findFirstByName("Super User")
-            .orElse(createRole("Super User"));
-        AppAccess appAccess = createAppAccess(role);
-        SecurityContextHolder.getContext()
-            .setAuthentication(new UserAuthentication(
-                appAccess,
-                List.of(new SimpleGrantedAuthority("ROLE_SUPER_USER"))));
-
-        EditRequest editRequest = editRequestService.getNextPendingEditRequest()
-            .orElseThrow(() -> new NotFoundException("No pending edit requests"));
-
-        RecordingDTO recording = editRequestService.performEdit(editRequest);
-
-        return ResponseEntity.ok(Map.of(
-            "request", editRequest,
-            "recording", recording
-        ));
-    }
-
     @PostMapping(value = "/trigger-task/{taskName}")
     public ResponseEntity<Void> triggerTask(@PathVariable String taskName) {
         final String beanName = toLowerCase(taskName.charAt(0)) + taskName.substring(1);

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -83,7 +83,8 @@ import static java.lang.Character.toLowerCase;
 
 @RestController
 @RequestMapping("/testing-support")
-@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveImports", "PMD.TestClassWithoutTestCases"})
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveImports",
+    "PMD.TestClassWithoutTestCases", "PMD.TooManyMethods"})
 @ConditionalOnExpression("${testing-support-endpoints.enabled:false}")
 class TestingSupportController {
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/BookingService.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.entities.Participant;
+import uk.gov.hmcts.reform.preapi.entities.ShareBooking;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.enums.RecordingStatus;
 import uk.gov.hmcts.reform.preapi.enums.UpsertResult;
@@ -266,5 +267,10 @@ public class BookingService {
             Pageable.unpaged()
         )
             .toList();
+    }
+
+    @Transactional
+    public List<ShareBooking> findAllSharesForBooking(Booking booking) {
+        return shareBookingService.findAllByBooking(booking);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
@@ -188,7 +188,6 @@ public class EditRequestService {
      */
     @Transactional
     public void sendNotifications(Booking booking) {
-        log.info("Sending notifications for booking {}", booking);
         List<ShareBooking> shareBookings = bookingService.findAllSharesForBooking(booking);
         shareBookings
             .stream()

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
@@ -188,6 +188,7 @@ public class EditRequestService {
      */
     @Transactional
     public void sendNotifications(Booking booking) {
+        log.info("Sending notifications for booking {}", booking);
         List<ShareBooking> shareBookings = bookingService.findAllSharesForBooking(booking);
         shareBookings
             .stream()

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
@@ -182,7 +182,7 @@ public class EditRequestService {
      * Note: This method fetches the shared bookings directly from the database (via BookingService) rather than call
      * booking.getShares(). This is to avoid LazyInitializationException that could occur if the Booking entity
      * passed does not have its shares loaded.
-     * </p
+     * </p>
      * @param booking the booking whose shared users will be notified
      */
     @Transactional

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/EditRequestService.java
@@ -178,6 +178,7 @@ public class EditRequestService {
 
     /**
      * Sends notification emails that the recording has been edited to all users that have access to the booking.
+     *
      * <p>
      * Note: This method fetches the shared bookings directly from the database (via BookingService) rather than call
      * booking.getShares(). This is to avoid LazyInitializationException that could occur if the Booking entity

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/ShareBookingService.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.preapi.repositories.UserRepository;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -176,5 +177,10 @@ public class ShareBookingService {
                               + " of shared booking: " + share.getBooking().getId());
             }
         }
+    }
+
+    @Transactional
+    public List<ShareBooking> findAllByBooking(Booking booking) {
+        return shareBookingRepository.findAllByBookingAndDeletedAtIsNull(booking);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/BookingServiceTest.java
@@ -716,6 +716,14 @@ class BookingServiceTest {
                 any());
     }
 
+    @Test
+    @DisplayName("Should find all shares for a booking")
+    void findAllSharesForBooking() {
+        Booking booking = createBooking(createCourt(), Timestamp.from(Instant.now()));
+        bookingService.findAllSharesForBooking(booking);
+        verify(shareBookingService, times(1)).findAllByBooking(booking);
+    }
+
     private Court createCourt() {
         var court = new Court();
         court.setId(UUID.randomUUID());

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/ShareBookingServiceTest.java
@@ -542,4 +542,15 @@ public class ShareBookingServiceTest {
 
         verify(govNotify, times(1)).recordingReady(any(), any());
     }
+
+    @DisplayName("Should get all shares for a booking by booking entity")
+    @Test
+    void getSharesForBookingByEntity() {
+        UUID bookingId = UUID.randomUUID();
+        Booking bookingEntity = new Booking();
+        bookingEntity.setId(bookingId);
+        shareBookingService.findAllByBooking(bookingEntity);
+        verify(shareBookingRepository, times(1))
+            .findAllByBookingAndDeletedAtIsNull(bookingEntity);
+    }
 }


### PR DESCRIPTION
### JIRA ticket(s)

- S28-4625 - https://tools.hmcts.net/jira/browse/S28-4625

### Change description

- The EditRequestService now brings in the BookingService to get the share bookings directly from the database so that they are definitely available for sending the notification emails. This replaces trying to get the share bookings using the booking entity
- Adds a TODO for the /trigger-edit-request-processing/{editId} endpoint as it is missing some logic
- Adds another testing endpoint that processes the next pending edit request /trigger-processing-next-pending-edit-request
- Note: No integration tests as ShareBookingService is being [mocked](https://github.com/hmcts/pre-api/blob/1f6faaa5cf2c8ffa5cc8b05362178da44a8f6120/src/integrationTest/java/uk/gov/hmcts/reform/preapi/utils/IntegrationTestBase.java#L27) at the integration base class level

**QA instructions**

It is the PerformEditRequest task which is affected by the LazyInitializationException which I am not sure we can test on a PR. We could test the logic that the task does by hitting the new /trigger-processing-next-pending-edit-request endpoint however this would not validate that the LazyInitializationException due to web requests currently being protected from this exception.
