### PR TITLE
S28-5088 Fix - UpdateRecordingsVisibility job deletes V1 recordings only

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/preapi/services/RecordingServiceIT.java
@@ -576,13 +576,19 @@ class RecordingServiceIT extends IntegrationTestBase {
         mockAdminUser();
 
         // Set up
-        Recording preRecording = createSampleOriginalRecording(RecordingOrigin.PRE);
+        Recording preRecording = createSampleRecording(RecordingOrigin.PRE, null, 1);
 
-        Recording vfOriginal1 = createSampleOriginalRecording(RecordingOrigin.VODAFONE);
+        Recording vfOriginal1 = createSampleRecording(RecordingOrigin.VODAFONE, null, 1);
 
-        Recording vfOriginal2 = createSampleOriginalRecording(RecordingOrigin.VODAFONE);
+        Recording vfOriginal2 = createSampleRecording(RecordingOrigin.VODAFONE, null, 1);
 
         Recording reencodedVf1 = createSampleReencodedRecording(vfOriginal1, 2);
+
+        Recording vfOriginal3V1 = createSampleRecording(RecordingOrigin.VODAFONE, null, 1);
+
+        Recording vfOriginal3V2 = createSampleRecording(RecordingOrigin.VODAFONE, vfOriginal3V1, 2);
+
+        Recording reencodedVf3 = createSampleReencodedRecording(vfOriginal3V1, 3);
 
         // Pre-test check
         Map<UUID, RecordingDTO> recordingsBeforeFlagSet = recordingService.findAll(
@@ -595,7 +601,8 @@ class RecordingServiceIT extends IntegrationTestBase {
         checkResultsForDeletedRecordings(
             recordingsBeforeFlagSet,
             List.of(),
-            List.of(preRecording.getId(), vfOriginal1.getId(), reencodedVf1.getId(), vfOriginal2.getId())
+            List.of(preRecording.getId(), vfOriginal1.getId(), reencodedVf1.getId(), vfOriginal2.getId(),
+                    vfOriginal3V1.getId(), vfOriginal3V2.getId(), reencodedVf3.getId())
         );
 
         // Test: delete originals
@@ -612,8 +619,8 @@ class RecordingServiceIT extends IntegrationTestBase {
 
         checkResultsForDeletedRecordings(
             recordingsAfterDeletion,
-            List.of(vfOriginal1.getId()),
-            List.of(preRecording.getId(), reencodedVf1.getId(), vfOriginal2.getId())
+            List.of(vfOriginal1.getId(), vfOriginal3V1.getId(), vfOriginal3V2.getId()),
+            List.of(preRecording.getId(), reencodedVf1.getId(), vfOriginal2.getId(), reencodedVf3.getId())
         );
 
         recordingService.undeleteOriginalWhereReencodedVersionExists();
@@ -632,7 +639,8 @@ class RecordingServiceIT extends IntegrationTestBase {
             List.of(),
             List.of(
                 preRecording.getId(), reencodedVf1.getId(), vfOriginal2.getId(),
-                vfOriginal1.getId()
+                vfOriginal1.getId(), vfOriginal3V1.getId(), vfOriginal3V2.getId(),
+                reencodedVf3.getId()
             )
         );
 
@@ -662,13 +670,15 @@ class RecordingServiceIT extends IntegrationTestBase {
             .isEqualTo("User does not have sufficient privileges to undelete original recordings");
     }
 
-    private Recording createSampleOriginalRecording(RecordingOrigin recordingOrigin) {
+    private Recording createSampleRecording(RecordingOrigin recordingOrigin,
+                                            Recording parentRecording,
+                                            Integer versionNumber) {
         CaptureSession sampleCaptureSession = persistSampleCourtCaseBookingCaptureSession(
             recordingOrigin
         );
 
         Recording recording = HelperFactory.createRecording(
-            sampleCaptureSession, null, 1,
+            sampleCaptureSession, parentRecording, versionNumber,
             "", null
         );
         recording.setDuration(Duration.ofHours(1));

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -209,18 +209,40 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
     )
     List<Recording> findAllOriginVodafoneNoDuration();
 
-    @Query("""
-        SELECT r FROM Recording r
-        WHERE r.captureSession.origin = 'VODAFONE'
-        AND r.deletedAt IS NULL
-        AND r.id in
-                (SELECT reencoded.parentRecording.id FROM Recording reencoded
-                        where reencoded.captureSession.origin = 'VODAFONE'
-                                AND reencoded.deletedAt IS NULL
-                                        AND reencoded.reencode = true
-                        )
-        """
+    @Query(value = """
+        WITH reencoded AS (
+        SELECT r.parent_recording_id, r.version
+        FROM recordings r
+        JOIN capture_sessions cs ON cs.id = r.capture_session_id
+        WHERE r.is_reencode = TRUE
+          AND r.deleted_at IS NULL
+          AND cs.origin = 'VODAFONE'
+          AND r.parent_recording_id IS NOT NULL
+    ),
+    wanted_ids AS (
+        -- include the parent recording
+        SELECT DISTINCT p.id
+        FROM recordings p
+        JOIN capture_sessions cs_p ON cs_p.id = p.capture_session_id
+        JOIN reencoded re ON re.parent_recording_id = p.id
+        WHERE p.deleted_at IS NULL
+          AND cs_p.origin = 'VODAFONE'
+
+        UNION
+
+        -- include sibling children before the reencoded version
+        SELECT DISTINCT c.id
+        FROM recordings c
+        JOIN capture_sessions cs_c ON cs_c.id = c.capture_session_id
+        JOIN reencoded re ON re.parent_recording_id = c.parent_recording_id
+        WHERE c.deleted_at IS NULL
+          AND cs_c.origin = 'VODAFONE'
+          AND c.version < re.version
     )
+    SELECT r.*
+    FROM recordings r
+    WHERE r.id IN (SELECT id FROM wanted_ids)
+        """, nativeQuery = true)
     List<Recording> findVodafoneOriginalRecordingsWhereReencodedVersionExists();
 
     List<Recording> findRecordingsByDeletedAtIsNotNullAndVfOriginalNowReencodedIsTrue();

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -210,38 +210,27 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
     List<Recording> findAllOriginVodafoneNoDuration();
 
     @Query(value = """
-        WITH reencoded AS (
-        SELECT r.parent_recording_id, r.version
+        SELECT r.*
         FROM recordings r
         JOIN capture_sessions cs ON cs.id = r.capture_session_id
-        WHERE r.is_reencode = TRUE
+        WHERE cs.origin = 'VODAFONE'
           AND r.deleted_at IS NULL
-          AND cs.origin = 'VODAFONE'
-          AND r.parent_recording_id IS NOT NULL
-    ),
-    wanted_ids AS (
-        -- include the parent recording
-        SELECT DISTINCT p.id
-        FROM recordings p
-        JOIN capture_sessions cs_p ON cs_p.id = p.capture_session_id
-        JOIN reencoded re ON re.parent_recording_id = p.id
-        WHERE p.deleted_at IS NULL
-          AND cs_p.origin = 'VODAFONE'
-
-        UNION
-
-        -- include sibling children before the reencoded version
-        SELECT DISTINCT c.id
-        FROM recordings c
-        JOIN capture_sessions cs_c ON cs_c.id = c.capture_session_id
-        JOIN reencoded re ON re.parent_recording_id = c.parent_recording_id
-        WHERE c.deleted_at IS NULL
-          AND cs_c.origin = 'VODAFONE'
-          AND c.version < re.version
-    )
-    SELECT r.*
-    FROM recordings r
-    WHERE r.id IN (SELECT id FROM wanted_ids)
+          AND EXISTS (
+              SELECT 1
+              FROM recordings re
+              JOIN capture_sessions re_cs ON re_cs.id = re.capture_session_id
+              WHERE re_cs.origin = 'VODAFONE'
+                AND re.deleted_at IS NULL
+                AND re.is_reencode = TRUE
+                AND (
+                    re.parent_recording_id = r.id
+                    OR (
+                        r.parent_recording_id IS NOT NULL
+                        AND re.parent_recording_id = r.parent_recording_id
+                        AND r.version < re.version
+                    )
+                )
+          )
         """, nativeQuery = true)
     List<Recording> findVodafoneOriginalRecordingsWhereReencodedVersionExists();
 

--- a/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/preapi/repositories/RecordingRepository.java
@@ -210,27 +210,42 @@ public interface RecordingRepository extends JpaRepository<Recording, UUID> {
     List<Recording> findAllOriginVodafoneNoDuration();
 
     @Query(value = """
+        -- Reencoded Vodafone recordings
+        WITH reencoded AS (
+            SELECT
+                re.parent_recording_id AS parent_id,
+                re.version AS reencoded_version
+            FROM recordings re
+            JOIN capture_sessions re_cs ON re_cs.id = re.capture_session_id
+            WHERE re_cs.origin = 'VODAFONE'
+              AND re.deleted_at IS NULL
+              AND re.is_reencode = TRUE
+        ),
+
+        target_ids AS (
+            -- The parent/original recordings
+            SELECT DISTINCT p.id
+            FROM recordings p
+            JOIN capture_sessions p_cs ON p_cs.id = p.capture_session_id
+            JOIN reencoded re ON re.parent_id = p.id
+            WHERE p_cs.origin = 'VODAFONE'
+              AND p.deleted_at IS NULL
+
+            UNION
+
+            -- The earlier siblings before the reencoded version
+            SELECT DISTINCT c.id
+            FROM recordings c
+            JOIN capture_sessions c_cs ON c_cs.id = c.capture_session_id
+            JOIN reencoded re ON re.parent_id = c.parent_recording_id
+            WHERE c_cs.origin = 'VODAFONE'
+              AND c.deleted_at IS NULL
+              AND c.version < re.reencoded_version
+        )
+
         SELECT r.*
         FROM recordings r
-        JOIN capture_sessions cs ON cs.id = r.capture_session_id
-        WHERE cs.origin = 'VODAFONE'
-          AND r.deleted_at IS NULL
-          AND EXISTS (
-              SELECT 1
-              FROM recordings re
-              JOIN capture_sessions re_cs ON re_cs.id = re.capture_session_id
-              WHERE re_cs.origin = 'VODAFONE'
-                AND re.deleted_at IS NULL
-                AND re.is_reencode = TRUE
-                AND (
-                    re.parent_recording_id = r.id
-                    OR (
-                        r.parent_recording_id IS NOT NULL
-                        AND re.parent_recording_id = r.parent_recording_id
-                        AND r.version < re.version
-                    )
-                )
-          )
+        WHERE r.id IN (SELECT id FROM target_ids)
         """, nativeQuery = true)
     List<Recording> findVodafoneOriginalRecordingsWhereReencodedVersionExists();
 


### PR DESCRIPTION
### JIRA ticket(s)
https://tools.hmcts.net/jira/browse/S28-5088

### Change description
Changes the UpdateRecordingsVisibility job to delete not just the V1 recordings prior to reencoding, but all the versions prior to reencoding.