### PR TITLE
S28-4704 Support classpath CSV for re-encode task

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,10 +554,13 @@ source_recording_id,case_reference
 22222222-2222-2222-2222-222222222222,CASE-456
 ```
 
+For deployments that build the CSV into the application, replace `src/main/resources/re-encode-recordings.csv` before
+building the image and set `REENCODE_RECORDINGS_CSV_PATH=classpath:re-encode-recordings.csv`.
+
 Run it by source:
 
 ```bash
-REENCODE_RECORDINGS_CSV_PATH=/path/to/re-encode-recordings.csv \
+REENCODE_RECORDINGS_CSV_PATH=classpath:re-encode-recordings.csv \
 TASK_NAME=ReEncodeRecordingsFromCsv \
 ./gradlew bootRun
 ```
@@ -566,10 +569,13 @@ Or by JAR:
 
 ```bash
 ./gradlew bootJar
-REENCODE_RECORDINGS_CSV_PATH=/path/to/re-encode-recordings.csv \
+REENCODE_RECORDINGS_CSV_PATH=classpath:re-encode-recordings.csv \
 TASK_NAME=ReEncodeRecordingsFromCsv \
 java -jar build/libs/pre-api.jar run
 ```
+
+Filesystem paths are also supported for local runs, for example
+`REENCODE_RECORDINGS_CSV_PATH=/path/to/re-encode-recordings.csv`.
 
 ## Troubleshooting
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/ReEncodeRecordingsFromCsv.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/ReEncodeRecordingsFromCsv.java
@@ -6,6 +6,8 @@ import com.opencsv.bean.CsvToBeanBuilder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.preapi.dto.CreateEditRequestDTO;
 import uk.gov.hmcts.reform.preapi.enums.EditRequestStatus;
@@ -15,6 +17,7 @@ import uk.gov.hmcts.reform.preapi.services.UserService;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +37,7 @@ public class ReEncodeRecordingsFromCsv extends RobotUserTask {
     private static final String STATUS_ERROR = "ERROR";
 
     private final EditRequestService editRequestService;
+    private final ResourceLoader resourceLoader;
     private final String csvPath;
     private final boolean forceReencode;
 
@@ -67,11 +71,13 @@ public class ReEncodeRecordingsFromCsv extends RobotUserTask {
     public ReEncodeRecordingsFromCsv(EditRequestService editRequestService,
                                      UserService userService,
                                      UserAuthenticationService userAuthenticationService,
+                                     ResourceLoader resourceLoader,
                                      @Value("${cron-user-email}") String cronUserEmail,
                                      @Value("${REENCODE_RECORDINGS_CSV_PATH:}") String csvPath,
                                      @Value("${REENCODE_RECORDINGS_FORCE:false}") boolean forceReencode) {
         super(userService, userAuthenticationService, cronUserEmail);
         this.editRequestService = editRequestService;
+        this.resourceLoader = resourceLoader;
         this.csvPath = csvPath;
         this.forceReencode = forceReencode;
     }
@@ -95,13 +101,7 @@ public class ReEncodeRecordingsFromCsv extends RobotUserTask {
             throw new IOException("REENCODE_RECORDINGS_CSV_PATH must be set");
         }
 
-        Path path = Path.of(csvPath);
-        if (!Files.exists(path)) {
-            throw new IOException("CSV file not found: " + csvPath);
-        }
-
-        log.info("Reading re-encode CSV file from {}", path.toAbsolutePath());
-        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+        try (BufferedReader reader = openCsvReader()) {
             CsvToBean<ReEncodeRow> csvToBean = new CsvToBeanBuilder<ReEncodeRow>(reader)
                 .withType(ReEncodeRow.class)
                 .withIgnoreLeadingWhiteSpace(true)
@@ -115,6 +115,26 @@ public class ReEncodeRecordingsFromCsv extends RobotUserTask {
             ));
             return rows;
         }
+    }
+
+    private BufferedReader openCsvReader() throws IOException {
+        if (csvPath.startsWith(ResourceLoader.CLASSPATH_URL_PREFIX)) {
+            Resource resource = resourceLoader.getResource(csvPath);
+            if (!resource.exists()) {
+                throw new IOException("CSV file not found: " + csvPath);
+            }
+
+            log.info("Reading re-encode CSV file from {}", csvPath);
+            return new BufferedReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8));
+        }
+
+        Path path = Path.of(csvPath);
+        if (!Files.exists(path)) {
+            throw new IOException("CSV file not found: " + csvPath);
+        }
+
+        log.info("Reading re-encode CSV file from {}", path.toAbsolutePath());
+        return Files.newBufferedReader(path, StandardCharsets.UTF_8);
     }
 
     private void processRows(List<ReEncodeRow> rows) {

--- a/src/main/resources/re-encode-recordings.csv
+++ b/src/main/resources/re-encode-recordings.csv
@@ -1,0 +1,1 @@
+source_recording_id,case_reference

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/ReEncodeRecordingsFromCsvTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/ReEncodeRecordingsFromCsvTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.springframework.core.io.DefaultResourceLoader;
 import uk.gov.hmcts.reform.preapi.dto.AccessDTO;
 import uk.gov.hmcts.reform.preapi.dto.CreateEditRequestDTO;
 import uk.gov.hmcts.reform.preapi.dto.base.BaseAppAccessDTO;
@@ -125,6 +126,17 @@ class ReEncodeRecordingsFromCsvTest {
     }
 
     @Test
+    @DisplayName("Reads re-encode CSV from classpath resource")
+    void readsCsvFromClasspathResource() {
+        task("classpath:re-encode-recordings.csv", false).run();
+
+        var dtoCaptor = ArgumentCaptor.forClass(CreateEditRequestDTO.class);
+        verify(editRequestService).upsert(dtoCaptor.capture());
+        assertThat(dtoCaptor.getValue().getSourceRecordingId())
+            .isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+    }
+
+    @Test
     @DisplayName("Skips invalid recording ids without submitting an edit request")
     void skipsInvalidRecordingIds() throws IOException {
         Path csv = writeCsv("""
@@ -192,6 +204,7 @@ class ReEncodeRecordingsFromCsvTest {
             editRequestService,
             userService,
             userAuthenticationService,
+            new DefaultResourceLoader(),
             CRON_USER_EMAIL,
             csvPath,
             forceReencode

--- a/src/test/resources/re-encode-recordings.csv
+++ b/src/test/resources/re-encode-recordings.csv
@@ -1,0 +1,2 @@
+source_recording_id,case_reference
+00000000-0000-0000-0000-000000000001,CASE-RESOURCE


### PR DESCRIPTION
### Change description

- Add classpath resource loading for the re-encode recordings CSV task
- Add a default `src/main/resources/re-encode-recordings.csv` location and document using `classpath:re-encode-recordings.csv`
