### PR TITLE
Tweak alert ignore reencode job

### DIFF
--- a/infrastructure/exception-alert.tf
+++ b/infrastructure/exception-alert.tf
@@ -12,6 +12,7 @@ module "pre-api-exception-alert" {
 union exceptions, traces
 | where severityLevel >= 3
 | where cloud_RoleInstance startswith "pre-api-java" or cloud_RoleInstance startswith "pre-api-cron"
+| where cloud_RoleInstance !startswith "pre-api-cron-re-encode-recordings-job"
 EOF
 
   frequency_in_minutes       = "15"

--- a/infrastructure/exception-alert.tf
+++ b/infrastructure/exception-alert.tf
@@ -12,7 +12,7 @@ module "pre-api-exception-alert" {
 union exceptions, traces
 | where severityLevel >= 3
 | where cloud_RoleInstance startswith "pre-api-java" or cloud_RoleInstance startswith "pre-api-cron"
-| where cloud_RoleInstance !startswith "pre-api-cron-re-encode-recordings-job"
+| where not(cloud_RoleInstance startswith "pre-api-cron-re-encode-recordings-job" and type has "uk.gov.hmcts.reform.preapi.exception.NotFoundException")
 EOF
 
   frequency_in_minutes       = "15"


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-0000
-->

### Change description

The slack channel for alerts is getting flooded by re-encode job failures due to recording not found

Tweak the automatic alerts to ignore re-encode jobs that fail because a resource (probably recording) wasn't found. 

Note: the errors will still be logged in app insights. This just stops it sending an auto-alert to the slack channel, so that it's easier to spot and respond to the live prod alerts. 

Slack channel: https://moj.enterprise.slack.com/archives/C02F3N771U7 (#dts-pre-rec-evidence-tech)

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
