### PR TITLE
add explanation for azurerm staying version 4.21

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -3,6 +3,8 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
+      # Temporarily pinned: do not upgrade azurerm until issue #29502 is resolved.
+      # https://github.com/hashicorp/terraform-provider-azurerm/issues/29502
       version = "4.21.0"
     }
   }

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -2,7 +2,7 @@ terraform {
   backend "azurerm" {}
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
+      source = "hashicorp/azurerm"
       # Temporarily pinned: do not upgrade azurerm until issue #29502 is resolved.
       # https://github.com/hashicorp/terraform-provider-azurerm/issues/29502
       version = "4.21.0"


### PR DESCRIPTION
### Change description

Add comments explaining that the Azurerm version should stay fixed to 4.21 until the issue of overwriting protocol is fixed:

https://github.com/hashicorp/terraform-provider-azurerm/pull/29523
https://github.com/hashicorp/terraform-provider-azurerm/issues/29502
