### PR TITLE
S28-4813 remove re-encode readback

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -442,12 +442,11 @@ class TestingSupportController {
                 List.of(new SimpleGrantedAuthority("ROLE_SUPER_USER"))));
 
         EditRequest editRequest = editRequestPerformService.markAsProcessing(editId);
-        RecordingDTO recording = editRequestPerformService.performEdit(editRequest);
+        editRequestPerformService.performEdit(editRequest);
         EditRequestDTO request = editRequestService.findById(editId);
 
         return ResponseEntity.ok(Map.of(
-            "request", request,
-            "recording", recording
+            "request", request
         ));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/controllers/TestingSupportController.java
@@ -432,7 +432,7 @@ class TestingSupportController {
 
     @SneakyThrows
     @PostMapping(value = "/trigger-edit-request-processing/{editId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> triggerEditRequestProcessing(@PathVariable UUID editId) {
+    public ResponseEntity<EditRequestDTO> triggerEditRequestProcessing(@PathVariable UUID editId) {
         Role role = roleRepository.findFirstByName("Super User")
             .orElse(createRole("Super User"));
         AppAccess appAccess = createAppAccess(role);
@@ -445,9 +445,7 @@ class TestingSupportController {
         editRequestPerformService.performEdit(editRequest);
         EditRequestDTO request = editRequestService.findById(editId);
 
-        return ResponseEntity.ok(Map.of(
-            "request", request
-        ));
+        return ResponseEntity.ok(request);
     }
 
     @PostMapping(value = "/trigger-task/{taskName}")

--- a/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.EditRequestDTO;
-import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.entities.EditRequest;
 import uk.gov.hmcts.reform.preapi.enums.CaseState;
 import uk.gov.hmcts.reform.preapi.enums.EditRequestStatus;
@@ -45,7 +44,7 @@ public class EditRequestPerformService {
         return editRequestCrudService.getNextPendingEditRequest(reencodeOnly);
     }
 
-    public RecordingDTO performEdit(EditRequest request) throws InterruptedException {
+    public void performEdit(EditRequest request) throws InterruptedException {
         UUID newRecordingId = UUID.randomUUID();
         try {
             EditInstructions editInstructions = fromJson(request.getEditInstruction());
@@ -60,7 +59,6 @@ public class EditRequestPerformService {
         }
 
         editRequestCrudService.updateEditRequestStatus(request.getId(), EditRequestStatus.COMPLETE);
-        return recordingService.findById(newRecordingId);
     }
 
     private void ensureSourceRecordingCaseIsOpen(EditRequest request, EditInstructions editInstructions) {

--- a/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/services/edit/EditRequestPerformServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.reform.preapi.dto.CreateRecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.EditRequestDTO;
-import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.entities.Booking;
 import uk.gov.hmcts.reform.preapi.entities.CaptureSession;
 import uk.gov.hmcts.reform.preapi.entities.Case;
@@ -186,24 +185,20 @@ class EditRequestPerformServiceTest {
         when(mockCase.getState()).thenReturn(CaseState.CLOSED);
         when(mockEditRequest.getEditInstruction()).thenReturn("{\"forceReencode\":true}");
 
-        RecordingDTO newRecordingDto = new RecordingDTO();
-        newRecordingDto.setParentRecordingId(mockRecording.getId());
-        when(recordingService.findById(any(UUID.class))).thenReturn(newRecordingDto);
+        underTest.performEdit(mockEditRequest);
 
-        RecordingDTO res = underTest.performEdit(mockEditRequest);
-
-        assertThat(res).isNotNull();
         verify(editingService, times(1)).performEdit(any(UUID.class), eq(mockEditRequest));
         verify(assetGenerationService, times(1)).generateAsset(any(UUID.class), eq(mockEditRequest));
         verify(recordingService, times(1)).forceUpsert(any(CreateRecordingDTO.class));
         verify(recordingService, never()).upsert(any(CreateRecordingDTO.class));
+        verify(recordingService, never()).findById(any(UUID.class));
         verify(editRequestCrudService, times(1))
             .updateEditRequestStatus(mockEditRequestId, EditRequestStatus.COMPLETE);
     }
 
     // This should probably be an integration test
     @Test
-    @DisplayName("Should perform edit request and return created recording")
+    @DisplayName("Should perform edit request and create recording")
     void performEditSuccess() throws InterruptedException {
         when(assetGenerationService.generateAsset(any(UUID.class), any(EditRequest.class))).thenReturn("filename");
         when(recordingService.getNextVersionNumber(mockRecording.getId())).thenReturn(2);
@@ -215,14 +210,7 @@ class EditRequestPerformServiceTest {
                 + "\"ffmpegInstructions\":null,\"forceReencode\":false,"
                 + "\"sendNotifications\":true}");
 
-
-        RecordingDTO newRecordingDto = new RecordingDTO();
-        newRecordingDto.setParentRecordingId(mockRecording.getId());
-        when(recordingService.findById(any(UUID.class))).thenReturn(newRecordingDto);
-
-        RecordingDTO res = underTest.performEdit(mockEditRequest);
-        assertThat(res).isNotNull();
-        assertThat(res.getParentRecordingId()).isEqualTo(mockRecording.getId());
+        underTest.performEdit(mockEditRequest);
 
         ArgumentCaptor<UUID> newRecIdCaptor = ArgumentCaptor.forClass(UUID.class);
         ArgumentCaptor<EditRequest> saveCaptor = ArgumentCaptor.forClass(EditRequest.class);
@@ -247,7 +235,7 @@ class EditRequestPerformServiceTest {
         JSONAssert.assertEquals(newRecCaptor.getValue().getEditInstructions(),
                                 expectedInstructions, JSONCompareMode.LENIENT);
 
-        verify(recordingService, times(1)).findById(any(UUID.class));
+        verify(recordingService, never()).findById(any(UUID.class));
         verify(recordingService, never()).forceUpsert(any(CreateRecordingDTO.class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/preapi/tasks/PerformEditRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/preapi/tasks/PerformEditRequestTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.reform.preapi.dto.AccessDTO;
-import uk.gov.hmcts.reform.preapi.dto.RecordingDTO;
 import uk.gov.hmcts.reform.preapi.dto.base.BaseAppAccessDTO;
 import uk.gov.hmcts.reform.preapi.entities.EditRequest;
 import uk.gov.hmcts.reform.preapi.enums.EditRequestStatus;
@@ -88,8 +87,6 @@ class PerformEditRequestTest {
         when(editRequestService.markAsProcessing(editRequest1.getId())).thenReturn(editRequest1);
         when(editRequestService.markAsProcessing(editRequest2.getId())).thenReturn(editRequest2);
         when(editRequestService.markAsProcessing(editRequest5.getId())).thenReturn(editRequest5);
-        // when request is successful
-        when(editRequestService.performEdit(editRequest1)).thenReturn(new RecordingDTO());
         // when request errors in ffmpeg stage
         doThrow(UnknownServerException.class).when(editRequestService).performEdit(editRequest2);
         // when edit request is locked it should skip


### PR DESCRIPTION
## Summary
- stop edit request processing from reading the newly created recording after marking the request complete
- update the testing support endpoint and unit tests for the command-style processing flow
- avoid post-success authorization errors for hidden re-encoded recordings
