### PR TITLE
Potential fix for code scanning alert no. 7: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java
@@ -61,7 +61,32 @@ public class SecurityConfig {
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)
+            .csrf(csrf -> csrf
+                .ignoringRequestMatchers(
+                    "/testing-support/**",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/v3/api-docs",
+                    "/health/**",
+                    "/health",
+                    "/info",
+                    "/prometheus",
+                    "/users/by-email/**",
+                    "/reports/**",
+                    "/audit/**",
+                    "/b2c/**",
+                    "/error",
+                    "/app-terms-and-conditions/latest",
+                    "/portal-terms-and-conditions/latest",
+                    "/invites",
+                    "/invites/redeem",
+                    "/batch",
+                    "/batch/fetch-xml",
+                    "/batch/process-migration",
+                    "/batch/post-migration-tasks",
+                    "/batch/migrate-exclusions"
+                )
+            )
             .authorizeHttpRequests(authorize ->
                                        authorize
                                            .requestMatchers(HttpMethod.GET, PERMITTED_URIS_GET_ONLY).permitAll()


### PR DESCRIPTION

### JIRA ticket(s)
- S28-3957



Potential fix for [https://github.com/hmcts/pre-api/security/code-scanning/7](https://github.com/hmcts/pre-api/security/code-scanning/7)

In general, the fix is to stop globally disabling Spring Security’s CSRF protection and, if some endpoints truly need to be accessible without CSRF tokens (e.g. for non‑browser clients), explicitly configure CSRF to ignore only those specific paths while leaving protection enabled for everything else.

The best fix here, without changing existing functionality more than necessary, is:
- Remove `.csrf(AbstractHttpConfigurer::disable)` so that CSRF protection is not turned off globally.
- Replace it with a CSRF configuration that:
  - Leaves CSRF enabled by default.
  - Excludes from CSRF checks the endpoints that appear to be non‑browser or machine‑to‑machine APIs (`/testing-support/**`, `/v3/api-docs/**`, health/info/metrics URIs, batch processing, etc.) by using `csrf.ignoringRequestMatchers(...)`.
This preserves the current behavior for clearly non‑browser / operational endpoints while enabling CSRF protection for any remaining state‑changing browser‑accessible routes.

Concretely, in `SecurityConfig.filterChain(HttpSecurity http)` in `src/main/java/uk/gov/hmcts/reform/preapi/config/SecurityConfig.java`, replace `.csrf(AbstractHttpConfigurer::disable)` with a lambda that configures `ignoringRequestMatchers` using patterns consistent with the already defined permit‑all URIs (and POST batch URIs). No new imports are required because we already use `HttpMethod` and path strings; `ignoringRequestMatchers` can take those as ant‑style patterns directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
