### PR TITLE
S28-4945 Fix edit request failure handling

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
@@ -48,11 +48,12 @@ public class EditRequestPerformService {
     public RecordingDTO performEdit(EditRequest request) throws InterruptedException {
         UUID newRecordingId = UUID.randomUUID();
         try {
-            ensureSourceRecordingCaseIsOpen(request);
+            EditInstructions editInstructions = fromJson(request.getEditInstruction());
+            ensureSourceRecordingCaseIsOpen(request, editInstructions);
             editingService.performEdit(newRecordingId, request);
             String filename = assetGenerationService.generateAsset(newRecordingId, request);
-            CreateRecordingDTO createDto = createRecordingDto(newRecordingId, filename, request);
-            recordingService.upsert(createDto);
+            CreateRecordingDTO createDto = createRecordingDto(newRecordingId, filename, request, editInstructions);
+            upsertRecording(createDto, editInstructions);
         } catch (Exception e) {
             markRequestAsError(request.getId(), e);
             throw e;
@@ -62,7 +63,11 @@ public class EditRequestPerformService {
         return recordingService.findById(newRecordingId);
     }
 
-    private void ensureSourceRecordingCaseIsOpen(EditRequest request) {
+    private void ensureSourceRecordingCaseIsOpen(EditRequest request, EditInstructions editInstructions) {
+        if (editInstructions.isForceReencode()) {
+            return;
+        }
+
         EditRequestValidator.ensureEditRequestHasSourceRecording(request);
         CaseState caseState = request.getSourceRecording()
             .getCaptureSession()
@@ -89,14 +94,17 @@ public class EditRequestPerformService {
         return editRequestCrudService.updateEditRequestStatus(request.getId(), EditRequestStatus.PROCESSING);
     }
 
-    private @NotNull CreateRecordingDTO createRecordingDto(UUID newRecordingId, String filename, EditRequest request) {
+    private @NotNull CreateRecordingDTO createRecordingDto(UUID newRecordingId,
+                                                           String filename,
+                                                           EditRequest request,
+                                                           EditInstructions editInstructions) {
         UUID parentId = request.getSourceRecording().getParentRecording() == null
             ? request.getSourceRecording().getId()
             : request.getSourceRecording().getParentRecording().getId();
 
         // if edit on edit without original edits saved (legacy edit),
         //  then these edits will not align with the original timeline
-        EditInstructionDump dump = new EditInstructionDump(request.getId(), fromJson(request.getEditInstruction()));
+        EditInstructionDump dump = new EditInstructionDump(request.getId(), editInstructions);
 
         return new CreateRecordingDTO(
             newRecordingId,
@@ -108,6 +116,15 @@ public class EditRequestPerformService {
             null,
             toJson(dump)
         );
+    }
+
+    private void upsertRecording(CreateRecordingDTO createDto, EditInstructions editInstructions) {
+        if (editInstructions.isForceReencode()) {
+            recordingService.forceUpsert(createDto);
+            return;
+        }
+
+        recordingService.upsert(createDto);
     }
 
     private void markRequestAsError(UUID requestId, Exception originalException) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.EditRequestDTO;
@@ -44,23 +43,19 @@ public class EditRequestPerformService {
         return editRequestCrudService.getNextPendingEditRequest(reencodeOnly);
     }
 
-    @Transactional(noRollbackFor = {Exception.class, RuntimeException.class}, propagation = Propagation.REQUIRES_NEW)
     public RecordingDTO performEdit(EditRequest request) throws InterruptedException {
         UUID newRecordingId = UUID.randomUUID();
-        String filename;
         try {
             editingService.performEdit(newRecordingId, request);
-            filename = assetGenerationService.generateAsset(newRecordingId, request);
+            String filename = assetGenerationService.generateAsset(newRecordingId, request);
+            CreateRecordingDTO createDto = createRecordingDto(newRecordingId, filename, request);
+            recordingService.upsert(createDto);
         } catch (Exception e) {
-            editRequestCrudService.updateEditRequestStatus(request.getId(), EditRequestStatus.ERROR);
+            markRequestAsError(request.getId(), e);
             throw e;
         }
 
         editRequestCrudService.updateEditRequestStatus(request.getId(), EditRequestStatus.COMPLETE);
-
-        CreateRecordingDTO createDto = createRecordingDto(newRecordingId, filename, request);
-        recordingService.upsert(createDto);
-
         return recordingService.findById(newRecordingId);
     }
 
@@ -92,6 +87,15 @@ public class EditRequestPerformService {
             null,
             toJson(dump)
         );
+    }
+
+    private void markRequestAsError(UUID requestId, Exception originalException) {
+        try {
+            editRequestCrudService.updateEditRequestStatus(requestId, EditRequestStatus.ERROR);
+        } catch (Exception statusUpdateException) {
+            log.error("Failed to mark EditRequest {} as ERROR after perform failure", requestId, statusUpdateException);
+            originalException.addSuppressed(statusUpdateException);
+        }
     }
 
     private record EditInstructionDump(UUID editRequestId, EditInstructions editInstructions) {

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
@@ -10,7 +10,9 @@ import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.EditRequestDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.entities.EditRequest;
+import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.enums.EditRequestStatus;
+import uk.gov.hmcts.reform.preapi.exception.ResourceInWrongStateException;
 import uk.gov.hmcts.reform.preapi.media.edit.EditInstructions;
 import uk.gov.hmcts.reform.preapi.services.RecordingService;
 
@@ -46,6 +48,7 @@ public class EditRequestPerformService {
     public RecordingDTO performEdit(EditRequest request) throws InterruptedException {
         UUID newRecordingId = UUID.randomUUID();
         try {
+            ensureSourceRecordingCaseIsOpen(request);
             editingService.performEdit(newRecordingId, request);
             String filename = assetGenerationService.generateAsset(newRecordingId, request);
             CreateRecordingDTO createDto = createRecordingDto(newRecordingId, filename, request);
@@ -57,6 +60,24 @@ public class EditRequestPerformService {
 
         editRequestCrudService.updateEditRequestStatus(request.getId(), EditRequestStatus.COMPLETE);
         return recordingService.findById(newRecordingId);
+    }
+
+    private void ensureSourceRecordingCaseIsOpen(EditRequest request) {
+        EditRequestValidator.ensureEditRequestHasSourceRecording(request);
+        CaseState caseState = request.getSourceRecording()
+            .getCaptureSession()
+            .getBooking()
+            .getCaseId()
+            .getState();
+
+        if (caseState != CaseState.OPEN) {
+            throw new ResourceInWrongStateException(
+                "Recording",
+                request.getSourceRecording().getId(),
+                caseState,
+                "OPEN"
+            );
+        }
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/reform/preapi/tasks/PerformEditRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/tasks/PerformEditRequest.java
@@ -43,12 +43,20 @@ public class PerformEditRequest extends RobotUserTask {
 
     private void attemptPerformEditRequest(EditRequest editRequest) {
         log.info("Attempting to perform EditRequest {}", editRequest.getId());
+        EditRequest lockedRequest;
         try {
-            EditRequest lockedRequest = editRequestService.markAsProcessing(editRequest.getId());
-            editRequestService.performEdit(lockedRequest);
+            lockedRequest = editRequestService.markAsProcessing(editRequest.getId());
         } catch (PessimisticLockingFailureException | ResourceInWrongStateException e) {
             // edit request is locked or has already been updated to a different state so it is skipped
             log.info("Skipping EditRequest {}, already reserved by another process", editRequest.getId());
+            return;
+        } catch (Exception e) {
+            log.error("Error while reserving EditRequest {}", editRequest.getId(), e);
+            return;
+        }
+
+        try {
+            editRequestService.performEdit(lockedRequest);
         } catch (InterruptedException e) {
             log.error("Error while performing EditRequest {}", editRequest.getId(), e);
             Thread.currentThread().interrupt();

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
@@ -176,7 +176,29 @@ class EditRequestPerformServiceTest {
         verify(editingService, never()).performEdit(any(UUID.class), any(EditRequest.class));
         verify(assetGenerationService, never()).generateAsset(any(UUID.class), any(EditRequest.class));
         verify(recordingService, never()).upsert(any(CreateRecordingDTO.class));
+        verify(recordingService, never()).forceUpsert(any(CreateRecordingDTO.class));
         verify(recordingService, never()).findById(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("Should perform re-encode request when source recording case is not open")
+    void performReencodeCaseNotOpenSuccess() throws InterruptedException {
+        when(mockCase.getState()).thenReturn(CaseState.CLOSED);
+        when(mockEditRequest.getEditInstruction()).thenReturn("{\"forceReencode\":true}");
+
+        RecordingDTO newRecordingDto = new RecordingDTO();
+        newRecordingDto.setParentRecordingId(mockRecording.getId());
+        when(recordingService.findById(any(UUID.class))).thenReturn(newRecordingDto);
+
+        RecordingDTO res = underTest.performEdit(mockEditRequest);
+
+        assertThat(res).isNotNull();
+        verify(editingService, times(1)).performEdit(any(UUID.class), eq(mockEditRequest));
+        verify(assetGenerationService, times(1)).generateAsset(any(UUID.class), eq(mockEditRequest));
+        verify(recordingService, times(1)).forceUpsert(any(CreateRecordingDTO.class));
+        verify(recordingService, never()).upsert(any(CreateRecordingDTO.class));
+        verify(editRequestCrudService, times(1))
+            .updateEditRequestStatus(mockEditRequestId, EditRequestStatus.COMPLETE);
     }
 
     // This should probably be an integration test
@@ -226,6 +248,7 @@ class EditRequestPerformServiceTest {
                                 expectedInstructions, JSONCompareMode.LENIENT);
 
         verify(recordingService, times(1)).findById(any(UUID.class));
+        verify(recordingService, never()).forceUpsert(any(CreateRecordingDTO.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.EditRequest;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
+import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.enums.EditRequestStatus;
 import uk.gov.hmcts.reform.preapi.exception.NotFoundException;
 import uk.gov.hmcts.reform.preapi.exception.ResourceInWrongStateException;
@@ -128,6 +129,25 @@ class EditRequestPerformServiceTest {
         assertThat(performedEditRequest.getId()).isEqualTo(mockEditRequestId);
 
         verify(recordingService, never()).upsert(any());
+    }
+
+    @Test
+    @DisplayName("Should mark edit request as error when recording creation fails")
+    void performEditRecordingCreationError() {
+        doThrow(new ResourceInWrongStateException("Recording", UUID.randomUUID(), CaseState.CLOSED, "OPEN"))
+            .when(recordingService).upsert(any(CreateRecordingDTO.class));
+
+        assertThrows(
+            ResourceInWrongStateException.class,
+            () -> underTest.performEdit(mockEditRequest)
+        );
+
+        verify(editRequestCrudService, times(1))
+            .updateEditRequestStatus(mockEditRequestId, EditRequestStatus.ERROR);
+        verify(editRequestCrudService, never())
+            .updateEditRequestStatus(mockEditRequestId, EditRequestStatus.COMPLETE);
+        verify(recordingService, times(1)).upsert(any(CreateRecordingDTO.class));
+        verify(recordingService, never()).findById(any(UUID.class));
     }
 
     // This should probably be an integration test

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
@@ -13,7 +13,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.EditRequestDTO;
 import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
+import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
+import uk.gov.hmcts.reform.preapi.entities.Case;
 import uk.gov.hmcts.reform.preapi.entities.EditRequest;
 import uk.gov.hmcts.reform.preapi.entities.Recording;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
@@ -67,6 +69,12 @@ class EditRequestPerformServiceTest {
     @MockitoBean
     private CaptureSession mockCaptureSession;
 
+    @MockitoBean
+    private Booking mockBooking;
+
+    @MockitoBean
+    private Case mockCase;
+
     @Autowired
     private EditRequestPerformService underTest;
 
@@ -92,6 +100,9 @@ class EditRequestPerformServiceTest {
         when(mockRecording.getCaptureSession()).thenReturn(mockCaptureSession);
 
         when(mockCaptureSession.getId()).thenReturn(mockCaptureSessionId);
+        when(mockCaptureSession.getBooking()).thenReturn(mockBooking);
+        when(mockBooking.getCaseId()).thenReturn(mockCase);
+        when(mockCase.getState()).thenReturn(CaseState.OPEN);
 
         Integer nextParentVersionNumber = 35;
         when(recordingService.getNextVersionNumber(mockParentRecordingId)).thenReturn(nextParentVersionNumber);
@@ -147,6 +158,24 @@ class EditRequestPerformServiceTest {
         verify(editRequestCrudService, never())
             .updateEditRequestStatus(mockEditRequestId, EditRequestStatus.COMPLETE);
         verify(recordingService, times(1)).upsert(any(CreateRecordingDTO.class));
+        verify(recordingService, never()).findById(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("Should mark edit request as error without running edit when source recording case is not open")
+    void performEditCaseNotOpenError() throws InterruptedException {
+        when(mockCase.getState()).thenReturn(CaseState.CLOSED);
+
+        assertThrows(
+            ResourceInWrongStateException.class,
+            () -> underTest.performEdit(mockEditRequest)
+        );
+
+        verify(editRequestCrudService, times(1))
+            .updateEditRequestStatus(mockEditRequestId, EditRequestStatus.ERROR);
+        verify(editingService, never()).performEdit(any(UUID.class), any(EditRequest.class));
+        verify(assetGenerationService, never()).generateAsset(any(UUID.class), any(EditRequest.class));
+        verify(recordingService, never()).upsert(any(CreateRecordingDTO.class));
         verify(recordingService, never()).findById(any(UUID.class));
     }
 


### PR DESCRIPTION
## Summary
- allow force re-encode edit requests to run for non-open cases
- keep normal edit requests on the existing OPEN case-state validation path
- use forceUpsert only for force re-encode recording creation so normal recording upsert behaviour is preserved
- mark edit requests as ERROR when edit performance fails before recording creation completes
- avoid wrapping the long-running edit workflow in a single transaction so failure status updates can commit
- keep reservation-state errors separate from execution errors in the edit request task

## Testing
- ./gradlew test --tests uk.gov.hmcts.reform.preapi.services.edit.EditRequestPerformServiceTest --tests uk.gov.hmcts.reform.preapi.tasks.PerformEditRequestTest
- ./gradlew test
- ./gradlew checkstyleMain checkstyleTest
- ./gradlew pmdMain

## Notes
- ./gradlew check reached integration tests but failed because the Azurite Testcontainers image pull from ACR returned 401 Unauthorized.
- ./gradlew pmdMain pmdTest previously ran pmdMain successfully, then pmdTest failed on the existing test PMD baseline with 3001 violations.