### PR TITLE
chore: test workaround for power app failure after api update

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -13,7 +13,14 @@ properties([
 def secrets = [
   'pre-hmctskv-${env}': [
     secret('govnotify-key-test', 'GOV_NOTIFY_API_KEY_TEST'),
-    secret('api-MKIO-TOKEN', 'MEDIA_KIND_TOKEN')
+    secret('api-MKIO-TOKEN', 'MEDIA_KIND_TOKEN'),
+    secret('pre-power-app-base-url', 'PRE_POWER_APP_URL'),
+    secret('pre-api-url', 'PRE_POWER_APP_API_URL'),
+    secret('pre-portal-base-url', 'PRE_PORTAL_URL'),
+    secret('pre-level-1-test-login-email', 'PRE_LEVEL_1_USER_EMAIL'),
+    secret('pre-level-1-test-login-password', 'PRE_LEVEL_1_USER_PASSWORD'),
+    secret('pre-level-3-test-login-email', 'PRE_LEVEL_3_USER_EMAIL'),
+    secret('pre-level-3-test-login-password', 'PRE_LEVEL_3_USER_PASSWORD')
   ]
 ]
 
@@ -46,6 +53,10 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
   }
 
+  afterSuccess('buildinfra:demo') {
+    runPowerAppE2eTests('demo')
+  }
+
   afterSuccess('Publish Helm chart') {
     if (!params.DEPLOY_TO_PROD) {
       echo "DEPLOY_TO_PROD not set - skipping production deployment"
@@ -65,4 +76,92 @@ static String swaggerValidate(String branchName) {
     'fi;'
 
   return script
+}
+
+void runPowerAppE2eTests(String environment) {
+  echo "Running Power App e2e tests against ${environment}"
+
+  dir('pre-e2e-tests') {
+    checkout([
+      $class: 'GitSCM',
+      branches: [[name: 'refs/heads/master']],
+      userRemoteConfigs: [[url: 'https://github.com/hmcts/pre-e2e-tests.git',
+                           credentialsId: 'hmcts-jenkins-cnp']]
+    ])
+
+    withEnv([
+      "CI=true",
+      "FUNCTIONAL_TESTS_WORKERS=1"
+    ]) {
+      try {
+        sh """
+          docker build -t pre-e2e-tests-${environment} . && \\
+          docker run --rm \\
+            --ipc=host \\
+            -e CI=true \\
+            -e FUNCTIONAL_TESTS_WORKERS=1 \\
+            -e PRE_LEVEL_1_USER_EMAIL='${env.PRE_LEVEL_1_USER_EMAIL}' \\
+            -e PRE_LEVEL_1_USER_PASSWORD='${env.PRE_LEVEL_1_USER_PASSWORD}' \\
+            -e PRE_LEVEL_3_USER_EMAIL='${env.PRE_LEVEL_3_USER_EMAIL}' \\
+            -e PRE_LEVEL_3_USER_PASSWORD='${env.PRE_LEVEL_3_USER_PASSWORD}' \\
+            -e PRE_POWER_APP_URL='${env.PRE_POWER_APP_URL}' \\
+            -e PRE_POWER_APP_API_URL='${env.PRE_POWER_APP_API_URL}' \\
+            -e PRE_PORTAL_URL='${env.PRE_PORTAL_URL}' \\
+            -v \"\$(pwd)/playwright-report:/playwright/playwright-report\" \\
+            pre-e2e-tests-${environment} \\
+            "yarn playwright test playwright-e2e/tests/pre-power-app/e2e --project=Pre-Power-App-Edge --workers=1"
+        """
+      } catch (err) {
+        echo "Power App e2e tests failed for ${environment}: ${err.message}"
+        echo "Attempting APIM gateway recovery before re-running tests..."
+        forceApimGatewayRebuild(environment)
+        sleep(15)
+
+        sh """
+          docker run --rm \\
+            --ipc=host \\
+            -e CI=true \\
+            -e FUNCTIONAL_TESTS_WORKERS=1 \\
+            -e PRE_LEVEL_1_USER_EMAIL='${env.PRE_LEVEL_1_USER_EMAIL}' \\
+            -e PRE_LEVEL_1_USER_PASSWORD='${env.PRE_LEVEL_1_USER_PASSWORD}' \\
+            -e PRE_LEVEL_3_USER_EMAIL='${env.PRE_LEVEL_3_USER_EMAIL}' \\
+            -e PRE_LEVEL_3_USER_PASSWORD='${env.PRE_LEVEL_3_USER_PASSWORD}' \\
+            -e PRE_POWER_APP_URL='${env.PRE_POWER_APP_URL}' \\
+            -e PRE_POWER_APP_API_URL='${env.PRE_POWER_APP_API_URL}' \\
+            -e PRE_PORTAL_URL='${env.PRE_PORTAL_URL}' \\
+            -v \"\$(pwd)/playwright-report:/playwright/playwright-report\" \\
+            pre-e2e-tests-${environment} \\
+            "yarn playwright test playwright-e2e/tests/pre-power-app/e2e --project=Pre-Power-App-Edge --workers=1"
+        """
+      } finally {
+        sh "docker rmi pre-e2e-tests-${environment} --force || true"
+        publishHTML([
+          allowMissing: true,
+          alwaysLinkToLastBuild: true,
+          keepAll: true,
+          reportDir: 'playwright-report',
+          reportFiles: 'index.html',
+          reportName: "Power App E2E Tests - ${environment}"
+        ])
+      }
+    }
+  }
+}
+
+void forceApimGatewayRebuild(String environment) {
+  def apimServiceName = "sds-api-mgmt-${environment}"
+  def resourceGroup = "ss-${environment}-network-rg"
+
+  echo "Forcing APIM gateway rebuild: reimporting spec to ${apimServiceName}"
+
+  sh """
+    az apim api import \\
+      --resource-group ${resourceGroup} \\
+      --service-name ${apimServiceName} \\
+      --api-id pre-api \\
+      --specification-format OpenApiJson \\
+      --specification-path specs/pre-api.json \\
+      --path pre-api \\
+      --service-url https://pre-api.${environment == 'prod' ? 'platform.hmcts.net' : "${environment}.platform.hmcts.net"}
+  """
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -53,8 +53,8 @@ withPipeline(type, product, component) {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
   }
 
-  afterSuccess('buildinfra:demo') {
-    runPowerAppE2eTests('demo')
+  afterSuccess('buildinfra:dev') {
+    runPowerAppE2eTests('dev')
   }
 
   afterSuccess('Publish Helm chart') {
@@ -114,7 +114,7 @@ void runPowerAppE2eTests(String environment) {
       } catch (err) {
         echo "Power App e2e tests failed for ${environment}: ${err.message}"
         echo "Attempting APIM gateway recovery before re-running tests..."
-        forceApimGatewayRebuild(environment)
+        // forceApimGatewayRebuild(environment)
         sleep(15)
 
         sh """


### PR DESCRIPTION
<!--
PR checklist:

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Tests have been updated / new tests has been added (if needed)
- [ ] QA have been notified to perform manual testing (if needed)
  - [ ] Add the `enable_keep_helm` label to the PR
- [ ] Power Platform team have been notified of any breaking changes to the API (if needed)
- [ ] Branch name should reference the Jira ticket, if not JIRA ticket has been linked
-->

<!-- Uncomment the following to manually link the JIRA ticket, ticket numbers will autolink -->

<!--
### JIRA ticket(s)

- S28-0000
-->

### Change description

- Update Jenkinsfile to run e2e tests on PRE Power App after the buildinfra stage of the pipeline. If it fails, run `az cli` command to re-import the API spec and re-run tests.
- Potential workaround for issue where the PRE Power App reports 404s after the API update. No other consumers report the same issue.

<!-- If this PR needs to be manually tested add the `enable_keep_helm` label and uncomment the following: -->

<!--
> [!IMPORTANT]
> This PR requires manual testing by QA. Please notify the QA team @hmcts/pre-rec-evidence-qa.

**QA instructions**

-
-
-->

<!-- If this PR contains a breaking change uncomment the following: -->

<!--
> [!CAUTION]
> This PR introduces a breaking change. Please notify the Power Platform team @hmcts/pre-rec-evidence-power-platform.

**Breaking change description**

-
-
-->
