### PR TITLE
Add a warning comment to PRs that update the API

### DIFF
--- a/.github/workflows/update-openapi-specs.yaml
+++ b/.github/workflows/update-openapi-specs.yaml
@@ -30,6 +30,7 @@ jobs:
         env:
           API_NAME: 'pre-api'
           RUN_DB_MIGRATION_ON_STARTUP: false
+          GH_TOKEN: ${{ github.token }}
         run: |
           ./gradlew buildOpenApiSpecs --tests 'uk.gov.hmcts.reform.preapi.openapi.OpenAPIPublisher'
           echo "Generated OpenAPI doc for ${API_NAME}"

--- a/scripts/increment-apim-revision-and-commit.sh
+++ b/scripts/increment-apim-revision-and-commit.sh
@@ -38,6 +38,23 @@ convert_open_api_to_swagger() {
   rm -rf swagger_docs
 };
 
+add_warning_comment(){
+  echo "Adding warning comment that API spec has been updated"
+
+  branch_name=$(git branch --show-current)
+
+  commentBody="""
+:bangbang: Change to API Spec detected
+
+Monitor carefully when deploying to production.
+
+Follow the release process and manually check that the Streaming Manager and portal are healthy after the release.
+
+See https://tools.hmcts.net/confluence/spaces/S28/pages/1958069495/API+release+process for details."""
+
+  gh pr comment "$branch_name" --edit-last --create-if-none -b "$commentBody"
+}
+
 bump_revision_number_and_commit_changes_to_github(){
   CHANGED=$(git diff --name-only "specs/pre-api.json" pre-api-stg.yaml infrastructure/main.tf)
 
@@ -48,6 +65,7 @@ bump_revision_number_and_commit_changes_to_github(){
     echo "About to commit: ${commit_message}"
     git -c user.name='PRE DevOps' -c user.email='138598290+pre-devops@users.noreply.github.com' commit -m "$commit_message"
     git push
+    add_warning_comment
   fi
 }
 


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

### JIRA ticket(s)

- S28-4989


### Change description

- Adds a warning comment to PRs that update the API spec
- To avoid more P1 incidents where the Streaming Manager can't reach the API after a fresh deployment

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
