### PR TITLE
Add build parameter for prod deployment

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -56,9 +56,9 @@ withPipeline(type, product, component) {
 
   afterSuccess('build') {
     if (!params.DEPLOY_TO_PROD) {
+      echo("Deployment to production not approved")
       // I altered this to be SUCCESS so we don't get false red dots
       currentBuild.result = 'SUCCESS'
-      echo("Deployment to production not approved")
     }
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -46,19 +46,10 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
   }
 
-//  afterSuccess('Publish Helm chart') {
-//    if (!params.DEPLOY_TO_PROD) {
-//      // I altered this to be SUCCESS so we don't get false red dots
-//      currentBuild.result = 'SUCCESS'
-//      error("Deployment to production not approved")
-//    }
-//  }
-
-  afterSuccess('build') {
+  afterSuccess('build') { // Set to 'build' for testing only, change to 'Publish Helm chart' before merging
     if (!params.DEPLOY_TO_PROD) {
-      echo("Deployment to production not approved")
-      // I altered this to be SUCCESS so we don't get false red dots
-      currentBuild.result = 'SUCCESS'
+      echo "DEPLOY_TO_PROD not set - skipping production deployment"
+      error("AUTO_ABORT: Production deployment skipped")
     }
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -58,7 +58,7 @@ withPipeline(type, product, component) {
     if (!params.DEPLOY_TO_PROD) {
       // I altered this to be SUCCESS so we don't get false red dots
       currentBuild.result = 'SUCCESS'
-      error("Deployment to production not approved")
+      echo("Deployment to production not approved")
     }
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -46,7 +46,15 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
   }
 
-  afterSuccess('Publish Helm chart') {
+//  afterSuccess('Publish Helm chart') {
+//    if (!params.DEPLOY_TO_PROD) {
+//      // I altered this to be SUCCESS so we don't get false red dots
+//      currentBuild.result = 'SUCCESS'
+//      error("Deployment to production not approved")
+//    }
+//  }
+
+  afterSuccess('build') {
     if (!params.DEPLOY_TO_PROD) {
       // I altered this to be SUCCESS so we don't get false red dots
       currentBuild.result = 'SUCCESS'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,8 +1,14 @@
 #!groovy
-@Library("Infrastructure")
+@Library("Infrastructure@test-pre-prod-approval")
 def type = "java"
 def product = "pre"
 def component = "api"
+
+properties([
+  parameters([
+    booleanParam(name: 'DEPLOY_TO_PROD', defaultValue: false, description: 'Deploy to production?')
+  ])
+])
 
 def secrets = [
   'pre-hmctskv-${env}': [
@@ -39,9 +45,17 @@ withPipeline(type, product, component) {
   afterSuccess('functionalTest:stg') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
   }
+
+  afterSuccess('Publish Helm chart') {
+    if (!params.DEPLOY_TO_PROD) {
+      // I altered this to be SUCCESS so we don't get false red dots
+      currentBuild.result = 'SUCCESS'
+      error("Deployment to production not approved")
+    }
+  }
 }
 
-static String swaggerValidate(String branchName){
+static String swaggerValidate(String branchName) {
   def repoName = "pre-api"
   def swaggerPath = "specs/pre-api.json"
   def script = 'url="https://raw.githubusercontent.com/hmcts/' + repoName + '/' + branchName + '/' + swaggerPath + '";' +

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -46,7 +46,7 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
   }
 
-  afterSuccess('build') { // Set to 'build' for testing only, change to 'Publish Helm chart' before merging
+  afterSuccess('Publish Helm chart') {
     if (!params.DEPLOY_TO_PROD) {
       echo "DEPLOY_TO_PROD not set - skipping production deployment"
       error("AUTO_ABORT: Production deployment skipped")


### PR DESCRIPTION
### JIRA ticket(s)
https://tools.hmcts.net/jira/browse/S28-4915

### Change description
Adds a build parameter "DEPLOY_TO_PROD" which can be used to toggle deployment to prod for a master build within Jenkins.

Defaults to false, so by default, deployments will stop after deploying to staging.

The build will be given the "aborted" status when it stops in this way.

`afterSuccess('Publish Helm chart')` can be changed to `afterSuccess('build'`) temporarily in order to test the stopping of the pipeline on the PR branch.

### Build parameter
<img width="271" height="212" alt="image" src="https://github.com/user-attachments/assets/b0a17015-84b5-4bf4-8a73-f9eae3dd4a32" />

### Aborted build
<img width="645" height="92" alt="image" src="https://github.com/user-attachments/assets/59ff267a-8f4e-4d00-9cf7-ef6d6159750e" />
